### PR TITLE
feat: 현재 게임 참여자 수 및 참여자 목록 조회 API 제공

### DIFF
--- a/backend/src/modules/canvas/canvas.controller.ts
+++ b/backend/src/modules/canvas/canvas.controller.ts
@@ -20,6 +20,7 @@ export const canvasController = {
       if (!canvas) {
         return res.status(404).json({ message: "진행 중인 캔버스가 없어요" });
       }
+
       const cells = await canvasService.getCells(canvas.id);
       return res.json({
         canvas,
@@ -27,6 +28,32 @@ export const canvasController = {
         roundDurationSec: gameConfig.roundDurationSec,
       });
     } catch (err) {
+      return res.status(500).json({ message: String(err) });
+    }
+  },
+
+  async getCurrentParticipantCount(_req: Request, res: Response) {
+    try {
+      const result = await canvasService.getCurrentParticipantCount();
+      return res.json(result);
+    } catch (err) {
+      if (String(err).includes("진행 중인 캔버스가 없어요")) {
+        return res.status(404).json({ message: String(err) });
+      }
+
+      return res.status(500).json({ message: String(err) });
+    }
+  },
+
+  async getCurrentParticipantList(_req: Request, res: Response) {
+    try {
+      const result = await canvasService.getCurrentParticipantList();
+      return res.json(result);
+    } catch (err) {
+      if (String(err).includes("진행 중인 캔버스가 없어요")) {
+        return res.status(404).json({ message: String(err) });
+      }
+
       return res.status(500).json({ message: String(err) });
     }
   },

--- a/backend/src/modules/canvas/canvas.router.ts
+++ b/backend/src/modules/canvas/canvas.router.ts
@@ -6,5 +6,15 @@ const router = Router();
 
 router.post("/", authMiddleware, canvasController.create);
 router.get("/current", authMiddleware, canvasController.getCurrent);
+router.get(
+    "/current/participants/count",
+    authMiddleware,
+    canvasController.getCurrentParticipantCount,
+);
+router.get(
+    "/current/participants",
+    authMiddleware,
+    canvasController.getCurrentParticipantList,
+);
 
 export default router;

--- a/backend/src/modules/canvas/canvas.service.ts
+++ b/backend/src/modules/canvas/canvas.service.ts
@@ -4,6 +4,10 @@ import { Canvas, CanvasStatus } from "../../entities/canvas.entity";
 import { Cell, CellStatus } from "../../entities/cell.entity";
 import { VoteRound } from "../../entities/vote-round.entity";
 import { startGameTimer } from "../game/game.timer";
+import {
+  participantSessionService,
+  type ParticipantSummary,
+} from "../participant/participant-session.service";
 
 const canvasRepository = AppDataSource.getRepository(Canvas);
 const cellRepository = AppDataSource.getRepository(Cell);
