### PR TITLE
refactor: shared/app 구조 분리 1차 정리

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,15 +1,6 @@
-import { Routes, Route, Navigate } from "react-router-dom";
-import LoginPage from "@/pages/LoginPage";
-import RegisterPage from "@/pages/RegisterPage";
-import CanvasPage from "@/pages/CanvasPage";
+import { RouterProvider } from "react-router-dom";
+import { router } from "./app/router";
 
 export default function App() {
-  return (
-    <Routes>
-      <Route path="/" element={<Navigate to="/login" replace />} />
-      <Route path="/login" element={<LoginPage />} />
-      <Route path="/register" element={<RegisterPage />} />
-      <Route path="/canvas" element={<CanvasPage />} />
-    </Routes>
-  );
+  return <RouterProvider router={router} />;
 }

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -1,9 +1,4 @@
-import axios from "axios";
-
-const api = axios.create({
-  baseURL: import.meta.env.VITE_API_URL,
-  withCredentials: true,
-});
+import api from "@/shared/api/client";
 
 export interface RegisterRequest {
   username: string;

--- a/frontend/src/api/vote.ts
+++ b/frontend/src/api/vote.ts
@@ -1,4 +1,4 @@
-import api from "@/lib/api";
+import api from "@/shared/api/client";
 
 export interface VoteSubmitRequest {
   canvasId: number;

--- a/frontend/src/app/guards/ProtectedRoute.tsx
+++ b/frontend/src/app/guards/ProtectedRoute.tsx
@@ -1,0 +1,9 @@
+import type { ReactNode } from "react";
+
+interface Props {
+  children: ReactNode;
+}
+
+export default function ProtectedRoute({ children }: Props) {
+  return <>{children}</>;
+}

--- a/frontend/src/app/router.tsx
+++ b/frontend/src/app/router.tsx
@@ -1,0 +1,23 @@
+import { Navigate, createBrowserRouter } from "react-router-dom";
+import CanvasPage from "@/pages/CanvasPage";
+import LoginPage from "@/pages/LoginPage";
+import RegisterPage from "@/pages/RegisterPage";
+
+export const router = createBrowserRouter([
+  {
+    path: "/",
+    element: <Navigate to="/login" replace />,
+  },
+  {
+    path: "/login",
+    element: <LoginPage />,
+  },
+  {
+    path: "/register",
+    element: <RegisterPage />,
+  },
+  {
+    path: "/canvas",
+    element: <CanvasPage />,
+  },
+]);

--- a/frontend/src/components/vote/CoordinateNavigator.tsx
+++ b/frontend/src/components/vote/CoordinateNavigator.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { Button } from "@/components/ui/button";
+import { Button } from "@/shared/ui/button";
 
 interface Props {
   gridX: number;

--- a/frontend/src/components/vote/VotePopup.tsx
+++ b/frontend/src/components/vote/VotePopup.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef } from "react";
-import { Button } from "@/components/ui/button";
+import { Button } from "@/shared/ui/button";
 import ColorPalette from "./ColorPalette";
 import { voteApi } from "@/api/vote";
 import { Cell } from "@/types/canvas";

--- a/frontend/src/hooks/useSocket.ts
+++ b/frontend/src/hooks/useSocket.ts
@@ -1,5 +1,5 @@
 import { useEffect } from "react";
-import socket from "@/lib/socket";
+import socket from "@/shared/lib/socket";
 
 interface RoundStartedPayload {
   roundId: number;

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,8 +1,1 @@
-import axios from 'axios';
-
-const api = axios.create({
-  baseURL: 'http://localhost:4000',
-  withCredentials: true, // 세션 쿠키 자동 전송
-});
-
-export default api;
+export { default } from "@/shared/api/client";

--- a/frontend/src/lib/socket.ts
+++ b/frontend/src/lib/socket.ts
@@ -1,8 +1,1 @@
-import { io } from "socket.io-client";
-
-const socket = io(import.meta.env.VITE_API_URL, {
-  withCredentials: true,
-  autoConnect: false,
-});
-
-export default socket;
+export { default } from "@/shared/lib/socket";

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,13 +1,10 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
-import { BrowserRouter } from "react-router-dom";
 import "./index.css";
 import App from "./App";
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
-    <BrowserRouter>
-      <App />
-    </BrowserRouter>
+    <App />
   </StrictMode>,
 );

--- a/frontend/src/pages/CanvasPage.tsx
+++ b/frontend/src/pages/CanvasPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState, useCallback } from "react";
-import api from "@/lib/api";
+import api from "@/shared/api/client";
 import { CanvasCurrentResponse, Cell } from "@/types/canvas";
 import VotePanel from "@/components/vote/VotePanel";
 import VotePopup from "@/components/vote/VotePopup";

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
-import { useNavigate, Link } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import { authApi } from "@/api/auth";
-import { Button } from "@/components/ui/button";
+import { Button } from "@/shared/ui/button";
 
 export default function LoginPage() {
   const navigate = useNavigate();
@@ -12,6 +12,7 @@ export default function LoginPage() {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setError("");
+
     try {
       await authApi.login({ username, password });
       navigate("/canvas");
@@ -20,15 +21,16 @@ export default function LoginPage() {
         const axiosErr = err as { response: { data: { message: string } } };
         setError(axiosErr.response.data.message);
       } else {
-        setError("로그인 중 오류가 발생했어요");
+        setError("로그인 중 오류가 발생했어요.");
       }
     }
   };
 
   return (
-    <div className="min-h-screen flex items-center justify-center">
-      <div className="w-full max-w-sm flex flex-col gap-6">
-        <h1 className="text-2xl font-bold text-center">VoteDots</h1>
+    <div className="flex min-h-screen items-center justify-center">
+      <div className="flex w-full max-w-sm flex-col gap-6">
+        <h1 className="text-center text-2xl font-bold">VoteDots</h1>
+
         <form onSubmit={handleSubmit} className="flex flex-col gap-4">
           <div className="flex flex-col gap-1">
             <label className="text-sm font-medium">아이디</label>
@@ -36,26 +38,30 @@ export default function LoginPage() {
               type="text"
               value={username}
               onChange={(e) => setUsername(e.target.value)}
-              className="border rounded px-3 py-2 text-sm"
+              className="rounded border px-3 py-2 text-sm"
               required
             />
           </div>
+
           <div className="flex flex-col gap-1">
             <label className="text-sm font-medium">비밀번호</label>
             <input
               type="password"
               value={password}
               onChange={(e) => setPassword(e.target.value)}
-              className="border rounded px-3 py-2 text-sm"
+              className="rounded border px-3 py-2 text-sm"
               required
             />
           </div>
+
           {error && <p className="text-sm text-red-500">{error}</p>}
+
           <Button type="submit" className="w-full">
             로그인
           </Button>
         </form>
-        <p className="text-sm text-center">
+
+        <p className="text-center text-sm">
           계정이 없으신가요?{" "}
           <Link to="/register" className="underline">
             회원가입

--- a/frontend/src/pages/RegisterPage.tsx
+++ b/frontend/src/pages/RegisterPage.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
-import { useNavigate, Link } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import { authApi } from "@/api/auth";
-import { Button } from "@/components/ui/button";
+import { Button } from "@/shared/ui/button";
 
 export default function RegisterPage() {
   const navigate = useNavigate();
@@ -13,6 +13,7 @@ export default function RegisterPage() {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setError("");
+
     try {
       await authApi.register({ username, password, nickname });
       navigate("/login");
@@ -21,15 +22,16 @@ export default function RegisterPage() {
         const axiosErr = err as { response: { data: { message: string } } };
         setError(axiosErr.response.data.message);
       } else {
-        setError("회원가입 중 오류가 발생했어요");
+        setError("회원가입 중 오류가 발생했어요.");
       }
     }
   };
 
   return (
-    <div className="min-h-screen flex items-center justify-center">
-      <div className="w-full max-w-sm flex flex-col gap-6">
-        <h1 className="text-2xl font-bold text-center">VoteDots</h1>
+    <div className="flex min-h-screen items-center justify-center">
+      <div className="flex w-full max-w-sm flex-col gap-6">
+        <h1 className="text-center text-2xl font-bold">VoteDots</h1>
+
         <form onSubmit={handleSubmit} className="flex flex-col gap-4">
           <div className="flex flex-col gap-1">
             <label className="text-sm font-medium">아이디</label>
@@ -37,36 +39,41 @@ export default function RegisterPage() {
               type="text"
               value={username}
               onChange={(e) => setUsername(e.target.value)}
-              className="border rounded px-3 py-2 text-sm"
+              className="rounded border px-3 py-2 text-sm"
               required
             />
           </div>
+
           <div className="flex flex-col gap-1">
             <label className="text-sm font-medium">닉네임</label>
             <input
               type="text"
               value={nickname}
               onChange={(e) => setNickname(e.target.value)}
-              className="border rounded px-3 py-2 text-sm"
+              className="rounded border px-3 py-2 text-sm"
               required
             />
           </div>
+
           <div className="flex flex-col gap-1">
             <label className="text-sm font-medium">비밀번호</label>
             <input
               type="password"
               value={password}
               onChange={(e) => setPassword(e.target.value)}
-              className="border rounded px-3 py-2 text-sm"
+              className="rounded border px-3 py-2 text-sm"
               required
             />
           </div>
+
           {error && <p className="text-sm text-red-500">{error}</p>}
+
           <Button type="submit" className="w-full">
             회원가입
           </Button>
         </form>
-        <p className="text-sm text-center">
+
+        <p className="text-center text-sm">
           이미 계정이 있으신가요?{" "}
           <Link to="/login" className="underline">
             로그인

--- a/frontend/src/shared/api/client.ts
+++ b/frontend/src/shared/api/client.ts
@@ -1,0 +1,8 @@
+import axios from "axios";
+
+const api = axios.create({
+  baseURL: import.meta.env.VITE_API_URL ?? "http://localhost:4000",
+  withCredentials: true,
+});
+
+export default api;

--- a/frontend/src/shared/lib/socket.ts
+++ b/frontend/src/shared/lib/socket.ts
@@ -1,0 +1,8 @@
+import { io } from "socket.io-client";
+
+const socket = io(import.meta.env.VITE_API_URL ?? "http://localhost:4000", {
+  withCredentials: true,
+  autoConnect: false,
+});
+
+export default socket;

--- a/frontend/src/shared/ui/button.tsx
+++ b/frontend/src/shared/ui/button.tsx
@@ -1,0 +1,57 @@
+import { Button as ButtonPrimitive } from "@base-ui/react/button";
+import { cva, type VariantProps } from "class-variance-authority";
+import { cn } from "@/shared/utils";
+
+const buttonVariants = cva(
+  "group/button inline-flex shrink-0 items-center justify-center rounded-lg border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  {
+    variants: {
+      variant: {
+        default: "bg-primary text-primary-foreground [a]:hover:bg-primary/80",
+        outline:
+          "border-border bg-background hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50",
+        secondary:
+          "bg-secondary text-secondary-foreground hover:bg-secondary/80 aria-expanded:bg-secondary aria-expanded:text-secondary-foreground",
+        ghost:
+          "hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:hover:bg-muted/50",
+        destructive:
+          "bg-destructive/10 text-destructive hover:bg-destructive/20 focus-visible:border-destructive/40 focus-visible:ring-destructive/20 dark:bg-destructive/20 dark:hover:bg-destructive/30 dark:focus-visible:ring-destructive/40",
+        link: "text-primary underline-offset-4 hover:underline",
+      },
+      size: {
+        default:
+          "h-8 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2",
+        xs: "h-6 gap-1 rounded-[min(var(--radius-md),10px)] px-2 text-xs in-data-[slot=button-group]:rounded-lg has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3",
+        sm: "h-7 gap-1 rounded-[min(var(--radius-md),12px)] px-2.5 text-[0.8rem] in-data-[slot=button-group]:rounded-lg has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3.5",
+        lg: "h-9 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-3 has-data-[icon=inline-start]:pl-3",
+        icon: "size-8",
+        "icon-xs":
+          "size-6 rounded-[min(var(--radius-md),10px)] in-data-[slot=button-group]:rounded-lg [&_svg:not([class*='size-'])]:size-3",
+        "icon-sm":
+          "size-7 rounded-[min(var(--radius-md),12px)] in-data-[slot=button-group]:rounded-lg",
+        "icon-lg": "size-9",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  },
+);
+
+function Button({
+  className,
+  variant = "default",
+  size = "default",
+  ...props
+}: ButtonPrimitive.Props & VariantProps<typeof buttonVariants>) {
+  return (
+    <ButtonPrimitive
+      data-slot="button"
+      className={cn(buttonVariants({ variant, size, className }))}
+      {...props}
+    />
+  );
+}
+
+export { Button, buttonVariants };

--- a/frontend/src/shared/utils/index.ts
+++ b/frontend/src/shared/utils/index.ts
@@ -1,0 +1,6 @@
+import { clsx, type ClassValue } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}


### PR DESCRIPTION
## 관련 이슈
- Close #89 

## 작업 내용
- 프론트엔드 리팩터링 이슈 #69의 1단계인 `shared/app` 구조 정리를 진행했습니다.
- 앱 진입점과 라우팅 구성을 분리할 수 있도록 `app` 레이어를 추가했습니다.
- 공통으로 사용하는 API 클라이언트, 소켓 클라이언트, 버튼, 유틸을 `shared` 레이어로 정리했습니다.
- 기존 기능 동작은 유지한 채, 관련 파일들의 import 경로를 새 구조에 맞게 정리했습니다.

## 상세 변경 사항
- `frontend/src/app/router.tsx` 추가
  - 라우팅 구성을 별도 파일로 분리
- `frontend/src/shared/api/client.ts` 추가
  - 공통 axios 클라이언트 분리
- `frontend/src/shared/lib/socket.ts` 추가
  - 공통 socket client 분리
- `frontend/src/shared/ui/button.tsx` 추가
  - 공용 버튼 컴포넌트 위치 정리
- `frontend/src/shared/utils/index.ts` 추가
  - 공통 유틸 함수 분리
- 기존 페이지/훅/API 파일에서 `shared` 경로를 사용하도록 import 정리
- `main.tsx`, `App.tsx`에서 새 app 구조를 사용하도록 정리

## 테스트 및 확인 사항
- 코드 구조 정리 중심의 변경
- 기능 동작 동일 유지 목적
- 별도 테스트는 아직 수행하지 않음

## 체크리스트
- [x] 기존 기능을 크게 변경하지 않는 범위에서 구조를 정리했는가?
- [x] 공통 레이어와 앱 진입점 분리를 반영했는가?
- [ ] 빌드 및 lint 확인
- [ ] 후속 `canvas` 도메인 분리 진행