### PR TITLE
feat: 라운드 UI 구현

### DIFF
--- a/frontend/src/components/vote/RoundInfo.tsx
+++ b/frontend/src/components/vote/RoundInfo.tsx
@@ -1,0 +1,46 @@
+import { useEffect, useState } from "react";
+
+interface Props {
+  roundNumber: number | null;
+  startedAt: string | null;
+  durationSec: number;
+}
+
+export default function RoundInfo({
+  roundNumber,
+  startedAt,
+  durationSec,
+}: Props) {
+  const [remaining, setRemaining] = useState<number | null>(null);
+
+  useEffect(() => {
+    if (!startedAt) {
+      setRemaining(null);
+      return;
+    }
+
+    const calc = () => {
+      const elapsed = Math.floor(
+        (Date.now() - new Date(startedAt).getTime()) / 1000,
+      );
+      const left = Math.max(0, durationSec - elapsed);
+      setRemaining(left);
+    };
+
+    calc();
+    const interval = setInterval(calc, 1000);
+    return () => clearInterval(interval);
+  }, [startedAt, durationSec]);
+
+  return (
+    <div className="flex flex-col gap-1">
+      <p className="text-sm font-medium">라운드</p>
+      <p className="text-sm text-gray-500">
+        {roundNumber ? `#${roundNumber}` : "진행 중인 라운드 없음"}
+      </p>
+      {remaining !== null && (
+        <p className="text-sm text-gray-500">남은 시간: {remaining}초</p>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/vote/VotePanel.tsx
+++ b/frontend/src/components/vote/VotePanel.tsx
@@ -1,12 +1,19 @@
 import { useState, useEffect } from "react";
 import { Button } from "@/components/ui/button";
 import ColorPalette from "./ColorPalette";
+import RoundInfo from "./RoundInfo";
 import { voteApi } from "@/api/vote";
 import { Cell } from "@/types/canvas";
+
+const ROUND_DURATION_SEC = parseInt(
+  import.meta.env.VITE_ROUND_DURATION_SEC ?? "60",
+);
 
 interface Props {
   canvasId: number;
   roundId: number | null;
+  roundNumber: number | null;
+  startedAt: string | null;
   selectedCell: Cell | null;
   onVoteSuccess: () => void;
 }
@@ -14,6 +21,8 @@ interface Props {
 export default function VotePanel({
   canvasId,
   roundId,
+  roundNumber,
+  startedAt,
   selectedCell,
   onVoteSuccess,
 }: Props) {
@@ -23,7 +32,10 @@ export default function VotePanel({
   const [loading, setLoading] = useState(false);
 
   useEffect(() => {
-    if (!roundId) return;
+    if (!roundId) {
+      setRemaining(null);
+      return;
+    }
     voteApi.getTickets(roundId).then(({ data }) => {
       setRemaining(data.remaining);
     });
@@ -61,13 +73,12 @@ export default function VotePanel({
         <h2 className="text-lg font-bold">VoteDots</h2>
       </div>
 
-      {/* 라운드 정보 */}
-      <div className="flex flex-col gap-1">
-        <p className="text-sm font-medium">라운드</p>
-        <p className="text-sm text-gray-500">
-          {roundId ? `#${roundId}` : "진행 중인 라운드 없음"}
-        </p>
-      </div>
+      {/* 라운드 정보 + 타이머 */}
+      <RoundInfo
+        roundNumber={roundNumber}
+        startedAt={startedAt}
+        durationSec={ROUND_DURATION_SEC}
+      />
 
       {/* 남은 투표권 */}
       <div className="flex flex-col gap-1">
@@ -93,10 +104,8 @@ export default function VotePanel({
         <ColorPalette selected={color} onChange={setColor} />
       </div>
 
-      {/* 에러 */}
       {error && <p className="text-sm text-red-500">{error}</p>}
 
-      {/* 투표 버튼 */}
       <Button
         onClick={handleSubmit}
         disabled={!selectedCell || !roundId || loading}

--- a/frontend/src/hooks/useSocket.ts
+++ b/frontend/src/hooks/useSocket.ts
@@ -1,6 +1,5 @@
 import { useEffect } from "react";
 import socket from "@/lib/socket";
-import { Cell } from "@/types/canvas";
 
 interface RoundStartedPayload {
   roundId: number;

--- a/frontend/src/pages/CanvasPage.tsx
+++ b/frontend/src/pages/CanvasPage.tsx
@@ -25,7 +25,6 @@ function drawGrid(
     );
   });
 
-  // 선택된 셀 하이라이트
   if (selectedCell) {
     ctx.strokeStyle = "#3b82f6";
     ctx.lineWidth = 2;
@@ -48,6 +47,8 @@ export default function CanvasPage() {
   const [cells, setCells] = useState<Cell[]>([]);
   const [canvasId, setCanvasId] = useState<number | null>(null);
   const [roundId, setRoundId] = useState<number | null>(null);
+  const [roundNumber, setRoundNumber] = useState<number | null>(null);
+  const [startedAt, setStartedAt] = useState<string | null>(null);
   const [selectedCell, setSelectedCell] = useState<Cell | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
@@ -70,19 +71,19 @@ export default function CanvasPage() {
         if (!ctx) return;
         drawGrid(ctx, cells, null);
 
-        // 진행 중인 라운드 조회
         return api.get(`/canvas/${canvas.id}/rounds/active`);
       })
       .then((res) => {
         if (res?.data?.round) {
           setRoundId(res.data.round.id);
+          setRoundNumber(res.data.round.roundNumber);
+          setStartedAt(res.data.round.startedAt);
         }
       })
       .catch(() => setError("진행 중인 캔버스가 없어요."))
       .finally(() => setLoading(false));
   }, []);
 
-  // 셀 목록 또는 선택 셀 변경 시 리렌더
   useEffect(() => {
     const canvasEl = canvasRef.current;
     if (!canvasEl) return;
@@ -91,12 +92,28 @@ export default function CanvasPage() {
     drawGrid(ctx, cells, selectedCell);
   }, [cells, selectedCell]);
 
-  const handleRoundStarted = useCallback(({ roundId }: { roundId: number }) => {
-    setRoundId(roundId);
-  }, []);
+  const handleRoundStarted = useCallback(
+    ({
+      roundId,
+      roundNumber,
+      startedAt,
+    }: {
+      roundId: number;
+      roundNumber: number;
+      startedAt: string;
+    }) => {
+      setRoundId(roundId);
+      setRoundNumber(roundNumber);
+      setStartedAt(startedAt);
+    },
+    [],
+  );
 
   const handleRoundEnded = useCallback(() => {
     setSelectedCell(null);
+    setRoundId(null);
+    setRoundNumber(null);
+    setStartedAt(null);
   }, []);
 
   const handleCanvasUpdated = useCallback(
@@ -116,6 +133,8 @@ export default function CanvasPage() {
   const handleGameEnded = useCallback(() => {
     setGameEnded(true);
     setRoundId(null);
+    setRoundNumber(null);
+    setStartedAt(null);
   }, []);
 
   useSocket({
@@ -150,7 +169,6 @@ export default function CanvasPage() {
     if (e.button !== 0) return;
     isPanning.current = false;
 
-    // 드래그가 아닌 클릭일 때만 셀 선택
     if (!hasPanned.current) {
       const canvasEl = canvasRef.current;
       const container = containerRef.current;
@@ -190,7 +208,6 @@ export default function CanvasPage() {
 
   return (
     <div className="flex w-full h-screen">
-      {/* 캔버스 영역 */}
       <div
         ref={containerRef}
         className="overflow-auto bg-gray-50 cursor-grab active:cursor-grabbing"
@@ -207,7 +224,6 @@ export default function CanvasPage() {
         </div>
       </div>
 
-      {/* 패널 영역 */}
       <div
         className="border-l border-gray-200 bg-white shrink-0"
         style={{ width: `${PANEL_WIDTH}px` }}
@@ -216,6 +232,8 @@ export default function CanvasPage() {
           <VotePanel
             canvasId={canvasId}
             roundId={roundId}
+            roundNumber={roundNumber}
+            startedAt={startedAt}
             selectedCell={selectedCell}
             onVoteSuccess={handleVoteSuccess}
           />


### PR DESCRIPTION
## 관련 이슈
- Close #48 


## 작업 내용
- src/components/vote/RoundInfo.tsx 생성 (라운드 번호 + 카운트다운 타이머)
- src/components/vote/VotePanel.tsx 수정 (RoundInfo 추가, roundNumber/startedAt props 추가)
- src/hooks/useSocket.ts 수정 (roundNumber, startedAt 페이로드 전달)
- src/pages/CanvasPage.tsx 수정 (roundNumber, startedAt 상태 추가 및 VotePanel 전달)

## 테스트 및 확인 사항
- 우측 패널 라운드 번호 표시 확인
- 남은 시간 카운트다운 확인
- 라운드 종료 후 새 라운드 시작 시 타이머 리셋 확인

<img width="232" height="110" alt="image" src="https://github.com/user-attachments/assets/2fc8ca5c-51e6-4688-90c9-60e7b4c994aa" />

- 현재 라운드 종료 시 화면 갱신 안됨 백엔드에서는 처리하고 있기 때문에 새로고침하면 진행중인 상태의 다음라운드로 표시됨

## 체크리스트
- [ ] 불필요한 주석 및 디버깅 코드를 제거하였는가?
- [ ] 모든 테스트를 통과하였는가?
- [ ] 변경 사항에 대한 문서 업데이트가 필요한가?
