### PR TITLE
feat: 게임 도중 서버 비정상 종료 상태에서 서버 재시작 시 캔버스 클린업 및 캔버스 재생성

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -13,6 +13,7 @@ import authRouter from "./modules/auth/auth.router";
 import canvasRouter from "./modules/canvas/canvas.router";
 import roundRouter from "./modules/round/round.router";
 import voteRouter from "./modules/vote/vote.router";
+import { canvasService } from "./modules/canvas/canvas.service";
 
 dotenv.config();
 
@@ -34,7 +35,10 @@ app.use(sessionMiddleware);
 
 // TypeORM 연결
 AppDataSource.initialize()
-  .then(() => console.log("DB 연결 성공"))
+  .then(async () => {
+    console.log("DB 연결 성공");
+    await canvasService.recoverOnStartup(io);
+  })
   .catch((err) => console.error("DB 연결 실패:", err));
 
 // Health check

--- a/backend/src/modules/canvas/canvas.service.ts
+++ b/backend/src/modules/canvas/canvas.service.ts
@@ -2,10 +2,12 @@ import { Server } from "socket.io";
 import { AppDataSource } from "../../database/data-source";
 import { Canvas, CanvasStatus } from "../../entities/canvas.entity";
 import { Cell, CellStatus } from "../../entities/cell.entity";
+import { VoteRound } from "../../entities/vote-round.entity";
 import { startGameTimer } from "../game/game.timer";
 
 const canvasRepository = AppDataSource.getRepository(Canvas);
 const cellRepository = AppDataSource.getRepository(Cell);
+const voteRoundRepository = AppDataSource.getRepository(VoteRound);
 
 const GRID_X = parseInt(process.env.GRID_SIZE_X ?? "25");
 const GRID_Y = parseInt(process.env.GRID_SIZE_Y ?? "25");
@@ -61,5 +63,38 @@ export const canvasService = {
       where: { canvas: { id: canvasId } },
       order: { y: "ASC", x: "ASC" },
     });
+  },
+
+  async recoverOnStartup(io: Server): Promise<Canvas> {
+    const now = new Date();
+
+    const playingCanvases = await canvasRepository.find({
+      where: { status: CanvasStatus.PLAYING },
+      order: { startedAt: "DESC" },
+    });
+
+    if (playingCanvases.length > 0) {
+      const canvasIds = playingCanvases.map((canvas) => canvas.id);
+
+      await canvasRepository.update(
+        { status: CanvasStatus.PLAYING },
+        {
+          status: CanvasStatus.FINISHED,
+          endedAt: now,
+        },
+      );
+
+      for (const canvasId of canvasIds) {
+        await voteRoundRepository.update(
+          { canvas: { id: canvasId }, isActive: true },
+          {
+            isActive: false,
+            endedAt: now,
+          },
+        );
+      }
+    }
+
+    return this.create(io);
   },
 };


### PR DESCRIPTION
## 관련 이슈
- Close #65 

## 작업 내용
- 서버가 중단되거나 하면 DB의 캔버스 정보는 playing으로 남아 있어 다시 서버가 실행되는 경우 기존의 캔버스의 status를 'finished'로 변경하고 다시 캔버스를 생성하여 게임을 시작하도록 함

## 테스트 및 확인 사항
- canvas Table 데이터 확인, 캔버스 Id: 13 진행 중 서버 강제 종료 및 재시작
- 캔버스 Id: 13 status  finished로 업데이트 및 신규 캔버스 (id:14) 생성
<img width="540" height="79" alt="image" src="https://github.com/user-attachments/assets/7954e2c7-8abb-40de-8363-de954ad9c6fa" />

- vote_round Table 데이터 확인
- 라운드 진행중인 상태(isActive=true)에서 서버 강제 종료 및 재시작
- 마지막 라운드 isActive=false로 update되며15번 캔버스 생성 및 신규 라운드 시작
<img width="1302" height="202" alt="image" src="https://github.com/user-attachments/assets/742554e4-fb40-4623-b5f2-c7d48bc82e54" />


## 체크리스트
- [x] 불필요한 주석 및 디버깅 코드를 제거하였는가?
- [x] 모든 테스트를 통과하였는가?
- [ ] 변경 사항에 대한 문서 업데이트가 필요한가?
