### PR TITLE
feat: 캔버스 조작 개선 및 레이아웃 정렬 보완

### DIFF
--- a/frontend/src/features/gameplay/canvas/components/CanvasStage.tsx
+++ b/frontend/src/features/gameplay/canvas/components/CanvasStage.tsx
@@ -7,19 +7,23 @@ import {
 interface CanvasStageProps {
   containerRef: RefObject<HTMLDivElement | null>;
   children: ReactNode;
+  overlay?: ReactNode;
   onMouseDown: (event: React.MouseEvent) => void;
   onMouseMove: (event: React.MouseEvent) => void;
   onMouseUp: (event: React.MouseEvent) => void;
   onMouseLeave: () => void;
+  onWheel: (event: React.WheelEvent) => void;
 }
 
 export default function CanvasStage({
   containerRef,
   children,
+  overlay,
   onMouseDown,
   onMouseMove,
   onMouseUp,
   onMouseLeave,
+  onWheel,
 }: CanvasStageProps) {
   return (
     <div
@@ -32,7 +36,10 @@ export default function CanvasStage({
       onMouseMove={onMouseMove}
       onMouseUp={onMouseUp}
       onMouseLeave={onMouseLeave}
+      onWheel={onWheel}
     >
+      {overlay && <div className="absolute left-4 top-4 z-10">{overlay}</div>}
+
       <div
         ref={containerRef}
         className="h-full w-full overflow-auto [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden"

--- a/frontend/src/features/gameplay/canvas/components/CanvasStage.tsx
+++ b/frontend/src/features/gameplay/canvas/components/CanvasStage.tsx
@@ -1,8 +1,5 @@
 import type { ReactNode, RefObject } from "react";
-import {
-  CANVAS_BACKGROUND_COLOR,
-  PANEL_WIDTH,
-} from "../model/canvas.constants";
+import { CANVAS_BACKGROUND_COLOR } from "../model/canvas.constants";
 
 interface CanvasStageProps {
   containerRef: RefObject<HTMLDivElement | null>;

--- a/frontend/src/features/gameplay/canvas/components/CanvasStage.tsx
+++ b/frontend/src/features/gameplay/canvas/components/CanvasStage.tsx
@@ -27,9 +27,8 @@ export default function CanvasStage({
 }: CanvasStageProps) {
   return (
     <div
-      className="relative overflow-hidden cursor-grab active:cursor-grabbing"
+      className="relative min-w-0 flex-1 overflow-hidden cursor-grab active:cursor-grabbing"
       style={{
-        width: `calc(100% - ${PANEL_WIDTH}px)`,
         backgroundColor: CANVAS_BACKGROUND_COLOR,
       }}
       onMouseDown={onMouseDown}
@@ -44,7 +43,16 @@ export default function CanvasStage({
         ref={containerRef}
         className="h-full w-full overflow-auto [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden"
       >
-        <div className="min-h-full min-w-full">{children}</div>
+        <div
+          className="flex min-h-full min-w-full items-center justify-center px-10 py-8" // 변경: 캔버스 외곽의 내부 검은 여백 추가
+          style={{
+            width: "max-content",
+            minWidth: "100%",
+            minHeight: "100%",
+          }}
+        >
+          {children}
+        </div>
       </div>
     </div>
   );

--- a/frontend/src/features/gameplay/canvas/components/CanvasStage.tsx
+++ b/frontend/src/features/gameplay/canvas/components/CanvasStage.tsx
@@ -38,10 +38,19 @@ export default function CanvasStage({
 
       <div
         ref={containerRef}
+        tabIndex={0} // 변경: 캔버스 영역 포커스 가능
         className="h-full w-full overflow-auto [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden"
+        onMouseDown={() => {
+          containerRef.current?.focus(); // 변경: 캔버스 클릭 시 포커스 고정
+        }}
+        onKeyDown={(event) => {
+          if (event.code === "Space") {
+            event.preventDefault(); // 변경: 캔버스 포커스 상태에서 스페이스 기본 동작 차단
+          }
+        }}
       >
         <div
-          className="flex min-h-full min-w-full items-center justify-center px-10 py-8" // 변경: 캔버스 외곽의 내부 검은 여백 추가
+          className="flex min-h-full min-w-full items-center justify-center px-10 py-8"
           style={{
             width: "max-content",
             minWidth: "100%",

--- a/frontend/src/features/gameplay/canvas/hooks/useCanvasInteraction.ts
+++ b/frontend/src/features/gameplay/canvas/hooks/useCanvasInteraction.ts
@@ -1,11 +1,12 @@
 import { useRef, type RefObject } from "react";
-import { getGameConfig } from "@/shared/config/game-config";
 import { Cell } from "../model/canvas.types";
 
 interface UseCanvasInteractionParams {
   containerRef: RefObject<HTMLDivElement | null>;
   canvasRef: RefObject<HTMLCanvasElement | null>;
   cells: Cell[];
+  gridX: number;
+  gridY: number;
   onSelectCell: (cell: Cell) => void;
   onResetPreviewColor: () => void;
   onOpenPopup: (position: { x: number; y: number }) => void;
@@ -15,6 +16,8 @@ export function useCanvasInteraction({
   containerRef,
   canvasRef,
   cells,
+  gridX,
+  gridY,
   onSelectCell,
   onResetPreviewColor,
   onOpenPopup,
@@ -57,13 +60,14 @@ export function useCanvasInteraction({
     if (hasPanned.current) return;
 
     const canvas = canvasRef.current;
-    if (!canvas) return;
-
-    const cellSize = getGameConfig().board.cellSize;
+    if (!canvas || gridX === 0 || gridY === 0) return;
 
     const rect = canvas.getBoundingClientRect();
-    const x = Math.floor((event.clientX - rect.left) / cellSize);
-    const y = Math.floor((event.clientY - rect.top) / cellSize);
+    const cellWidth = rect.width / gridX;
+    const cellHeight = rect.height / gridY;
+
+    const x = Math.floor((event.clientX - rect.left) / cellWidth);
+    const y = Math.floor((event.clientY - rect.top) / cellHeight);
 
     const cell = cells.find(
       (candidate) => candidate.x === x && candidate.y === y,
@@ -74,8 +78,8 @@ export function useCanvasInteraction({
     onSelectCell(cell);
     onResetPreviewColor();
     onOpenPopup({
-      x: rect.left + (cell.x + 2) * cellSize,
-      y: rect.top + (cell.y - 1.5) * cellSize,
+      x: rect.left + (cell.x + 2) * cellWidth,
+      y: rect.top + (cell.y - 1.5) * cellHeight,
     });
   };
 

--- a/frontend/src/features/gameplay/canvas/hooks/useCanvasNavigation.ts
+++ b/frontend/src/features/gameplay/canvas/hooks/useCanvasNavigation.ts
@@ -1,15 +1,18 @@
 import { useCallback, type RefObject } from "react";
-import { getGameConfig } from "@/shared/config/game-config";
 
 interface UseCanvasNavigationParams {
   containerRef: RefObject<HTMLDivElement | null>;
   canvasRef: RefObject<HTMLCanvasElement | null>;
+  gridX: number;
+  gridY: number;
   updateViewport: () => void;
 }
 
 export function useCanvasNavigation({
   containerRef,
   canvasRef,
+  gridX,
+  gridY,
   updateViewport,
 }: UseCanvasNavigationParams) {
   const navigateToCoordinate = useCallback(
@@ -17,12 +20,13 @@ export function useCanvasNavigation({
       const container = containerRef.current;
       const canvas = canvasRef.current;
 
-      if (!container || !canvas) return;
+      if (!container || !canvas || gridX === 0 || gridY === 0) return;
 
-      const cellSize = getGameConfig().board.cellSize;
+      const cellWidth = canvas.offsetWidth / gridX;
+      const cellHeight = canvas.offsetHeight / gridY;
 
-      const targetX = x * cellSize + cellSize / 2;
-      const targetY = y * cellSize + cellSize / 2;
+      const targetX = x * cellWidth + cellWidth / 2;
+      const targetY = y * cellHeight + cellHeight / 2;
 
       const nextScrollLeft =
         canvas.offsetLeft + targetX - container.clientWidth / 2;
@@ -48,7 +52,7 @@ export function useCanvasNavigation({
         updateViewport();
       });
     },
-    [canvasRef, containerRef, updateViewport],
+    [canvasRef, containerRef, gridX, gridY, updateViewport],
   );
 
   return {

--- a/frontend/src/features/gameplay/canvas/model/viewport.ts
+++ b/frontend/src/features/gameplay/canvas/model/viewport.ts
@@ -29,12 +29,17 @@ export function calculateViewport({
 
   const canvasLeft = canvas.offsetLeft;
   const canvasTop = canvas.offsetTop;
+  const renderedCanvasWidth = canvas.offsetWidth;
+  const renderedCanvasHeight = canvas.offsetHeight;
 
   const canvasVisibleLeft = Math.max(0, visibleLeft - canvasLeft);
   const canvasVisibleTop = Math.max(0, visibleTop - canvasTop);
-  const canvasVisibleRight = Math.min(canvas.width, visibleRight - canvasLeft);
+  const canvasVisibleRight = Math.min(
+    renderedCanvasWidth,
+    visibleRight - canvasLeft,
+  );
   const canvasVisibleBottom = Math.min(
-    canvas.height,
+    renderedCanvasHeight,
     visibleBottom - canvasTop,
   );
 
@@ -43,19 +48,19 @@ export function calculateViewport({
 
   const nextWidth = Math.min(
     minimapWidth,
-    (visibleWidth / canvas.width) * minimapWidth,
+    (visibleWidth / renderedCanvasWidth) * minimapWidth,
   );
   const nextHeight = Math.min(
     minimapHeight,
-    (visibleHeight / canvas.height) * minimapHeight,
+    (visibleHeight / renderedCanvasHeight) * minimapHeight,
   );
 
   const nextLeft = Math.min(
-    Math.max(0, (canvasVisibleLeft / canvas.width) * minimapWidth),
+    Math.max(0, (canvasVisibleLeft / renderedCanvasWidth) * minimapWidth),
     Math.max(0, minimapWidth - nextWidth),
   );
   const nextTop = Math.min(
-    Math.max(0, (canvasVisibleTop / canvas.height) * minimapHeight),
+    Math.max(0, (canvasVisibleTop / renderedCanvasHeight) * minimapHeight),
     Math.max(0, minimapHeight - nextHeight),
   );
 

--- a/frontend/src/features/gameplay/vote/components/VotePopup.tsx
+++ b/frontend/src/features/gameplay/vote/components/VotePopup.tsx
@@ -68,7 +68,7 @@ function getButtonLabel(
   return "투표하기";
 }
 
-function isInteractiveElement(target: EventTarget | null): boolean {
+function isTextInputElement(target: EventTarget | null): boolean {
   if (!(target instanceof HTMLElement)) {
     return false;
   }
@@ -79,8 +79,6 @@ function isInteractiveElement(target: EventTarget | null): boolean {
     tagName === "INPUT" ||
     tagName === "TEXTAREA" ||
     tagName === "SELECT" ||
-    tagName === "BUTTON" ||
-    tagName === "A" ||
     target.isContentEditable
   );
 }
@@ -299,17 +297,21 @@ export default function VotePopup({
     setError("");
   }, [isRoundExpired, isVotingPhase]);
 
-  useEffect(() => {
+    useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.code !== "Space" || event.repeat) {
+      if (event.code !== "Space") {
         return;
       }
 
-      if (isInteractiveElement(event.target)) {
+      if (isTextInputElement(event.target)) {
         return;
       }
 
-      event.preventDefault();
+      event.preventDefault(); // 변경: 모달이 열려 있으면 스페이스 기본 스크롤 차단
+
+      if (event.repeat) {
+        return;
+      }
 
       if (isVoteDisabled) {
         return;
@@ -324,6 +326,7 @@ export default function VotePopup({
       window.removeEventListener("keydown", handleKeyDown);
     };
   }, [handleSubmit, isVoteDisabled]);
+
 
   return (
     <div
@@ -344,11 +347,11 @@ export default function VotePopup({
               selectedCell.color
                 ? { backgroundColor: selectedCell.color }
                 : {
-                    backgroundColor: "#f9fafb",
-                    backgroundImage: CHECKER_PATTERN,
-                    backgroundPosition: "0 0, 4px 4px",
-                    backgroundSize: "8px 8px",
-                  }
+                  backgroundColor: "#f9fafb",
+                  backgroundImage: CHECKER_PATTERN,
+                  backgroundPosition: "0 0, 4px 4px",
+                  backgroundSize: "8px 8px",
+                }
             }
             onClick={(event) => {
               event.stopPropagation();

--- a/frontend/src/features/gameplay/vote/components/VotePopup.tsx
+++ b/frontend/src/features/gameplay/vote/components/VotePopup.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import type { Cell } from "@/features/gameplay/canvas";
 import {
   GAME_PHASE,
@@ -68,6 +68,23 @@ function getButtonLabel(
   return "투표하기";
 }
 
+function isInteractiveElement(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) {
+    return false;
+  }
+
+  const tagName = target.tagName;
+
+  return (
+    tagName === "INPUT" ||
+    tagName === "TEXTAREA" ||
+    tagName === "SELECT" ||
+    tagName === "BUTTON" ||
+    tagName === "A" ||
+    target.isContentEditable
+  );
+}
+
 export default function VotePopup({
   canvasId,
   roundId,
@@ -132,7 +149,7 @@ export default function VotePopup({
     handleColorChange(slotColor);
   };
 
-  const handleSubmit = async () => {
+  const handleSubmit = useCallback(async () => {
     if (!roundId) {
       return;
     }
@@ -175,7 +192,18 @@ export default function VotePopup({
     } finally {
       setLoading(false);
     }
-  };
+  }, [
+    roundId,
+    isVotingPhase,
+    phaseBlockedMessage,
+    isRoundExpired,
+    color,
+    canvasId,
+    selectedCell.id,
+    onColorChange,
+    onVoteSuccess,
+    onClose,
+  ]);
 
   const handleDragStart = (event: React.MouseEvent) => {
     isDragging.current = true;
@@ -270,6 +298,32 @@ export default function VotePopup({
 
     setError("");
   }, [isRoundExpired, isVotingPhase]);
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.code !== "Space" || event.repeat) {
+        return;
+      }
+
+      if (isInteractiveElement(event.target)) {
+        return;
+      }
+
+      event.preventDefault();
+
+      if (isVoteDisabled) {
+        return;
+      }
+
+      void handleSubmit();
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [handleSubmit, isVoteDisabled]);
 
   return (
     <div

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -122,7 +122,7 @@ body {
 }
 
 #root {
-  width: 1126px;
+  width: 80%;
   max-width: 100%;
   margin: 0 auto;
   text-align: center;

--- a/frontend/src/pages/canvas/CanvasPage.tsx
+++ b/frontend/src/pages/canvas/CanvasPage.tsx
@@ -39,6 +39,7 @@ export default function CanvasPage() {
     handleMouseMove,
     handleMouseUp,
     handleMouseLeave,
+    handleWheel,
     popupOpen,
     popupPos,
     canvasId,
@@ -66,6 +67,7 @@ export default function CanvasPage() {
     gridY,
     viewport,
     navigateToCoordinate,
+    resetCanvasZoom,
   } = useCanvasPage({
     onSessionEnded: handleSessionEnded,
     onUnauthorized: handleUnauthorized,
@@ -87,10 +89,26 @@ export default function CanvasPage() {
     <div className="flex h-screen w-full">
       <CanvasStage
         containerRef={containerRef}
+        overlay={
+          <button
+            type="button"
+            className="flex h-9 w-9 items-center justify-center rounded-md border border-gray-200 bg-white text-gray-600 shadow-sm hover:bg-gray-50"
+            aria-label="초기 줌 비율로 복귀"
+            title="초기 줌 비율로 복귀"
+            onMouseDown={(event) => event.stopPropagation()}
+            onClick={(event) => {
+              event.stopPropagation();
+              resetCanvasZoom();
+            }}
+          >
+            ⟲
+          </button>
+        }
         onMouseDown={handleMouseDown}
         onMouseMove={handleMouseMove}
         onMouseUp={handleMouseUp}
         onMouseLeave={handleMouseLeave}
+        onWheel={handleWheel}
       >
         <CanvasSurface canvasRef={canvasRef} />
       </CanvasStage>

--- a/frontend/src/pages/canvas/model/useCanvasPage.ts
+++ b/frontend/src/pages/canvas/model/useCanvasPage.ts
@@ -43,6 +43,7 @@ export default function useCanvasPage({
     selectedCell,
     viewport,
     navigateToCoordinate,
+    resetCanvasZoom,
     setCanvasId,
     setGridX,
     setGridY,
@@ -51,6 +52,7 @@ export default function useCanvasPage({
     handleMouseMove,
     handleMouseUp,
     handleMouseLeave,
+    handleWheel,
     handleCanvasUpdated,
     clearSelectedCell,
   } = useCanvasScene({
@@ -107,6 +109,7 @@ export default function useCanvasPage({
     handleMouseMove,
     handleMouseUp,
     handleMouseLeave,
+    handleWheel,
     popupOpen,
     popupPos,
     canvasId,
@@ -135,5 +138,6 @@ export default function useCanvasPage({
     gridY,
     viewport,
     navigateToCoordinate,
+    resetCanvasZoom,
   };
 }

--- a/frontend/src/pages/canvas/model/useCanvasScene.ts
+++ b/frontend/src/pages/canvas/model/useCanvasScene.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 import {
   Cell,
   useCanvasInteraction,
@@ -18,6 +18,48 @@ interface UseCanvasSceneParams {
   closePopup: () => void;
 }
 
+interface ZoomBounds {
+  minZoom: number;
+  maxZoom: number;
+}
+
+interface PendingZoomAdjustment {
+  contentX: number;
+  contentY: number;
+  viewportOffsetX: number;
+  viewportOffsetY: number;
+}
+
+const ZOOM_STEP = 0.1;
+const MAX_ZOOM = 4;
+
+function getZoomBounds(
+  container: HTMLDivElement,
+  canvas: HTMLCanvasElement,
+): ZoomBounds {
+  if (canvas.width <= 0 || canvas.height <= 0) {
+    return {
+      minZoom: 1,
+      maxZoom: MAX_ZOOM,
+    };
+  }
+
+  const fitWidthZoom = container.clientWidth / canvas.width;
+  const fitHeightZoom = container.clientHeight / canvas.height;
+  const fittedZoom = Math.min(fitWidthZoom, fitHeightZoom);
+  const minZoom =
+    Number.isFinite(fittedZoom) && fittedZoom > 0 ? fittedZoom : 1;
+
+  return {
+    minZoom,
+    maxZoom: Math.max(MAX_ZOOM, minZoom),
+  };
+}
+
+function clampZoom(nextZoom: number, bounds: ZoomBounds) {
+  return Math.min(bounds.maxZoom, Math.max(bounds.minZoom, nextZoom));
+}
+
 export default function useCanvasScene({
   previewColorRef,
   votingCellIdsRef,
@@ -32,6 +74,10 @@ export default function useCanvasScene({
 
   const cellsRef = useRef<Cell[]>([]);
   const selectedCellRef = useRef<Cell | null>(null);
+  const zoomRef = useRef(1);
+  const initialZoomRef = useRef(1);
+  const sceneKeyRef = useRef<string | null>(null);
+  const pendingZoomAdjustmentRef = useRef<PendingZoomAdjustment | null>(null);
 
   const [cells, setCells] = useState<Cell[]>([]);
   const [canvasId, setCanvasId] = useState<number | null>(null);
@@ -39,10 +85,15 @@ export default function useCanvasScene({
   const [gridY, setGridY] = useState(0);
   const [selectedCell, setSelectedCell] = useState<Cell | null>(null);
   const [canvasReady, setCanvasReady] = useState(false);
+  const [zoom, setZoom] = useState(1);
 
   useEffect(() => {
     selectedCellRef.current = selectedCell;
   }, [selectedCell]);
+
+  useEffect(() => {
+    zoomRef.current = zoom;
+  }, [zoom]);
 
   const updateCells = useCallback(
     (updater: Cell[] | ((prev: Cell[]) => Cell[])) => {
@@ -60,9 +111,12 @@ export default function useCanvasScene({
     [],
   );
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     const canvas = canvasRef.current;
     if (!canvas || !canvasId || gridX === 0 || gridY === 0) {
+      if (canvasReady) {
+        setCanvasReady(false);
+      }
       return;
     }
 
@@ -70,8 +124,19 @@ export default function useCanvasScene({
 
     canvas.width = gridX * cellSize;
     canvas.height = gridY * cellSize;
-    setCanvasReady(true);
-  }, [canvasId, gridX, gridY]);
+    canvas.style.width = `${canvas.width * zoom}px`;
+    canvas.style.height = `${canvas.height * zoom}px`;
+
+    const sceneKey = `${canvasId}:${gridX}:${gridY}`;
+    if (sceneKeyRef.current !== sceneKey) {
+      sceneKeyRef.current = sceneKey;
+      initialZoomRef.current = zoom;
+    }
+
+    if (!canvasReady) {
+      setCanvasReady(true);
+    }
+  }, [canvasId, gridX, gridY, zoom, canvasReady]);
 
   const { viewport, updateViewport } = useCanvasViewport({
     containerRef,
@@ -81,9 +146,44 @@ export default function useCanvasScene({
     canvasReady,
   });
 
+  useLayoutEffect(() => {
+    const container = containerRef.current;
+    const canvas = canvasRef.current;
+    const pending = pendingZoomAdjustmentRef.current;
+
+    if (!container || !canvas || !canvasReady || !pending) {
+      return;
+    }
+
+    const nextScrollLeft =
+      canvas.offsetLeft + pending.contentX * zoom - pending.viewportOffsetX;
+    const nextScrollTop =
+      canvas.offsetTop + pending.contentY * zoom - pending.viewportOffsetY;
+
+    const maxScrollLeft = Math.max(
+      0,
+      container.scrollWidth - container.clientWidth,
+    );
+    const maxScrollTop = Math.max(
+      0,
+      container.scrollHeight - container.clientHeight,
+    );
+
+    container.scrollTo({
+      left: Math.min(Math.max(0, nextScrollLeft), maxScrollLeft),
+      top: Math.min(Math.max(0, nextScrollTop), maxScrollTop),
+      behavior: "auto",
+    });
+
+    pendingZoomAdjustmentRef.current = null;
+    updateViewport();
+  }, [zoom, canvasReady, updateViewport]);
+
   const { navigateToCoordinate } = useCanvasNavigation({
     containerRef,
     canvasRef,
+    gridX,
+    gridY,
     updateViewport,
   });
 
@@ -107,10 +207,87 @@ export default function useCanvasScene({
       containerRef,
       canvasRef,
       cells,
+      gridX,
+      gridY,
       onSelectCell: handleSelectCell,
       onResetPreviewColor: resetPreviewColor,
       onOpenPopup: openPopup,
     });
+
+  const resetCanvasZoom = useCallback(() => {
+    const container = containerRef.current;
+    const canvas = canvasRef.current;
+
+    if (!container || !canvas || !canvasReady) {
+      return;
+    }
+
+    const bounds = getZoomBounds(container, canvas);
+
+    setZoom((currentZoom) => {
+      const nextZoom = clampZoom(initialZoomRef.current, bounds);
+
+      if (nextZoom === currentZoom) {
+        return currentZoom;
+      }
+
+      pendingZoomAdjustmentRef.current = {
+        contentX:
+          (container.scrollLeft + container.clientWidth / 2 - canvas.offsetLeft) /
+          currentZoom,
+        contentY:
+          (container.scrollTop + container.clientHeight / 2 - canvas.offsetTop) /
+          currentZoom,
+        viewportOffsetX: container.clientWidth / 2,
+        viewportOffsetY: container.clientHeight / 2,
+      };
+
+      zoomRef.current = nextZoom;
+      return nextZoom;
+    });
+  }, [canvasReady]);
+
+  const handleWheel = useCallback(
+    (event: React.WheelEvent) => {
+      const container = containerRef.current;
+      const canvas = canvasRef.current;
+
+      if (!container || !canvas || !canvasReady) {
+        return;
+      }
+
+      event.preventDefault();
+
+      const containerRect = container.getBoundingClientRect();
+      const pointerOffsetX = event.clientX - containerRect.left;
+      const pointerOffsetY = event.clientY - containerRect.top;
+      const zoomDelta = event.deltaY < 0 ? ZOOM_STEP : -ZOOM_STEP;
+      const bounds = getZoomBounds(container, canvas);
+
+      setZoom((currentZoom) => {
+        const nextZoom = clampZoom(currentZoom + zoomDelta, bounds);
+
+        if (nextZoom === currentZoom) {
+          return currentZoom;
+        }
+
+        pendingZoomAdjustmentRef.current = {
+          contentX:
+            (container.scrollLeft + pointerOffsetX - canvas.offsetLeft) /
+            currentZoom,
+          contentY:
+            (container.scrollTop + pointerOffsetY - canvas.offsetTop) /
+            currentZoom,
+          viewportOffsetX: pointerOffsetX,
+          viewportOffsetY: pointerOffsetY,
+        };
+
+        zoomRef.current = nextZoom;
+        return nextZoom;
+      });
+    },
+    [canvasReady],
+  );
 
   const handleCanvasUpdated = useCallback(
     ({ cellId, color }: { cellId: number; color: string }) => {
@@ -153,6 +330,7 @@ export default function useCanvasScene({
     selectedCell,
     viewport,
     navigateToCoordinate,
+    resetCanvasZoom,
     setCanvasId,
     setGridX,
     setGridY,
@@ -161,6 +339,7 @@ export default function useCanvasScene({
     handleMouseMove,
     handleMouseUp,
     handleMouseLeave,
+    handleWheel,
     handleCanvasUpdated,
     clearSelectedCell,
   };


### PR DESCRIPTION
## 관련 이슈
- Close #179  

## 작업 내용

1. 스페이스바로 투표 동작 연결
    - 키보드 입력만으로도 투표를 실행할 수 있도록 스페이스바 동작을 연결했습니다.
    - 마우스 중심 흐름 외에 빠른 입력 경로를 추가했습니다.

2. 캔버스 휠 확대/축소 및 최소 축소 범위 제한
    - 마우스 휠로 캔버스를 확대/축소할 수 있도록 구현했습니다.
    - 과도하게 축소되어 사용성이 깨지지 않도록 최소 축소 범위를 제한했습니다.
    - 초기 배율 복귀 흐름도 함께 정리했습니다.

3. 캔버스 영역 너비 조정
    - 패널 폭은 유지하면서 캔버스가 사용할 수 있는 가로 영역을 더 넓게 확보했습니다.
    - 앱/페이지 레이아웃의 폭 제한과 여백 구조를 조정해 실사용 영역을 확장했습니다.

4. 캔버스 중앙 정렬
    - 캔버스가 가용 영역보다 작을 때 기본적으로 중앙에 보이도록 정렬 구조를 보완했습니다.
    - 캔버스가 큰 경우에는 기존처럼 스크롤 가능한 동작을 유지하도록 구성했습니다.

## 테스트 및 확인 사항
- 스페이스바 입력 시 의도한 투표 동작이 정상 실행되는지
- 휠 확대/축소가 자연스럽게 동작하는지
- 최소 축소 범위 아래로 더 축소되지 않는지
- `/play` 화면에서 캔버스 영역이 이전보다 넓게 보이는지
- 캔버스가 작은 경우 중앙 정렬되고, 큰 경우 스크롤이 정상 동작하는지

## 체크리스트
- [ ] 불필요한 주석 및 디버깅 코드를 제거하였는가?
- [ ] 모든 테스트를 통과하였는가?
- [ ] 변경 사항에 대한 문서 업데이트가 필요한가?
