### PR TITLE
chore: DuckDNS + Certbot 기반 HTTPS 구성

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -9,8 +9,12 @@ services:
     restart: unless-stopped
     ports:
       - "80:80"
+      - "443:443"
     depends_on:
       - backend
+    volumes:
+      - certbot-www:/var/www/certbot
+      - letsencrypt:/etc/letsencrypt
     networks:
       - default
 
@@ -41,6 +45,19 @@ services:
       - /opt/votedots/data/redis:/data
     networks:
       - default
+
+  certbot:
+    image: certbot/certbot:latest
+    container_name: votedots-certbot
+    volumes:
+      - certbot-www:/var/www/certbot
+      - letsencrypt:/etc/letsencrypt
+    networks:
+      - default
+
+volumes:
+  certbot-www:
+  letsencrypt:
 
 networks:
   shared-db-network:

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -1,9 +1,25 @@
 server {
     listen 80;
-    server_name _;
+    server_name votedots.duckdns.org;
+
+    location ^~ /.well-known/acme-challenge/ {
+        root /var/www/certbot;
+    }
+
+    location / {
+        return 301 https://$host$request_uri;
+    }
+}
+
+server {
+    listen 443 ssl http2;
+    server_name votedots.duckdns.org;
 
     root /usr/share/nginx/html;
     index index.html;
+
+    ssl_certificate /etc/letsencrypt/live/votedots.duckdns.org/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/votedots.duckdns.org/privkey.pem;
 
     location / {
         try_files $uri $uri/ /index.html;


### PR DESCRIPTION
## 관련 이슈
- Close #126 

## 작업 내용
- Docker 환경에서 `DuckDNS + Nginx + Certbot(webroot)` 기반 HTTPS 구성을 추가했습니다.
- `certbot` 서비스와 인증서/ACME 챌린지용 볼륨을 `docker-compose`에 추가했습니다.
- nginx가 `/.well-known/acme-challenge/` 경로를 서빙하도록 설정했습니다.
- `votedots.duckdns.org`에 대해 Let's Encrypt 인증서를 발급받도록 구성했습니다.
- HTTP 요청이 HTTPS로 리다이렉트되도록 nginx 설정을 변경했습니다.
- 인증서 자동 갱신이 가능하도록 `certbot renew` 실행 흐름을 정리했습니다.

## 변경 이유
기존에는 Docker 컨테이너 안에서 nginx가 동작하고 있어서 호스트에서 `certbot --nginx` 방식으로 인증서를 발급할 수 없었습니다.  
그래서 Docker 환경에 맞는 `certbot --webroot` 방식으로 HTTPS를 적용하도록 변경했습니다.

## 확인 내용
- `http://votedots.duckdns.org` 접속 시 HTTPS로 리다이렉트되는지 확인
- `https://votedots.duckdns.org` 접속이 정상 동작하는지 확인
- Let's Encrypt 인증서가 정상 발급되는지 확인
- `certbot renew --dry-run`으로 갱신 테스트 가능하도록 구성

## 참고
- DuckDNS는 DNS만 제공하므로 HTTPS 인증서는 별도 구성 필요
- 현재는 `votedots.duckdns.org` 기준으로 설정되어 있음
