### PR TITLE
feat: 게임 시작 intro phase 추가

### DIFF
--- a/backend/src/modules/canvas/canvas.service.ts
+++ b/backend/src/modules/canvas/canvas.service.ts
@@ -22,6 +22,7 @@ const voteRoundRepository = AppDataSource.getRepository(VoteRound);
 interface CreateCanvasOptions {
   profileKey?: string | null;
 }
+
 const CELL_INSERT_CHUNK_SIZE = 1000;
 
 function logPhaseChange(params: {
@@ -57,7 +58,7 @@ export const canvasService = {
 
     const now = new Date();
     const phaseEndsAt = new Date(
-      now.getTime() + snapshot.phases.roundStartWaitSec * 1000,
+      now.getTime() + snapshot.phases.introPhaseSec * 1000,
     );
 
     const canvas = canvasRepository.create({
@@ -66,7 +67,7 @@ export const canvasService = {
       configProfileKey: profileKey,
       configSnapshot: snapshot,
       status: CanvasStatus.PLAYING,
-      phase: GamePhase.ROUND_START_WAIT,
+      phase: GamePhase.INTRO,
       phaseStartedAt: now,
       phaseEndsAt,
       currentRoundNumber: 1,
@@ -77,7 +78,7 @@ export const canvasService = {
 
     logPhaseChange({
       canvasId: canvas.id,
-      phase: GamePhase.ROUND_START_WAIT,
+      phase: GamePhase.INTRO,
       roundNumber: 1,
       phaseStartedAt: now,
       phaseEndsAt,
@@ -88,7 +89,7 @@ export const canvasService = {
     const outlineCellSet = buildOutlineCellSet(outlineTemplate);
 
     console.log(
-      `[canvas] selected outline template | canvasId=${canvas.id} canvasSize=${gridSizeX}x${gridSizeY} template=${outlineTemplate?.id ?? "none"}`,
+      `[canvas] outline template selected | canvasId=${canvas.id} profile=${profileKey} size=${gridSizeX}x${gridSizeY} templateId=${outlineTemplate?.id ?? "none"} templateName=${outlineTemplate?.name ?? "none"} outlineCellCount=${outlineCellSet.size}`,
     );
 
     const cells: Array<{
@@ -113,14 +114,10 @@ export const canvasService = {
       }
     }
 
-    // const cellInsertStartedAt = performance.now();
-
     for (let index = 0; index < cells.length; index += CELL_INSERT_CHUNK_SIZE) {
       const chunk = cells.slice(index, index + CELL_INSERT_CHUNK_SIZE);
       await cellRepository.insert(chunk);
     }
-
-    // console.log(`[perf] canvas cells insert | canvasId=${canvas.id} count=${cells.length} ms=${(performance.now() - cellInsertStartedAt).toFixed(2)}`,);
 
     await startGameTimer(io, canvas.id);
 
@@ -224,6 +221,7 @@ export const canvasService = {
 
     return this.create(io);
   },
+
   async getCanvasToResumeAfterReconnect(): Promise<Canvas | null> {
     const currentCanvas = await canvasRepository.findOne({
       where: { status: CanvasStatus.PLAYING },

--- a/backend/src/modules/game/game-phase.types.ts
+++ b/backend/src/modules/game/game-phase.types.ts
@@ -1,4 +1,5 @@
 export enum GamePhase {
+  INTRO = "intro",
   ROUND_START_WAIT = "round_start_wait",
   ROUND_ACTIVE = "round_active",
   ROUND_RESULT = "round_result",

--- a/backend/src/modules/game/game.timer.ts
+++ b/backend/src/modules/game/game.timer.ts
@@ -151,6 +151,13 @@ async function transitionToRoundStartWait(
   );
 }
 
+async function transitionFromIntro(
+  io: Server,
+  canvasId: number,
+): Promise<void> {
+  await transitionToRoundStartWait(io, canvasId, 1);
+}
+
 async function transitionToGameEnd(
   io: Server,
   canvasId: number,
@@ -337,6 +344,30 @@ async function transitionAfterRoundResult(
   }
 
   await transitionToRoundStartWait(io, canvasId, roundNumber + 1);
+}
+
+async function resumeIntro(io: Server, canvas: Canvas): Promise<void> {
+  const phaseEndsAt = canvas.phaseEndsAt;
+
+  if (!phaseEndsAt) {
+    await transitionFromIntro(io, canvas.id);
+    return;
+  }
+
+  const delayMs = Math.max(0, phaseEndsAt.getTime() - Date.now());
+
+  if (delayMs === 0) {
+    await transitionFromIntro(io, canvas.id);
+    return;
+  }
+
+  scheduleTimer(
+    canvas.id,
+    () => {
+      void transitionFromIntro(io, canvas.id);
+    },
+    delayMs,
+  );
 }
 
 async function resumeRoundStartWaitFromBoundary(
@@ -636,11 +667,24 @@ async function resumeCanvasPhase(io: Server, canvas: Canvas): Promise<void> {
   clearCanvasTimers(canvas.id);
 
   switch (canvas.phase) {
+    case GamePhase.INTRO:
+      await resumeIntro(io, canvas);
+      return;
+
     case GamePhase.ROUND_START_WAIT: {
       const delayMs = Math.max(
         0,
         (canvas.phaseEndsAt?.getTime() ?? Date.now()) - Date.now(),
       );
+
+      if (delayMs === 0) {
+        await runRound(
+          io,
+          canvas.id,
+          canvas.currentRoundNumber > 0 ? canvas.currentRoundNumber : 1,
+        );
+        return;
+      }
 
       scheduleTimer(
         canvas.id,

--- a/frontend/src/features/gameplay/round/components/RoundInfo.tsx
+++ b/frontend/src/features/gameplay/round/components/RoundInfo.tsx
@@ -9,6 +9,8 @@ import {
 
 function getPhaseLabel(phase: GamePhase): string {
   switch (phase) {
+    case GAME_PHASE.INTRO:
+      return "게임 시작 안내";
     case GAME_PHASE.ROUND_START_WAIT:
       return "라운드 시작 대기";
     case GAME_PHASE.ROUND_ACTIVE:

--- a/frontend/src/features/gameplay/session/hooks/useGameplayBootstrap.ts
+++ b/frontend/src/features/gameplay/session/hooks/useGameplayBootstrap.ts
@@ -46,6 +46,35 @@ function getPhaseDurationSeconds(
   );
 }
 
+function getFallbackPhaseDuration(
+  phase: string,
+  phaseDurationSeconds: number | null,
+  introPhaseSec: number,
+  roundStartWaitSec: number,
+  roundDurationSec: number,
+  roundResultDelaySec: number,
+  gameEndWaitSec: number,
+): number | null {
+  if (phaseDurationSeconds !== null) {
+    return phaseDurationSeconds;
+  }
+
+  switch (phase) {
+    case GAME_PHASE.INTRO:
+      return introPhaseSec;
+    case GAME_PHASE.ROUND_START_WAIT:
+      return roundStartWaitSec;
+    case GAME_PHASE.ROUND_ACTIVE:
+      return roundDurationSec;
+    case GAME_PHASE.ROUND_RESULT:
+      return roundResultDelaySec;
+    case GAME_PHASE.GAME_END:
+      return gameEndWaitSec;
+    default:
+      return null;
+  }
+}
+
 export function useGameplayBootstrap() {
   const bootstrap = useCallback(async (): Promise<SessionBootstrapResult> => {
     const { data } = await sessionApi.getCurrentCanvas();
@@ -82,15 +111,24 @@ export function useGameplayBootstrap() {
     const resolvedRemainingSeconds =
       roundState?.timer?.remainingSeconds ?? phaseRemainingSeconds;
 
+    const resolvedRoundDurationSec =
+      roundState?.round?.roundDurationSec ??
+      getFallbackPhaseDuration(
+        canvas.phase,
+        phaseDurationSeconds,
+        phases.introPhaseSec,
+        phases.roundStartWaitSec,
+        phases.roundDurationSec,
+        phases.roundResultDelaySec,
+        phases.gameEndWaitSec,
+      );
+
     const round: RoundInfoState = {
       phase: canvas.phase,
       roundId: roundState?.round?.id ?? null,
       roundNumber:
         roundState?.round?.roundNumber ?? canvas.currentRoundNumber ?? null,
-      roundDurationSec:
-        roundState?.round?.roundDurationSec ??
-        phaseDurationSeconds ??
-        phases.roundDurationSec,
+      roundDurationSec: resolvedRoundDurationSec,
       totalRounds: roundState?.round?.totalRounds ?? rules.totalRounds,
       formattedGameEndTime: roundState?.round
         ? formatClockTime(new Date(roundState.round.gameEndAt))
@@ -118,6 +156,7 @@ export function useGameplayBootstrap() {
       votes,
       remaining,
       phaseTiming: {
+        introPhaseSec: phases.introPhaseSec,
         roundStartWaitSec: phases.roundStartWaitSec,
         roundResultDelaySec: phases.roundResultDelaySec,
         gameEndWaitSec: phases.gameEndWaitSec,

--- a/frontend/src/features/gameplay/session/model/game-phase.types.ts
+++ b/frontend/src/features/gameplay/session/model/game-phase.types.ts
@@ -1,10 +1,12 @@
 export type GamePhase =
+  | "intro"
   | "round_start_wait"
   | "round_active"
   | "round_result"
   | "game_end";
 
 export const GAME_PHASE = {
+  INTRO: "intro",
   ROUND_START_WAIT: "round_start_wait",
   ROUND_ACTIVE: "round_active",
   ROUND_RESULT: "round_result",

--- a/frontend/src/features/gameplay/session/model/session.types.ts
+++ b/frontend/src/features/gameplay/session/model/session.types.ts
@@ -17,6 +17,7 @@ export interface RoundInfoState {
 }
 
 export interface PhaseTimingState {
+  introPhaseSec: number;
   roundStartWaitSec: number;
   roundResultDelaySec: number;
   gameEndWaitSec: number;

--- a/frontend/src/features/gameplay/vote/components/VotePopup.tsx
+++ b/frontend/src/features/gameplay/vote/components/VotePopup.tsx
@@ -35,6 +35,8 @@ interface Props {
 
 function getPhaseBlockedMessage(phase: GamePhase): string {
   switch (phase) {
+    case GAME_PHASE.INTRO:
+      return "게임 시작 안내 중에는 투표할 수 없어요.";
     case GAME_PHASE.ROUND_START_WAIT:
       return "라운드 시작 대기 중에는 투표할 수 없어요.";
     case GAME_PHASE.ROUND_RESULT:

--- a/frontend/src/pages/canvas/model/useCanvasGameplay.ts
+++ b/frontend/src/pages/canvas/model/useCanvasGameplay.ts
@@ -31,6 +31,7 @@ interface UseCanvasGameplayParams {
 }
 
 const DEFAULT_PHASE_TIMING: PhaseTimingState = {
+  introPhaseSec: 0,
   roundStartWaitSec: 0,
   roundResultDelaySec: 0,
   gameEndWaitSec: 0,
@@ -213,11 +214,42 @@ export default function useCanvasGameplay({
   useEffect(() => {
     clearLocalPhaseTransitionTimer();
 
-    if (
-      phase !== GAME_PHASE.ROUND_RESULT ||
-      !phaseEndsAt ||
-      roundNumber === null
-    ) {
+    if (!phaseEndsAt || roundNumber === null) {
+      return;
+    }
+
+    if (phase === GAME_PHASE.INTRO) {
+      const delayMs = Math.max(0, new Date(phaseEndsAt).getTime() - Date.now());
+
+      localPhaseTransitionTimerRef.current = window.setTimeout(() => {
+        localPhaseTransitionTimerRef.current = null;
+
+        const waitStartedAt = phaseEndsAt;
+        const waitEndsAt = new Date(
+          new Date(waitStartedAt).getTime() +
+            phaseTimingRef.current.roundStartWaitSec * 1000,
+        ).toISOString();
+
+        setRoundState({
+          phase: GAME_PHASE.ROUND_START_WAIT,
+          roundId: null,
+          roundNumber: 1,
+          roundDurationSec: phaseTimingRef.current.roundStartWaitSec,
+          totalRounds,
+          formattedGameEndTime,
+          phaseStartedAt: waitStartedAt,
+          phaseEndsAt: waitEndsAt,
+        });
+
+        setPhaseTimerState(waitEndsAt, false);
+      }, delayMs);
+
+      return () => {
+        clearLocalPhaseTransitionTimer();
+      };
+    }
+
+    if (phase !== GAME_PHASE.ROUND_RESULT) {
       return;
     }
 


### PR DESCRIPTION
## 관련 이슈
- Close #174 

## 요약
- 게임 시작 시 `INTRO` phase를 추가했습니다.
- 캔버스 생성 직후 바로 라운드 대기로 들어가지 않고, 인트로 구간을 먼저 거친 뒤 게임이 시작되도록 변경했습니다.
- 인트로 중에는 투표가 불가능하며 프론트에서 안내 문구를 표시하도록 정리했습니다.

## 변경 내용
- 백엔드/프론트 phase 정의에 `INTRO` 추가
- 캔버스 생성 시 시작 phase를 `INTRO`로 변경
- `introPhaseSec` 이후 `INTRO -> ROUND_START_WAIT`로 전환되도록 타이머 상태 머신 수정
- 서버 재시작 시 `INTRO` phase 복구 로직 추가
- 프론트 bootstrap에서 `INTRO` phase duration/timer 처리 추가
- 프론트 상태 라벨에 `게임 시작 안내` 문구 추가
- `INTRO` 중 투표 팝업에서 투표 불가 안내 문구 표시
- `INTRO`이 0초인 경우 즉시 다음 phase로 넘어가도록 처리

## 기대 동작
- 캔버스 생성 직후 phase는 `intro`
- `introPhaseSec` 동안 게임 시작 안내 구간이 유지됨
- 이후 `ROUND_START_WAIT -> ROUND_ACTIVE -> ROUND_RESULT` 흐름이 반복됨
- 마지막 라운드 종료 후 `GAME_END`로 전환됨
- `INTRO` 중에는 투표할 수 없고 안내 문구가 표시됨

## 테스트
- [x] 캔버스 생성 직후 `/canvas/current`의 `phase`가 `intro`인지 확인
<img width="253" height="182" alt="image" src="https://github.com/user-attachments/assets/e0ac953a-78d3-4bc3-9cf4-4718bc124f2d" />

<br>
<img width="456" height="456" alt="image-1" src="https://github.com/user-attachments/assets/8ed170bc-1310-4b88-846c-af19d96e4a84" />


- [x] 캔버스 생성 직후 `phaseEndsAt`이 `introPhaseSec` 기준으로 설정되는지 확인
<img width="639" height="65" alt="image-2" src="https://github.com/user-attachments/assets/b643f2fd-cb4e-4b84-8d8d-ab9f18a28389" />

- [x] `INTRO` 종료 후 첫 phase가 `ROUND_START_WAIT`로 전환되는지 확인
<img width="642" height="64" alt="image-3" src="https://github.com/user-attachments/assets/25a18f3d-58c9-4ca9-b408-429f7b3fa7c5" />

- [x] `INTRO` 동안 `ROUND_ACTIVE`가 바로 시작되지 않고 유지되는지 확인
<img width="632" height="63" alt="image-4" src="https://github.com/user-attachments/assets/ac8f4612-3466-4dcb-bf00-b8ee18e95b63" />

- [x] 마지막 라운드 종료 후 `GAME_END`로 정상 전환되는지 확인

- [x] 프론트에서 `INTRO` phase일 때 상태 라벨이 `게임 시작 안내`로 표시되는지 확인

- [x] `INTRO` 중 셀 클릭 시 팝업은 열리지만 `게임 시작 안내 중에는 투표할 수 없어요.` 문구가 표시되는지 확인
<img width="390" height="495" alt="image-5" src="https://github.com/user-attachments/assets/5df5507f-b54d-4ed6-b87e-e999d179e244" />

- [x] `INTRO` 동안 `ROUND_ACTIVE`가 바로 시작되지 않고 유지되는지 확인
<img width="632" height="63" alt="image-4" src="https://github.com/user-attachments/assets/ac8f4612-3466-4dcb-bf00-b8ee18e95b63" />

- [x] `INTRO`이 0초인 profile에서 캔버스 생성 시 phase 로그 기준으로 `intro -> round_start_wait`가 즉시 전환되는지 확인
<img width="912" height="16" alt="image-6" src="https://github.com/user-attachments/assets/501f7b7b-522b-4a08-9cec-0a0388ff1c4a" />


## 참고
- `INTRO`은 게임 config/profile의 `introPhaseSec` 값을 사용합니다.
- 현재는 인트로 안내 phase만 추가되었고, 별도 전용 인트로 화면보다는 기존 게임 화면 내 상태/타이머 표시 중심으로 동작합니다.
