### PR TITLE
chore: Redis 세션 설정

### DIFF
--- a/backend/src/config/session.ts
+++ b/backend/src/config/session.ts
@@ -1,0 +1,22 @@
+import session from "express-session";
+import { RedisStore } from "connect-redis";
+import { createClient } from "redis";
+
+export const redisClient = createClient({ url: process.env.REDIS_URL });
+
+redisClient
+  .connect()
+  .then(() => console.log("Redis 연결 성공"))
+  .catch((err) => console.error("Redis 연결 실패:", err));
+
+export const sessionMiddleware = session({
+  store: new RedisStore({ client: redisClient }),
+  secret: process.env.SESSION_SECRET ?? "dev-secret",
+  resave: false,
+  saveUninitialized: false,
+  cookie: {
+    httpOnly: true,
+    secure: false,
+    maxAge: 1000 * 60 * 60 * 24, // 24시간
+  },
+});

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -2,12 +2,10 @@ import "reflect-metadata";
 import express from "express";
 import http from "http";
 import { Server } from "socket.io";
-import { createClient } from "redis";
 import cors from "cors";
 import * as dotenv from "dotenv";
-import session from "express-session";
-import { RedisStore } from "connect-redis";
 import { AppDataSource } from "./database/data-source";
+import { sessionMiddleware, redisClient } from "./config/session";
 
 dotenv.config();
 
@@ -20,32 +18,11 @@ const io = new Server(server, {
 app.use(
   cors({
     origin: process.env.CLIENT_URL ?? "http://localhost:5173",
-    credentials: true, // 쿠키 전송 허용
+    credentials: true,
   }),
 );
 app.use(express.json());
-
-// Redis 연결
-const redisClient = createClient({ url: process.env.REDIS_URL });
-redisClient
-  .connect()
-  .then(() => console.log("Redis 연결 성공"))
-  .catch((err) => console.error("Redis 연결 실패:", err));
-
-// 세션 설정
-app.use(
-  session({
-    store: new RedisStore({ client: redisClient }),
-    secret: process.env.SESSION_SECRET ?? "dev-secret",
-    resave: false,
-    saveUninitialized: false,
-    cookie: {
-      httpOnly: true, // JS에서 쿠키 접근 차단
-      secure: false, // HTTPS 아니면 false
-      maxAge: 1000 * 60 * 60 * 24, // 24시간
-    },
-  }),
-);
+app.use(sessionMiddleware);
 
 // TypeORM 연결
 AppDataSource.initialize()


### PR DESCRIPTION
**1. express-session 연결**
req.session으로 세션 데이터에 접근하도록 로그인 후 세션을 관리하는 미들웨어를 Express에 붙임

**2. connect-redis로 세션 저장소를 Redis로 지정**
express-session은 메모리에 세션을 저장하며 이를 Redis에 저장함. 이로 인해 영속쿠키 구현할 수 있음

**3. cors에 credentials: true 추가**
세션은 쿠키로 전달되며 프론트(5173 포트)랑 백엔드(4000 포트)가 다른 출처이므로 쿠키가 차단됨.
정상적인 쿠키 전달을 위해 credentials: true 설정