@@ -14,7 +18,6 @@ const GRID_Y = parseInt(process.env.GRID_SIZE_Y ?? "25");
 
 export const canvasService = {
   async create(io: Server): Promise<Canvas> {
-    // 이미 진행 중인 캔버스가 있으면 생성 불가
     const existing = await canvasRepository.findOne({
       where: { status: CanvasStatus.PLAYING },
     });
@@ -22,7 +25,6 @@ export const canvasService = {
       throw new Error("이미 진행 중인 캔버스가 있어요");
     }
 
-    // 캔버스 생성
     const canvas = canvasRepository.create({
       gridX: GRID_X,
       gridY: GRID_Y,
@@ -31,7 +33,6 @@ export const canvasService = {
     });
     await canvasRepository.save(canvas);
 
-    // N×N 셀 일괄 생성
     const cells: Partial<Cell>[] = [];
     for (let y = 0; y < GRID_Y; y++) {
       for (let x = 0; x < GRID_X; x++) {
@@ -46,7 +47,6 @@ export const canvasService = {
     }
     await cellRepository.save(cells as Cell[]);
 
-    // 게임 타이머 시작
     await startGameTimer(io, canvas.id);
 
     return canvas;
@@ -63,6 +63,39 @@ export const canvasService = {
       where: { canvas: { id: canvasId } },
       order: { y: "ASC", x: "ASC" },
     });
+  },
+
+  async getCurrentParticipantCount(): Promise<{ canvasId: number; count: number }> {
+    const canvas = await this.getCurrent();
+    if (!canvas) {
+      throw new Error("진행 중인 캔버스가 없어요");
+    }
+
+    const count = await participantSessionService.getParticipantCount(canvas.id);
+
+    return {
+      canvasId: canvas.id,
+      count,
+    };
+  },
+
+  async getCurrentParticipantList(): Promise<{
+    canvasId: number;
+    participants: ParticipantSummary[];
+  }> {
+    const canvas = await this.getCurrent();
+    if (!canvas) {
+      throw new Error("진행 중인 캔버스가 없어요");
+    }
+
+    const participants = await participantSessionService.getParticipantList(
+      canvas.id,
+    );
+
+    return {
+      canvasId: canvas.id,
+      participants,
+    };
   },
 
   async recoverOnStartup(io: Server): Promise<Canvas> {

--- a/backend/src/modules/participant/participant-session.service.ts
+++ b/backend/src/modules/participant/participant-session.service.ts
@@ -29,6 +29,15 @@ interface JoinCanvasResult {
   restored: boolean;
 }
 
+export interface ParticipantSummary {
+  sessionId: string;
+  voterId: number;
+  voterUuid: string;
+  nickname: string;
+  status: ParticipantStatus;
+  connected: boolean;
+}
+
 const voteRoundRepository = AppDataSource.getRepository(VoteRound);
 
 class ParticipantSessionService {
@@ -199,8 +208,7 @@ class ParticipantSessionService {
     io: Server,
   ): Promise<JoinCanvasResult> {
     const existing = await this.getCanvasParticipation(canvasId, sessionId);
-    const replaced =
-      !!existing?.socketId && existing.socketId !== socketId;
+    const replaced = !!existing?.socketId && existing.socketId !== socketId;
 
     if (replaced && existing?.socketId) {
       io.to(existing.socketId).emit("session:replaced", { canvasId });
@@ -269,8 +277,7 @@ class ParticipantSessionService {
     const affectedCanvasIds: number[] = [];
     const disconnectedAt = new Date();
     const graceUntil = new Date(
-      disconnectedAt.getTime() +
-        gameConfig.participantGracePeriodSec * 1000,
+      disconnectedAt.getTime() + gameConfig.participantGracePeriodSec * 1000,
     ).toISOString();
 
     for (const canvasIdValue of canvasIds) {
@@ -344,6 +351,51 @@ class ParticipantSessionService {
     }
 
     return { voterIds };
+  }
+
+  async getParticipantList(canvasId: number): Promise<ParticipantSummary[]> {
+    const sessionIds = await redisClient.sMembers(
+      this.buildCanvasSessionsKey(canvasId),
+    );
+
+    const participants: ParticipantSummary[] = [];
+
+    for (const sessionId of sessionIds) {
+      const state = await this.getCanvasParticipation(canvasId, sessionId);
+      if (!state) {
+        continue;
+      }
+
+      const voter = await this.getSessionVoter(sessionId);
+      if (!voter) {
+        await this.cleanupParticipation(canvasId, sessionId);
+        continue;
+      }
+
+      participants.push({
+        sessionId,
+        voterId: voter.id,
+        voterUuid: voter.uuid,
+        nickname: voter.nickname,
+        status: state.status,
+        connected: state.connected,
+      });
+    }
+
+    participants.sort((left, right) => {
+      if (left.status !== right.status) {
+        return left.status === "voting" ? -1 : 1;
+      }
+
+      return left.nickname.localeCompare(right.nickname, "ko");
+    });
+
+    return participants;
+  }
+
+  async getParticipantCount(canvasId: number): Promise<number> {
+    const participants = await this.getParticipantList(canvasId);
+    return participants.length;
   }
 
   async assertVotingParticipant(


### PR DESCRIPTION
## 관련 이슈
- Close #79 

## 작업 내용
- 현재 게임 캔버스 기준 참여자 수 조회 API를 추가했습니다.
- 현재 게임 캔버스 기준 참여자 목록 조회 API를 추가했습니다.
- 참여자 수와 참여자 목록이 동일한 Redis 참여 상태 기준을 사용하도록 조회 로직을 정리했습니다.
- 라운드 UI와 참여자 패널이 동일한 응답 기준을 사용할 수 있도록 단순한 조회 인터페이스를 제공했습니다.

## 주요 변경 사항
- `GET /canvas/current/participants/count` 추가
- `GET /canvas/current/participants` 추가
- Redis 참여 상태 서비스에 참여자 목록 조회 로직 추가
- 참여자 수 계산이 목록 기준과 달라지지 않도록 동일한 조회 메서드를 재사용하도록 구성
- 참여자 목록 응답에 아래 정보를 포함하도록 구성
  - 사용자 식별 정보
  - 닉네임
  - 현재 상태 (`voting` | `waiting`)
  - 연결 상태 (`connected`)
- grace period가 지난 세션은 조회 시 정리되거나 제외되도록 처리

## 응답 기준
- 참여자 수와 참여자 목록 모두 동일한 Redis 참여자 상태를 기준으로 계산합니다.
- 현재 라운드 참여 상태가 `voting` 인 사용자가 우선 노출됩니다.
- 동일 상태 내에서는 닉네임 순으로 정렬됩니다.
- 진행 중인 캔버스가 없으면 `404`를 반환합니다.
- 인증되지 않은 요청은 기존과 동일하게 `401`을 반환합니다.

## 테스트
- 현재 게임이 있을 때 참여자 수 조회 API 정상 응답 확인
- 현재 게임이 있을 때 참여자 목록 조회 API 정상 응답 확인
- 참여자 수와 참여자 목록 길이가 동일한지 확인
- `voting` / `waiting` 상태가 목록에 정상 반영되는지 확인
- disconnect 후 grace period 상태 세션이 정책대로 포함되는지 확인
- grace period 만료 세션이 조회 시 정리 또는 제외되는지 확인
- 진행 중인 캔버스가 없을 때 `404` 반환 확인

<details> 
<summary></summary>

### 참여자 수 및 목록 조회

<img width="789" height="730" alt="image" src="https://github.com/user-attachments/assets/2ad23ef7-e5cc-4187-919f-d22f6d49742c" />
<img width="619" height="482" alt="image" src="https://github.com/user-attachments/assets/3014cd53-9c77-43ce-b30b-9159d6c80b6b" />

### `connected` 라운드 전환 `disconnect`

<img width="496" height="417" alt="image" src="https://github.com/user-attachments/assets/7655cc48-e427-4763-9e1f-8d363aa8e6a5" />
<img width="587" height="638" alt="image" src="https://github.com/user-attachments/assets/ec7be2f1-9211-4fbf-9c5f-40f293dda88b" />
<img width="575" height="636" alt="image" src="https://github.com/user-attachments/assets/063c5884-8a75-46dd-8347-e9115828af95" />
<img width="727" height="783" alt="image" src="https://github.com/user-attachments/assets/d856293f-49f7-441d-8ccf-1848e0451988" />

### `status` 및 정렬 확인

<img width="631" height="643" alt="image" src="https://github.com/user-attachments/assets/66857692-62a0-4004-a22e-319e0a8f6edb" />
<img width="611" height="648" alt="image" src="https://github.com/user-attachments/assets/5a971fdd-6ab9-41d1-ba9a-81b7574c5b24" />
<img width="611" height="648" alt="image" src="https://github.com/user-attachments/assets/bc9cd35a-f0c6-4e82-a1c1-884ad0dcd540" />
<img width="617" height="642" alt="image" src="https://github.com/user-attachments/assets/3ebfbc38-751d-4be3-bf14-1c8a00c63cea" />

</details>

## 비고
- 참여자 수와 목록이 서로 다른 기준으로 계산되지 않도록 동일한 서비스 로직을 사용했습니다.
- 이후 소켓 이벤트 payload와도 같은 기준을 재사용할 수 있도록 참여자 조회 기준을 서비스 레벨에 모았습니다.

### 미구현
- 인증 없이 호출 시 `401` 반환 확인