### PR TITLE
fix: 운영 배포용 nginx 프론트 빌드 및 공용 postgres 설정 정렬

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -29,7 +29,6 @@ const io = new Server(server, {
   },
 });
 
-// 미들웨어
 app.use(
   cors({
     origin: process.env.CLIENT_URL ?? "http://localhost:5173",
@@ -39,7 +38,6 @@ app.use(
 app.use(express.json());
 app.use(sessionMiddleware);
 
-// TypeORM 연결
 AppDataSource.initialize()
   .then(async () => {
     console.log("DB 연결 성공");
@@ -47,12 +45,10 @@ AppDataSource.initialize()
   })
   .catch((err) => console.error("DB 연결 실패:", err));
 
-// Health check
 app.get("/health", (_req, res) => {
   res.json({ status: "ok" });
 });
 
-// Redis 연결
 app.get("/health/redis", async (_req, res) => {
   try {
     await redisClient.set("test", "ok");
@@ -63,7 +59,6 @@ app.get("/health/redis", async (_req, res) => {
   }
 });
 
-// DB
 app.get("/health/db", async (_req, res) => {
   try {
     await AppDataSource.query("SELECT 1");
@@ -73,11 +68,9 @@ app.get("/health/db", async (_req, res) => {
   }
 });
 
-// Socket.io 초기화 (세션 인증 미들웨어 포함)
 initSocket(io);
 app.set("io", io);
 
-//Router
 app.use("/auth", authRouter);
 app.use("/canvas", canvasRouter);
 app.use("/canvas/:canvasId/rounds", roundRouter);

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,13 +1,14 @@
 services:
   nginx:
-    image: nginx:1.27-alpine
+    build:
+      context: .
+      dockerfile: nginx/Dockerfile
+      args:
+        NODE_VERSION: ${NODE_VERSION}
     container_name: votedots-nginx
     restart: unless-stopped
     ports:
       - "80:80"
-    volumes:
-      - ./nginx/default.conf:/etc/nginx/conf.d/default.conf:ro
-      - ./frontend/dist:/usr/share/nginx/html:ro
     depends_on:
       - backend
     networks:

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,0 +1,15 @@
+ARG NODE_VERSION
+
+FROM node:${NODE_VERSION}-alpine AS frontend-builder
+WORKDIR /app
+
+COPY frontend/package*.json ./
+RUN npm ci
+
+COPY frontend/ ./
+RUN npm run build
+
+FROM nginx:1.27-alpine
+
+COPY nginx/default.conf /etc/nginx/conf.d/default.conf
+COPY --from=frontend-builder /app/dist /usr/share/nginx/html


### PR DESCRIPTION
## 관련 이슈
- Close #124 

## 작업 내용
- 운영 배포 시 프론트 정적 파일을 호스트 dist 마운트 대신 Nginx 이미지에 포함하도록 변경
- docker-compose.prod.yml의 Nginx 구성을 이미지 기반에서 빌드 기반으로 변경
- 공용 PostgreSQL 연결 기준에 맞게 서버 배포 구조 정리
- backend 기본 포트 fallback을 4000으로 정리
- Express trust proxy 설정 추가
- session cookie 운영 분기 반영
- 프론트 API 기본 경로를 /api로 정리
- 프론트 Socket.IO 기본 경로를 /socket.io 기준으로 정리

## 해결 문제
- 서버에서 frontend/dist가 없어 발생하던 403 문제 대응
- backend가 host.docker.internal을 참조하던 개발용 DB 연결 기준 정리
- 서버 배포 시 docker compose -f docker-compose.prod.yml up -d --build만으로 재현 가능한 구조로 정리

## 체크리스트
- [ ] 불필요한 주석 및 디버깅 코드를 제거하였는가?
- [ ] 모든 테스트를 통과하였는가?
- [ ] 변경 사항에 대한 문서 업데이트가 필요한가?
