### PR TITLE
feat: 라운드 전환 시 마감 대기 구간 추가 및 BE,FE 정합성 구현

### DIFF
--- a/backend/src/config/game.config.ts
+++ b/backend/src/config/game.config.ts
@@ -1,9 +1,13 @@
 export const gameConfig = {
   roundDurationSec: 20,
   totalRounds: 10,
-  votesPerRound: 20,
+  votesPerRound: 3,
+  roundResultDelaySec: 3,
   get totalDurationSec() {
-    return this.roundDurationSec * this.totalRounds;
+    return (
+      this.roundDurationSec * this.totalRounds +
+      this.roundResultDelaySec * this.totalRounds
+    );
   },
 };
 

--- a/backend/src/modules/game/game.timer.ts
+++ b/backend/src/modules/game/game.timer.ts
@@ -10,13 +10,19 @@ const activeTimers = new Map<number, NodeJS.Timeout>();
 // canvasId별 timer:update broadcast interval 관리
 const activeBroadcasts = new Map<number, NodeJS.Timeout>();
 
+// 라운드 종료 후 다음 라운드 시작 전 마감 상태 유지 시간(초)
+const ROUND_RESULT_DELAY_SEC = 10;
+
 function getGameEndAt(roundStartedAt: Date, currentRound: number): Date {
   const remainingRoundsIncludingCurrent =
     gameConfig.totalRounds - currentRound + 1;
 
   return new Date(
     roundStartedAt.getTime() +
-      remainingRoundsIncludingCurrent * gameConfig.roundDurationSec * 1000,
+      remainingRoundsIncludingCurrent * gameConfig.roundDurationSec * 1000 +
+      Math.max(0, remainingRoundsIncludingCurrent - 1) *
+        gameConfig.roundResultDelaySec *
+        1000,
   );
 }
 
