### PR TITLE
feat: socket-handler 구현

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -7,6 +7,7 @@ import * as dotenv from "dotenv";
 import { AppDataSource } from "./database/data-source";
 import { sessionMiddleware } from "./config/session";
 import { redisClient } from "./config/redis";
+import { initSocket } from "./socket/socket";
 
 import authRouter from "./modules/auth/auth.router";
 import canvasRouter from "./modules/canvas/canvas.router";
@@ -21,7 +22,7 @@ const io = new Server(server, {
   cors: { origin: process.env.CLIENT_URL ?? "http://localhost:5173" },
 });
 
-// Front 연결
+// 미들웨어
 app.use(
   cors({
     origin: process.env.CLIENT_URL ?? "http://localhost:5173",
@@ -62,13 +63,8 @@ app.get("/health/db", async (_req, res) => {
   }
 });
 
-// Socket.io
-io.on("connection", (socket) => {
-  console.log("클라이언트 연결:", socket.id);
-  socket.on("disconnect", () => {
-    console.log("클라이언트 해제:", socket.id);
-  });
-});
+// Socket.io 초기화 (세션 인증 미들웨어 포함)
+initSocket(io);
 
 //Router
 app.use("/auth", authRouter);

--- a/backend/src/socket/socket.handler.ts
+++ b/backend/src/socket/socket.handler.ts
@@ -1,0 +1,21 @@
+import { Server, Socket } from "socket.io";
+
+export function registerHandlers(socket: Socket, io: Server): void {
+  // 캔버스 룸 입장
+  socket.on("join:canvas", (canvasId: number) => {
+    const room = `canvas:${canvasId}`;
+    socket.join(room);
+    console.log(
+      `${socket.voterNickname} → 룸 입장: ${room} (소켓: ${socket.id})`,
+    );
+  });
+
+  // 캔버스 룸 퇴장
+  socket.on("leave:canvas", (canvasId: number) => {
+    const room = `canvas:${canvasId}`;
+    socket.leave(room);
+    console.log(
+      `${socket.voterNickname} → 룸 퇴장: ${room} (소켓: ${socket.id})`,
+    );
+  });
+}

--- a/backend/src/socket/socket.ts
+++ b/backend/src/socket/socket.ts
@@ -1,0 +1,48 @@
+import { Server, Socket } from "socket.io";
+import { sessionMiddleware } from "../config/session";
+import { Request, Response, NextFunction } from "express";
+
+declare module "socket.io" {
+  interface Socket {
+    voterId?: number;
+    voterUuid?: string;
+    voterNickname?: string;
+  }
+}
+
+// express-session 미들웨어를 Socket.io에서 사용할 수 있도록 래핑
+const wrap =
+  (middleware: (req: Request, res: Response, next: NextFunction) => void) =>
+  (socket: Socket, next: (err?: Error) => void) =>
+    middleware(socket.request as Request, {} as Response, next as NextFunction);
+
+export function initSocket(io: Server): void {
+  // 세션 미들웨어 연결
+  io.use(wrap(sessionMiddleware));
+
+  // 세션 인증 미들웨어
+  io.use((socket, next) => {
+    const req = socket.request as Request;
+    const voter = req.session?.voter;
+
+    if (!voter) {
+      return next(new Error("인증이 필요해요"));
+    }
+
+    socket.voterId = voter.id;
+    socket.voterUuid = voter.uuid;
+    socket.voterNickname = voter.nickname;
+    next();
+  });
+
+  io.on("connection", (socket) => {
+    console.log(`소켓 연결: ${socket.id} (${socket.voterNickname})`);
+
+    // 이벤트 핸들러 등록
+    require("./socket.handler").registerHandlers(socket, io);
+
+    socket.on("disconnect", () => {
+      console.log(`소켓 해제: ${socket.id} (${socket.voterNickname})`);
+    });
+  });
+}


### PR DESCRIPTION
## 관련 이슈

- Close #33 

## 작업 내용
#### src/index.ts 수정
- `initSocket(io)` 호출

#### src/socket/socket.ts : 소켓 미들웨어 등록
- `socker.voterId`, `socket.voterUuid`, `socket.voterNickname` 필드 추가
- `initSocket(io)` : 소켓 연결 시 세션 인증 미들웨어 및 이벤트 핸들러 등록

#### src/socket/socket.handler.ts 생성 : 이벤트 핸들러
- `join:canvas` : 캔버스 룸 입장
- `leave:canvas` : 캔버스 룸 퇴장

## 기타
- 세션 만료 시간: 24시간

#### 접속 → 로그인 → 소켓연결 흐름
```
1. 브라우저에서 접속
   → 아직 아무것도 없음

2. POST /auth/login (HTTP)
   → 서버가 세션 생성
   → Redis에 저장 { voter: { id:1, uuid:"...", nickname:"테스터" } }
   → 브라우저에 쿠키 발급 (sid=abc123)

3. 소켓 연결 시도 (socket.io("http://localhost:4000"))
   → 브라우저가 쿠키 자동 포함
   socket.request.headers.cookie = "sid=abc123"

4. io.use(wrap(sessionMiddleware)) 실행
   → sid=abc123으로 Redis 조회
   → socket.request.session = { voter: { id:1, ... } }  ← 여기서 주입
   → next()

5. io.use((socket, next) => { ... }) 실행
   → socket.request.session.voter 꺼냄
   → socket.voterId = 1
   → socket.voterNickname = "테스터"
   → next()

6. io.on("connection") 실행
   → 연결 완료

7. join:canvas 이벤트
   → socket.join("canvas:1")
   → 룸 입장 완료
```

## 테스트 및 확인 사항
- Postman Socket.IO 테스트 완료
- `join:canvas`, `leave:canvas` 이벤트 호출 확인
<img width="589" height="618" alt="image" src="https://github.com/user-attachments/assets/c0c9eb47-145f-4534-afd2-c4e9227bf0d3" />


## 체크리스트

- [x] 불필요한 주석 및 디버깅 코드를 제거하였는가?
- [x]  모든 테스트를 통과하였는가?
- [x] 변경 사항에 대한 문서 업데이트가 필요한가?
 ㄹ