@@ -32,7 +38,7 @@ export async function startGameTimer(
   const canvasRepository = AppDataSource.getRepository(Canvas);
   const canvas = await canvasRepository.findOne({ where: { id: canvasId } });
   if (!canvas) {
-    throw new Error(`캔버스를 찾을 수 없어요 (id=${canvasId})`);
+    throw new Error(`캔버스를 찾을 수 없습니다. (id=${canvasId})`);
   }
 
   async function runRound(currentRound: number): Promise<void> {
@@ -56,37 +62,47 @@ export async function startGameTimer(
 
     const gameEndAt = getGameEndAt(round.startedAt, round.roundNumber);
 
-    const broadcastTimerUpdate = () => {
+    const broadcastTimerUpdate = (
+      remainingSecondsOverride?: number,
+      isRoundExpiredOverride?: boolean,
+    ) => {
       const elapsed = Math.floor(
         (Date.now() - round.startedAt.getTime()) / 1000,
       );
-      const remainingSeconds = Math.max(0, gameConfig.roundDurationSec - elapsed);
+
+      const remainingSeconds =
+        remainingSecondsOverride ??
+        Math.max(0, gameConfig.roundDurationSec - elapsed);
+
+      const isRoundExpired = isRoundExpiredOverride ?? remainingSeconds === 0;
 
       io.to(`canvas:${canvasId}`).emit("timer:update", {
         roundId: round.id,
         roundNumber: round.roundNumber,
         remainingSeconds,
-        isRoundExpired: remainingSeconds === 0,
+        isRoundExpired,
         roundDurationSec: gameConfig.roundDurationSec,
         totalRounds: gameConfig.totalRounds,
         gameEndAt: gameEndAt.toISOString(),
       });
     };
 
-    // 라운드 시작 직후 즉시 1회 전송
     broadcastTimerUpdate();
 
-    const broadcastInterval = setInterval(broadcastTimerUpdate, 1000);
+    const broadcastInterval = setInterval(() => {
+      broadcastTimerUpdate();
+    }, 1000);
     activeBroadcasts.set(canvasId, broadcastInterval);
 
     const timer = setTimeout(async () => {
-      activeTimers.delete(canvasId);
-
       const runningBroadcast = activeBroadcasts.get(canvasId);
       if (runningBroadcast) {
         clearInterval(runningBroadcast);
         activeBroadcasts.delete(canvasId);
       }
+
+      // 라운드 종료 직후 마감 상태를 즉시 1회 전송
+      broadcastTimerUpdate(0, true);
 
       try {
         await roundService.endRound(canvasId, round.id, io);
@@ -95,6 +111,7 @@ export async function startGameTimer(
           `[타이머] 라운드 종료 실패 (canvasId=${canvasId}, roundId=${round.id}):`,
           err,
         );
+        activeTimers.delete(canvasId);
         return;
       }
 
@@ -102,7 +119,12 @@ export async function startGameTimer(
         `[타이머] 라운드 ${round.roundNumber} 종료 (canvasId=${canvasId})`,
       );
 
-      runRound(currentRound + 1);
+      const delayTimer = setTimeout(() => {
+        activeTimers.delete(canvasId);
+        runRound(currentRound + 1);
+      }, gameConfig.roundResultDelaySec * 1000);
+
+      activeTimers.set(canvasId, delayTimer);
     }, gameConfig.roundDurationSec * 1000);
 
     activeTimers.set(canvasId, timer);

--- a/backend/src/modules/round/round.controller.ts
+++ b/backend/src/modules/round/round.controller.ts
@@ -35,14 +35,19 @@ export const roundController = {
     try {
       const canvasId = parseInt(String(req.params["canvasId"]));
       if (isNaN(canvasId)) {
-        return res.status(400).json({ message: "올바르지 않은 캔버스 ID예요" });
+        return res
+          .status(400)
+          .json({ message: "올바르지 않은 캔버스 ID입니다." });
       }
 
-      const round = await roundService.getActiveRound(canvasId);
-      if (!round) {
-        return res.status(404).json({ message: "진행 중인 라운드가 없어요" });
+      const roundState = await roundService.getActiveRoundState(canvasId);
+      if (!roundState) {
+        return res
+          .status(404)
+          .json({ message: "진행 중인 라운드가 없습니다." });
       }
-      return res.json({ round });
+
+      return res.json(roundState);
     } catch (err) {
       return res.status(500).json({ message: String(err) });
     }

--- a/backend/src/modules/round/round.service.ts
+++ b/backend/src/modules/round/round.service.ts
@@ -18,6 +18,50 @@ const voterRepository = AppDataSource.getRepository(Voter);
 
 const VOTES_PER_ROUND = gameConfig.votesPerRound;
 
+interface RoundStateResponse {
+  status: "active" | "waiting";
+  round: {
+    id: number;
+    roundNumber: number;
+    startedAt: Date;
+    endedAt: Date | null;
+    roundDurationSec: number;
+    totalRounds: number;
+    gameEndAt: string;
+  };
+  timer: {
+    remainingSeconds: number;
+    isRoundExpired: boolean;
+    roundDurationSec: number;
+    totalRounds: number;
+    gameEndAt: string;
+  };
+}
+
+function getActiveGameEndAt(roundStartedAt: Date, roundNumber: number): Date {
+  const remainingRoundsIncludingCurrent =
+    gameConfig.totalRounds - roundNumber + 1;
+
+  return new Date(
+    roundStartedAt.getTime() +
+      remainingRoundsIncludingCurrent * gameConfig.roundDurationSec * 1000 +
+      Math.max(0, remainingRoundsIncludingCurrent - 1) *
+        gameConfig.roundResultDelaySec *
+        1000,
+  );
+}
+
+function getWaitingGameEndAt(roundEndedAt: Date, roundNumber: number): Date {
+  const futureRounds = gameConfig.totalRounds - roundNumber;
+
+  return new Date(
+    roundEndedAt.getTime() +
+      gameConfig.roundResultDelaySec * 1000 +
+      futureRounds * gameConfig.roundDurationSec * 1000 +
+      Math.max(0, futureRounds - 1) * gameConfig.roundResultDelaySec * 1000,
+  );
+}
+
 export const roundService = {
   async startRound(canvasId: number, io?: Server): Promise<VoteRound> {
     const canvas = await canvasRepository.findOne({ where: { id: canvasId } });
@@ -67,10 +111,7 @@ export const roundService = {
       const remainingRoundsIncludingCurrent =
         gameConfig.totalRounds - round.roundNumber + 1;
 
-      const gameEndAt = new Date(
-        round.startedAt.getTime() +
-        remainingRoundsIncludingCurrent * gameConfig.roundDurationSec * 1000,
-      );
+      const gameEndAt = getActiveGameEndAt(round.startedAt, round.roundNumber);
 
       io.to(`canvas:${canvasId}`).emit("round:started", {
         roundId: round.id,
@@ -191,11 +232,11 @@ export const roundService = {
         endedAt: round.endedAt,
         winningCell: winningCell
           ? {
-            id: winningCell.id,
-            x: winningCell.x,
-            y: winningCell.y,
-            color: winningCell.color,
-          }
+              id: winningCell.id,
+              x: winningCell.x,
+              y: winningCell.y,
+              color: winningCell.color,
+            }
           : null,
       });
 
@@ -212,9 +253,85 @@ export const roundService = {
     return round;
   },
 
-  async getActiveRound(canvasId: number): Promise<VoteRound | null> {
-    return voteRoundRepository.findOne({
+  async getActiveRoundState(
+    canvasId: number,
+  ): Promise<RoundStateResponse | null> {
+    const now = new Date();
+
+    const activeRound = await voteRoundRepository.findOne({
       where: { canvas: { id: canvasId }, isActive: true },
+      order: { roundNumber: "DESC" },
     });
+
+    if (activeRound) {
+      const remainingSeconds = Math.max(
+        0,
+        gameConfig.roundDurationSec -
+          Math.floor((now.getTime() - activeRound.startedAt.getTime()) / 1000),
+      );
+
+      const gameEndAt = getActiveGameEndAt(
+        activeRound.startedAt,
+        activeRound.roundNumber,
+      );
+
+      return {
+        status: "active",
+        round: {
+          id: activeRound.id,
+          roundNumber: activeRound.roundNumber,
+          startedAt: activeRound.startedAt,
+          endedAt: activeRound.endedAt ?? null,
+          roundDurationSec: gameConfig.roundDurationSec,
+          totalRounds: gameConfig.totalRounds,
+          gameEndAt: gameEndAt.toISOString(),
+        },
+        timer: {
+          remainingSeconds,
+          isRoundExpired: remainingSeconds === 0,
+          roundDurationSec: gameConfig.roundDurationSec,
+          totalRounds: gameConfig.totalRounds,
+          gameEndAt: gameEndAt.toISOString(),
+        },
+      };
+    }
+
+    const lastRound = await voteRoundRepository.findOne({
+      where: { canvas: { id: canvasId } },
+      order: { roundNumber: "DESC" },
+    });
+
+    if (!lastRound?.endedAt) return null;
+
+    const waitingDeadline = new Date(
+      lastRound.endedAt.getTime() + gameConfig.roundResultDelaySec * 1000,
+    );
+
+    if (now >= waitingDeadline) return null;
+
+    const gameEndAt = getWaitingGameEndAt(
+      lastRound.endedAt,
+      lastRound.roundNumber,
+    );
+
+    return {
+      status: "waiting",
+      round: {
+        id: lastRound.id,
+        roundNumber: lastRound.roundNumber,
+        startedAt: lastRound.startedAt,
+        endedAt: lastRound.endedAt,
+        roundDurationSec: gameConfig.roundDurationSec,
+        totalRounds: gameConfig.totalRounds,
+        gameEndAt: gameEndAt.toISOString(),
+      },
+      timer: {
+        remainingSeconds: 0,
+        isRoundExpired: true,
+        roundDurationSec: gameConfig.roundDurationSec,
+        totalRounds: gameConfig.totalRounds,
+        gameEndAt: gameEndAt.toISOString(),
+      },
+    };
   },
 };

--- a/frontend/src/components/vote/VotePopup.tsx
+++ b/frontend/src/components/vote/VotePopup.tsx
@@ -24,11 +24,12 @@ interface VoteEntry {
 interface Props {
   canvasId: number;
   roundId: number | null;
+  isRoundExpired: boolean;
   selectedCell: Cell;
   votes: Record<string, number>;
   cells: Cell[];
   position: { x: number; y: number };
-  onVoteSuccess: (color: string) => void;
+  onVoteSuccess: () => void;
   onColorChange: (color: string | null) => void;
   onClose: () => void;
 }
@@ -69,6 +70,7 @@ function loadLastVotedColor(): string {
 export default function VotePopup({
   canvasId,
   roundId,
+  isRoundExpired,
   selectedCell,
   votes,
   cells,
@@ -80,7 +82,9 @@ export default function VotePopup({
   const [color, setColor] = useState(() => loadLastVotedColor());
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
-  const [slotColors, setSlotColors] = useState<string[]>(() => loadSlotColors());
+  const [slotColors, setSlotColors] = useState<string[]>(() =>
+    loadSlotColors(),
+  );
   const [slotCursor, setSlotCursor] = useState(0);
   const [pos, setPos] = useState(position);
   const isDragging = useRef(false);
@@ -90,14 +94,28 @@ export default function VotePopup({
   const voteEntries: VoteEntry[] = Object.entries(votes)
     .filter(([key]) => key.startsWith(`${selectedCell.id}:`))
     .map(([key, count]) => {
-      const [cellIdStr, color] = key.split(":");
+      const [cellIdStr, entryColor] = key.split(":");
       const cellId = parseInt(cellIdStr);
       const cell = cells.find((c) => c.id === cellId);
-      return { cellId, x: cell?.x ?? 0, y: cell?.y ?? 0, color, count };
+
+      return {
+        cellId,
+        x: cell?.x ?? 0,
+        y: cell?.y ?? 0,
+        color: entryColor,
+        count,
+      };
     })
     .sort((a, b) => b.count - a.count);
 
   const maxCount = voteEntries[0]?.count ?? 1;
+  const isVoteDisabled = !roundId || loading || isRoundExpired;
+
+  const buttonLabel = isRoundExpired
+    ? "투표 마감"
+    : loading
+      ? "투표 중..."
+      : "투표하기";
 
   const handleColorChange = (newColor: string) => {
     setColor(newColor);
@@ -129,9 +147,13 @@ export default function VotePopup({
     handleColorChange(slotColor);
   };
 
-
   const handleSubmit = async () => {
     if (!roundId) return;
+
+    if (isRoundExpired) {
+      setError("이 라운드 투표가 마감되었습니다.");
+      return;
+    }
 
     setError("");
     setLoading(true);
@@ -147,14 +169,16 @@ export default function VotePopup({
       });
 
       onColorChange(null);
-      onVoteSuccess(color);
+      onVoteSuccess();
       onClose();
     } catch (err: unknown) {
       if (err && typeof err === "object" && "response" in err) {
-        const axiosErr = err as { response: { data: { message: string } } };
-        setError(axiosErr.response.data.message);
+        const axiosErr = err as { response?: { data?: { message?: string } } };
+        setError(
+          axiosErr.response?.data?.message ?? "투표 중 오류가 발생했어요.",
+        );
       } else {
-        setError("투표 중 오류가 발생했어요");
+        setError("투표 중 오류가 발생했어요.");
       }
     } finally {
       setLoading(false);
@@ -168,7 +192,10 @@ export default function VotePopup({
   };
 
   useEffect(() => {
-    window.localStorage.setItem(STORAGE_KEYS.slotColors, JSON.stringify(slotColors));
+    window.localStorage.setItem(
+      STORAGE_KEYS.slotColors,
+      JSON.stringify(slotColors),
+    );
   }, [slotColors]);
 
   useEffect(() => {
@@ -225,6 +252,16 @@ export default function VotePopup({
     return () => onColorChange(null);
   }, []);
 
+  useEffect(() => {
+    if (isRoundExpired) {
+      setLoading(false);
+      setError("");
+      return;
+    }
+
+    setError("");
+  }, [isRoundExpired]);
+
   return (
     <div
       ref={popupRef}
@@ -244,11 +281,11 @@ export default function VotePopup({
               selectedCell.color
                 ? { backgroundColor: selectedCell.color }
                 : {
-                  backgroundColor: "#f9fafb",
-                  backgroundImage: CHECKER_PATTERN,
-                  backgroundPosition: "0 0, 4px 4px",
-                  backgroundSize: "8px 8px",
-                }
+                    backgroundColor: "#f9fafb",
+                    backgroundImage: CHECKER_PATTERN,
+                    backgroundPosition: "0 0, 4px 4px",
+                    backgroundSize: "8px 8px",
+                  }
             }
             onClick={(e) => {
               e.stopPropagation();
@@ -276,28 +313,28 @@ export default function VotePopup({
           <div>
             <p className="mb-2 text-xs font-medium">득표 현황</p>
             <div className="flex max-h-[72px] flex-col gap-1 overflow-y-auto">
-              {voteEntries.map(({ color: c, count }) => (
+              {voteEntries.map(({ color: entryColor, count }) => (
                 <button
-                  key={c}
+                  key={entryColor}
                   className="flex w-full items-center gap-2 rounded px-1 py-0.5 hover:bg-gray-50"
                   onClick={(e) => {
                     e.stopPropagation();
-                    handleVoteEntryClick(c);
+                    handleVoteEntryClick(entryColor);
                   }}
                 >
                   <div
                     className="h-3 w-3 shrink-0 rounded-sm border border-gray-200"
-                    style={{ backgroundColor: c }}
+                    style={{ backgroundColor: entryColor }}
                   />
                   <span className="w-14 shrink-0 text-left text-xs text-gray-500">
-                    {c}
+                    {entryColor}
                   </span>
                   <div className="h-2 flex-1 rounded bg-gray-100">
                     <div
                       className="h-2 rounded transition-all"
                       style={{
                         width: `${(count / maxCount) * 100}%`,
-                        backgroundColor: c,
+                        backgroundColor: entryColor,
                       }}
                     />
                   </div>
@@ -320,20 +357,31 @@ export default function VotePopup({
           onSlotSelect={handleSlotSelect}
         />
 
-
-        {error && <p className="text-xs text-red-500">{error}</p>}
+        {error && !isRoundExpired && (
+          <p className="text-xs text-red-500">{error}</p>
+        )}
 
         <Button
           onClick={(e) => {
             e.stopPropagation();
             handleSubmit();
           }}
-          disabled={!roundId || loading}
+          disabled={isVoteDisabled}
           className="w-full"
           size="sm"
         >
-          {loading ? "투표 중..." : "투표하기"}
+          {buttonLabel}
         </Button>
+
+        {isRoundExpired && (
+          <p className="text-center text-xs text-red-500">
+            이 라운드 투표가 마감되었습니다.
+          </p>
+        )}
+
+        {error && isRoundExpired && (
+          <p className="text-center text-xs text-red-500">{error}</p>
+        )}
       </div>
     </div>
   );

--- a/frontend/src/pages/CanvasPage.tsx
+++ b/frontend/src/pages/CanvasPage.tsx
@@ -6,15 +6,32 @@ import VotePopup from "@/components/vote/VotePopup";
 import useSocket from "@/hooks/useSocket";
 import { voteApi } from "@/api/vote";
 
-/**
- * 상수 정의
- */
 const CELL_SIZE = parseInt(import.meta.env.VITE_CELL_SIZE ?? "8");
 const PANEL_WIDTH = 280;
 const RESTART_TIME = 3;
 const CHECKER_LIGHT = "#6f6f6f";
 const CHECKER_DARK = "#5f5f5f";
 const CANVAS_BACKGROUND_COLOR = "#2a2a2a";
+
+interface RoundStateResponse {
+  status: "active" | "waiting";
+  round: {
+    id: number;
+    roundNumber: number;
+    startedAt: string;
+    endedAt: string | null;
+    roundDurationSec: number;
+    totalRounds: number;
+    gameEndAt: string;
+  };
+  timer: {
+    remainingSeconds: number;
+    isRoundExpired: boolean;
+    roundDurationSec: number;
+    totalRounds: number;
+    gameEndAt: string;
+  };
+}
 
 function formatClockTime(date: Date): string {
   const hours = String(date.getHours()).padStart(2, "0");
@@ -42,6 +59,7 @@ export default function CanvasPage() {
   const previewColorRef = useRef<string | null>(null);
   const votingCellIdsRef = useRef<Set<number>>(new Set());
   const topColorMapRef = useRef<Map<number, string>>(new Map());
+  const isRoundExpiredRef = useRef(false);
 
   const [cells, setCells] = useState<Cell[]>([]);
   const [canvasId, setCanvasId] = useState<number | null>(null);
@@ -49,9 +67,13 @@ export default function CanvasPage() {
   const [roundNumber, setRoundNumber] = useState<number | null>(null);
   const [roundDurationSec, setRoundDurationSec] = useState<number | null>(null);
   const [totalRounds, setTotalRounds] = useState<number>(0);
-  const [formattedGameEndTime, setFormattedGameEndTime] = useState<string | null>(null);
+  const [formattedGameEndTime, setFormattedGameEndTime] = useState<
+    string | null
+  >(null);
   const [remainingSeconds, setRemainingSeconds] = useState<number | null>(null);
-  const [formattedRemainingTime, setFormattedRemainingTime] = useState<string | null>(null);
+  const [formattedRemainingTime, setFormattedRemainingTime] = useState<
+    string | null
+  >(null);
   const [isRoundExpired, setIsRoundExpired] = useState(false);
   const [selectedCell, setSelectedCell] = useState<Cell | null>(null);
   const [previewColor, setPreviewColor] = useState<string | null>(null);
@@ -84,6 +106,10 @@ export default function CanvasPage() {
     topColorMapRef.current = topColorMap;
   }, [topColorMap]);
 
+  useEffect(() => {
+    isRoundExpiredRef.current = isRoundExpired;
+  }, [isRoundExpired]);
+
   const updateCells = useCallback(
     (updater: Cell[] | ((prev: Cell[]) => Cell[])) => {
       if (typeof updater === "function") {
@@ -111,21 +137,21 @@ export default function CanvasPage() {
 
       ctx.clearRect(0, 0, canvasEl.width, canvasEl.height);
 
-      const cells = cellsRef.current;
-      const selectedCell = selectedCellRef.current;
-      const previewColor = previewColorRef.current;
-      const votingCellIds = votingCellIdsRef.current;
-      const topColorMap = topColorMapRef.current;
+      const currentCells = cellsRef.current;
+      const currentSelectedCell = selectedCellRef.current;
+      const currentPreviewColor = previewColorRef.current;
+      const currentVotingCellIds = votingCellIdsRef.current;
+      const currentTopColorMap = topColorMapRef.current;
 
       const alpha = (Math.sin((timestamp / 500) * Math.PI) + 1) / 2;
       const dashOffset = -(timestamp / 100) % 8;
 
-      cells.forEach((cell) => {
+      currentCells.forEach((cell) => {
         const x = cell.x * CELL_SIZE;
         const y = cell.y * CELL_SIZE;
-        const isSelected = selectedCell?.id === cell.id;
-        const isVoting = votingCellIds.has(cell.id);
-        const topColor = topColorMap.get(cell.id);
+        const isSelected = currentSelectedCell?.id === cell.id;
+        const isVoting = currentVotingCellIds.has(cell.id);
+        const topColor = currentTopColorMap.get(cell.id);
 
         if (cell.color) {
           ctx.fillStyle = cell.color;
@@ -141,8 +167,8 @@ export default function CanvasPage() {
           ctx.fillRect(x + half, y + half, half, half);
         }
 
-        if (isSelected && previewColor) {
-          ctx.fillStyle = previewColor;
+        if (isSelected && currentPreviewColor) {
+          ctx.fillStyle = currentPreviewColor;
           ctx.fillRect(x, y, CELL_SIZE, CELL_SIZE);
         } else if (isVoting && topColor && !isSelected) {
           ctx.fillStyle = topColor;
@@ -177,34 +203,60 @@ export default function CanvasPage() {
   }, [canvasReady]);
 
   useEffect(() => {
-    api
-      .get<CanvasCurrentResponse>("/canvas/current")
-      .then(({ data }) => {
+    const initialize = async () => {
+      try {
+        const { data } =
+          await api.get<CanvasCurrentResponse>("/canvas/current");
         const { canvas, cells } = data;
+
         setCanvasId(canvas.id);
         updateCells(cells);
 
         const canvasEl = canvasRef.current;
         if (!canvasEl) return;
+
         canvasEl.width = canvas.gridX * CELL_SIZE;
         canvasEl.height = canvas.gridY * CELL_SIZE;
         setCanvasReady(true);
 
-        return api.get(`/canvas/${canvas.id}/rounds/active`);
-      })
-      .then((res) => {
-        if (res?.data?.round) {
-          setRoundId(res.data.round.id);
-          setRoundNumber(res.data.round.roundNumber);
-          return voteApi.getTickets(res.data.round.id);
+        const roundRes = await api.get<RoundStateResponse>(
+          `/canvas/${canvas.id}/rounds/active`,
+        );
+        const roundState = roundRes.data;
+
+        if (roundState?.round) {
+          setRoundId(roundState.round.id);
+          setRoundNumber(roundState.round.roundNumber);
+          setRoundDurationSec(roundState.round.roundDurationSec);
+          setTotalRounds(roundState.round.totalRounds);
+          setFormattedGameEndTime(
+            formatClockTime(new Date(roundState.round.gameEndAt)),
+          );
         }
-      })
-      .then((res) => {
-        if (res?.data) setRemaining(res.data.remaining);
-      })
-      .catch(() => setError("진행 중인 캔버스가 없어요."))
-      .finally(() => setLoading(false));
-  }, []);
+
+        if (roundState?.timer) {
+          setRemainingSeconds(roundState.timer.remainingSeconds);
+          setFormattedRemainingTime(
+            formatDuration(roundState.timer.remainingSeconds),
+          );
+          setIsRoundExpired(roundState.timer.isRoundExpired);
+        }
+
+        if (roundState?.status === "active" && roundState.round.id) {
+          const ticketsRes = await voteApi.getTickets(roundState.round.id);
+          setRemaining(ticketsRes.data.remaining);
+        } else {
+          setRemaining(null);
+        }
+      } catch {
+        setError("진행중인 캔버스가 없어요");
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    initialize();
+  }, [updateCells]);
 
   useEffect(() => {
     if (!gameEnded) return;
@@ -243,35 +295,31 @@ export default function CanvasPage() {
       setRemainingSeconds(roundDurationSec);
       setFormattedRemainingTime(formatDuration(roundDurationSec));
       setIsRoundExpired(false);
+      setError(null);
       votingCellIdsRef.current = new Set();
       topColorMapRef.current = new Map();
       setVotingCellIds(new Set());
       setTopColorMap(new Map());
+
       voteApi
         .getTickets(roundId)
-        .then(({ data }) => setRemaining(data.remaining));
-    }, []);
+        .then(({ data }) => setRemaining(data.remaining))
+        .catch(() => setRemaining(null));
+    },
+    [],
+  );
 
   const handleRoundEnded = useCallback(() => {
-    setSelectedCell(null);
-    selectedCellRef.current = null;
-    setPreviewColor(null);
-    previewColorRef.current = null;
-    setPopupOpen(false);
-    setRoundId(null);
-    setRoundNumber(null);
-    setRoundDurationSec(null);
     setVotes({});
     setRemaining(null);
-    setRemainingSeconds(null);
-    setFormattedRemainingTime(null);
-    setIsRoundExpired(false);
+    setRemainingSeconds(0);
+    setFormattedRemainingTime(formatDuration(0));
+    setIsRoundExpired(true);
     votingCellIdsRef.current = new Set();
     topColorMapRef.current = new Map();
     setVotingCellIds(new Set());
     setTopColorMap(new Map());
   }, []);
-
 
   const handleCanvasUpdated = useCallback(
     ({ cellId, color }: { cellId: number; color: string }) => {
@@ -280,13 +328,22 @@ export default function CanvasPage() {
           c.id === cellId ? { ...c, color, status: "painted" } : c,
         ),
       );
+
       if (selectedCellRef.current?.id === cellId) {
-        setSelectedCell(null);
-        selectedCellRef.current = null;
-        setPopupOpen(false);
+        const nextSelectedCell: Cell = {
+          ...selectedCellRef.current,
+          color,
+          status: "painted",
+        };
+        setSelectedCell(nextSelectedCell);
+        selectedCellRef.current = nextSelectedCell;
+
+        if (!isRoundExpiredRef.current) {
+          setPopupOpen(false);
+        }
       }
     },
-    [],
+    [updateCells],
   );
 
   const handleVoteUpdate = useCallback(
@@ -339,8 +396,9 @@ export default function CanvasPage() {
       setFormattedGameEndTime(formatClockTime(new Date(gameEndAt)));
       setRoundDurationSec(roundDurationSec);
       setTotalRounds(totalRounds);
-    }, []);
-
+    },
+    [],
+  );
 
   const handleGameEnded = useCallback(() => {
     setGameEnded(true);
@@ -359,7 +417,6 @@ export default function CanvasPage() {
     setVotingCellIds(new Set());
     setTopColorMap(new Map());
   }, []);
-
 
   useSocket({
     canvasId,
@@ -418,15 +475,11 @@ export default function CanvasPage() {
   };
 
   const handleVoteSuccess = () => {
-    setSelectedCell(null);
-    selectedCellRef.current = null;
-    setPreviewColor(null);
-    previewColorRef.current = null;
-    setPopupOpen(false);
     if (roundId) {
       voteApi
         .getTickets(roundId)
-        .then(({ data }) => setRemaining(data.remaining));
+        .then(({ data }) => setRemaining(data.remaining))
+        .catch(() => setRemaining(null));
     }
   };
 
@@ -443,25 +496,30 @@ export default function CanvasPage() {
     previewColorRef.current = color;
   };
 
-  if (loading)
+  if (loading) {
     return (
-      <div className="flex items-center justify-center h-screen">
+      <div className="flex h-screen items-center justify-center">
         로딩 중...
       </div>
     );
-  if (error)
+  }
+
+  if (error) {
     return (
-      <div className="flex items-center justify-center h-screen">{error}</div>
+      <div className="flex h-screen items-center justify-center">{error}</div>
     );
-  if (gameEnded)
+  }
+
+  if (gameEnded) {
     return (
-      <div className="flex items-center justify-center h-screen text-xl font-bold">
-        게임이 종료됐어요 🎨 새 게임을 생성할게요.
+      <div className="flex h-screen items-center justify-center text-xl font-bold">
+        게임이 종료되었어요. 곧 새 게임이 생성됩니다.
       </div>
     );
+  }
 
   return (
-    <div className="flex w-full h-screen">
+    <div className="flex h-screen w-full">
       <div
         className="relative overflow-hidden cursor-grab active:cursor-grabbing"
         style={{
@@ -475,8 +533,8 @@ export default function CanvasPage() {
           isPanning.current = false;
         }}
       >
-        <div ref={containerRef} className="overflow-auto w-full h-full">
-          <div className="flex items-center justify-center min-w-full min-h-full p-8">
+        <div ref={containerRef} className="h-full w-full overflow-auto">
+          <div className="flex min-h-full min-w-full items-center justify-center p-8">
             <canvas ref={canvasRef} className="border border-gray-300" />
           </div>
         </div>
@@ -486,6 +544,7 @@ export default function CanvasPage() {
         <VotePopup
           canvasId={canvasId}
           roundId={roundId}
+          isRoundExpired={isRoundExpired}
           selectedCell={selectedCell}
           votes={votes}
           cells={cells}
@@ -497,7 +556,7 @@ export default function CanvasPage() {
       )}
 
       <div
-        className="border-l border-gray-200 bg-white shrink-0"
+        className="shrink-0 border-l border-gray-200 bg-white"
         style={{ width: `${PANEL_WIDTH}px` }}
       >
         {canvasId && (


### PR DESCRIPTION
## 관련 이슈
- Close #76 

## 작업 내용

라운드 종료 직후 바로 다음 라운드로 넘어가던 흐름을 수정해, 마감 상태를 몇 초간 유지한 뒤 다음 라운드가 시작되도록 변경했습니다.

또한 투표 팝업이 라운드 종료 시 즉시 닫히지 않고 마감 상태를 보여주도록 수정했고, 새로고침 시에도 마감 대기 상태를 복구할 수 있도록 라운드 상태 조회 구조를 보완했습니다.

## 주요 변경 사항

### 백엔드
- 라운드 종료 후 다음 라운드 시작 전 `roundResultDelaySec` 만큼 대기하도록 타이머 흐름 수정
- `gameConfig`에 `roundResultDelaySec` 추가
- 전체 게임 종료 시각 계산에 라운드 간 대기 시간 반영
- 활성 라운드 조회 API를 확장해 `active` / `waiting` 상태를 모두 반환하도록 변경
- 마감 대기 상태에서도 새로고침 시 현재 캔버스와 라운드 상태를 복구할 수 있도록 응답 구조 보완

### 프론트엔드
- 라운드 종료 시 열려 있던 `VotePopup`이 유지되도록 수정
- 마감 대기 상태에서 팝업 버튼을 `투표 마감`으로 비활성화
- `이 라운드 투표가 마감되었습니다.` 문구를 투표 버튼 아래로 이동
- 다음 라운드 시작 시 팝업 상태가 자연스럽게 원상복구되도록 정리
- 새로고침 시 활성 라운드가 없어도 마감 대기 상태 화면이 유지되도록 초기 라운드 상태 로딩 로직 수정

## 변경 파일

### 백엔드
- `backend/src/config/game.config.ts`
- `backend/src/modules/game/game.timer.ts`
- `backend/src/modules/round/round.service.ts`
- `backend/src/modules/round/round.controller.ts`

### 프론트엔드
- `frontend/src/pages/CanvasPage.tsx`
- `frontend/src/components/vote/VotePopup.tsx`

## 테스트 항목

- 라운드 종료 시 열린 투표 팝업이 닫히지 않고 유지되는지
- 라운드 종료 직후 버튼이 `투표 마감`으로 비활성화되는지
- 마감 안내 문구가 투표 버튼 아래에 표시되는지
- 다음 라운드 시작 시 팝업이 다시 정상 상태로 동작하는지
- 마감 대기 상태에서 새로고침해도 `진행중인 캔버스가 없어요` 대신 마감 상태 화면이 유지되는지
- 마감 후 강제 클릭 시에도 프론트에서 한 번 더 제출을 방어하는지
- 서버 기준 라운드 종료 후 약 `roundResultDelaySec` 뒤에만 다음 라운드가 시작되는지
- devtool 조작으로 마감 대기 시간에도 투표가 막히는지
- 마감 대기 상태에서 API 직접 호출하여 투표한 경우 반영 불가 확인

## 관련 이슈
- closes #76

## 개발 도중 확인된 추가 이슈 정리
- 라운드 마감 시간 동안 간단한 라운드 집계 표시
- 소켓 재연결된 사람에게는 현재 투표중인 상태가 보이지 않음, 들어온 사람에게 최초 한번은  update 시켜야함
- 라운드 도중 투표권 전부 소모 시 투표하기 버튼 비활성화 
  - 경고 문구 수정 및 위치 하단으로 조정

## 체크리스트
- [x] 불필요한 주석 및 디버깅 코드를 제거하였는가?
- [x] 모든 테스트를 통과하였는가?
- [ ] 변경 사항에 대한 문서 업데이트가 필요한가?
