### PR TITLE
feat: 게임 참여 및 GAME_END 관전 흐름 개선

### DIFF
--- a/backend/src/modules/canvas/canvas.service.ts
+++ b/backend/src/modules/canvas/canvas.service.ts
@@ -125,8 +125,21 @@ export const canvasService = {
   },
 
   async getCurrent(): Promise<Canvas | null> {
-    return canvasRepository.findOne({
+    const currentCanvas = await canvasRepository.findOne({
       where: { status: CanvasStatus.PLAYING },
+      order: { startedAt: "DESC" },
+    });
+
+    if (currentCanvas) {
+      return currentCanvas;
+    }
+
+    return canvasRepository.findOne({
+      where: {
+        status: CanvasStatus.FINISHED,
+        phase: GamePhase.GAME_END,
+      },
+      order: { phaseStartedAt: "DESC" },
     });
   },
 

--- a/backend/src/modules/participant/participant-session.service.ts
+++ b/backend/src/modules/participant/participant-session.service.ts
@@ -95,10 +95,6 @@ class ParticipantSessionService {
   }
 
   private getDefaultStatusByPhase(phase: GamePhase | null): ParticipantStatus {
-    if (phase === GamePhase.ROUND_ACTIVE) {
-      return "waiting";
-    }
-
     if (phase === GamePhase.GAME_END) {
       return "waiting";
     }
@@ -110,15 +106,15 @@ class ParticipantSessionService {
     phase: GamePhase | null,
     existingStatus: ParticipantStatus,
   ): ParticipantStatus {
-    if (phase === GamePhase.ROUND_ACTIVE) {
-      return existingStatus;
-    }
-
     if (phase === GamePhase.GAME_END) {
       return "waiting";
     }
 
-    return "voting";
+    if (phase === GamePhase.ROUND_ACTIVE) {
+      return "voting";
+    }
+
+    return existingStatus === "waiting" ? "voting" : existingStatus;
   }
 
   private async getDefaultStatus(canvasId: number): Promise<ParticipantStatus> {

--- a/backend/src/modules/round/round.service.ts
+++ b/backend/src/modules/round/round.service.ts
@@ -14,6 +14,7 @@ import { Vote } from "../../entities/vote.entity";
 import { Voter } from "../../entities/voter.entity";
 import { GamePhase } from "../game/game-phase.types";
 import { participantSessionService } from "../participant/participant-session.service";
+import { voteService } from "../vote/vote.service";
 
 const canvasRepository = AppDataSource.getRepository(Canvas);
 const cellRepository = AppDataSource.getRepository(Cell);
@@ -186,6 +187,11 @@ export const roundService = {
       `[perf] vote tickets insert | roundId=${round.id} voterCount=${voters.length} ticketCount=${tickets.length} ms=${(performance.now() - ticketInsertStartedAt).toFixed(2)}`,
     );
 
+    await voteService.registerIssuedVoters(
+      round.id,
+      voters.map((voter) => voter.id),
+    );
+
     if (io) {
       const gameEndAt = getActiveGameEndAt(
         canvasGameConfig,
@@ -344,6 +350,7 @@ export const roundService = {
     });
 
     await redisClient.del(redisKey);
+    await voteService.clearIssuedVoters(round.id);
 
     if (io) {
       io.to(`canvas:${canvasId}`).emit("round:ended", {

--- a/backend/src/modules/vote/vote.service.ts
+++ b/backend/src/modules/vote/vote.service.ts
@@ -1,5 +1,7 @@
 import { Server } from "socket.io";
+import { getCanvasGameConfigSnapshot } from "../../config/game.config";
 import { AppDataSource } from "../../database/data-source";
+import { Canvas } from "../../entities/canvas.entity";
 import { Vote } from "../../entities/vote.entity";
 import { VoteTicket } from "../../entities/vote-ticket.entity";
 import { VoteRound } from "../../entities/vote-round.entity";
@@ -11,8 +13,106 @@ const voteRepository = AppDataSource.getRepository(Vote);
 const voteTicketRepository = AppDataSource.getRepository(VoteTicket);
 const voteRoundRepository = AppDataSource.getRepository(VoteRound);
 const cellRepository = AppDataSource.getRepository(Cell);
+const canvasRepository = AppDataSource.getRepository(Canvas);
+
+interface EnsureCurrentRoundTicketsResult {
+  roundId: number | null;
+  issued: boolean;
+}
+
+function getIssuedVotersKey(roundId: number): string {
+  return `vote:round:${roundId}:issued-voters`;
+}
 
 export const voteService = {
+  async registerIssuedVoters(
+    roundId: number,
+    voterIds: number[],
+  ): Promise<void> {
+    if (voterIds.length === 0) {
+      return;
+    }
+
+    await redisClient.sAdd(getIssuedVotersKey(roundId), voterIds.map(String));
+  },
+
+  async clearIssuedVoters(roundId: number): Promise<void> {
+    await redisClient.del(getIssuedVotersKey(roundId));
+  },
+
+  async ensureCurrentRoundTicketsForParticipant(
+    canvasId: number,
+    voterId: number,
+  ): Promise<EnsureCurrentRoundTicketsResult> {
+    const round = await voteRoundRepository.findOne({
+      where: { canvas: { id: canvasId }, isActive: true },
+    });
+
+    if (!round) {
+      return { roundId: null, issued: false };
+    }
+
+    const canvas = await canvasRepository.findOne({
+      where: { id: canvasId },
+    });
+
+    if (!canvas) {
+      return { roundId: round.id, issued: false };
+    }
+
+    const canvasGameConfig = getCanvasGameConfigSnapshot(canvas);
+    const roundEndsAt = new Date(
+      round.startedAt.getTime() +
+        canvasGameConfig.phases.roundDurationSec * 1000,
+    );
+
+    if (roundEndsAt.getTime() <= Date.now()) {
+      return { roundId: round.id, issued: false };
+    }
+
+    const issuedVotersKey = getIssuedVotersKey(round.id);
+
+    const existingTicketCount = await voteTicketRepository.count({
+      where: {
+        round: { id: round.id },
+        voter: { id: voterId },
+      },
+    });
+
+    if (existingTicketCount > 0) {
+      await redisClient.sAdd(issuedVotersKey, String(voterId));
+      return { roundId: round.id, issued: false };
+    }
+
+    const addedCount = await redisClient.sAdd(issuedVotersKey, String(voterId));
+
+    if (addedCount === 0) {
+      return { roundId: round.id, issued: false };
+    }
+
+    try {
+      const tickets = Array.from(
+        { length: canvasGameConfig.rules.votesPerRound },
+        () => ({
+          round: { id: round.id },
+          voter: { id: voterId },
+          isUsed: false,
+        }),
+      );
+
+      if (tickets.length > 0) {
+        await voteTicketRepository.insert(tickets);
+      }
+
+      return { roundId: round.id, issued: true };
+    } catch (error) {
+      await redisClient.sRem(issuedVotersKey, String(voterId));
+      throw new Error(
+        `현재 라운드 투표권 지급 중 오류가 발생했어요: ${String(error)}`,
+      );
+    }
+  },
+
   async submit(
     voterId: number,
     sessionId: string,

--- a/backend/src/socket/socket.handler.ts
+++ b/backend/src/socket/socket.handler.ts
@@ -1,5 +1,6 @@
 import { Server, Socket } from "socket.io";
 import { participantSessionService } from "../modules/participant/participant-session.service";
+import { voteService } from "../modules/vote/vote.service"; // 추가: 중간 입장자 현재 라운드 티켓 지급
 
 export function registerHandlers(socket: Socket, io: Server): void {
   socket.on("join:canvas", async (canvasIdValue: number | string) => {
@@ -25,6 +26,13 @@ export function registerHandlers(socket: Socket, io: Server): void {
         socket.id,
         io,
       );
+
+      if (typeof socket.voterId === "number") {
+        await voteService.ensureCurrentRoundTicketsForParticipant(
+          canvasId,
+          socket.voterId,
+        );
+      }
 
       const room = `canvas:${canvasId}`;
       socket.join(room);

--- a/frontend/src/pages/canvas/model/useCanvasGameplay.ts
+++ b/frontend/src/pages/canvas/model/useCanvasGameplay.ts
@@ -316,7 +316,11 @@ export default function useCanvasGameplay({
 
   const handleCanvasJoined = useCallback(() => {
     void refreshParticipants();
-  }, [refreshParticipants]);
+
+    if (roundId && isRoundActivePhase(phase)) {
+      void fetchTickets(roundId);
+    }
+  }, [fetchTickets, phase, refreshParticipants, roundId]);
 
   const handleRoundStarted = useCallback(
     async ({

--- a/frontend/src/pages/canvas/model/useCanvasGameplay.ts
+++ b/frontend/src/pages/canvas/model/useCanvasGameplay.ts
@@ -165,16 +165,12 @@ export default function useCanvasGameplay({
       if (cancelled || !result) {
         return;
       }
-
-      if (result.round.phase === GAME_PHASE.GAME_END) {
-        markGameEnded();
-      }
     });
 
     return () => {
       cancelled = true;
     };
-  }, [initializeSession, markGameEnded]);
+  }, [initializeSession]);
 
   useEffect(() => {
     if (!canvasId) {
@@ -182,8 +178,13 @@ export default function useCanvasGameplay({
       return;
     }
 
+    if (phase === GAME_PHASE.GAME_END) {
+      clearParticipants();
+      return;
+    }
+
     void refreshParticipants();
-  }, [canvasId, clearParticipants, refreshParticipants]);
+  }, [canvasId, clearParticipants, phase, refreshParticipants]);
 
   useEffect(() => {
     if (isRoundActivePhase(phase)) {


### PR DESCRIPTION
## 관련 이슈
- Close #181 

- `ROUND_ACTIVE` 중간 입장자도 현재 라운드에 즉시 참여할 수 있도록 투표권 지급 방식을 개선했습니다.
- `GAME_END` 상태에 새로 접속한 사용자도 마지막 캔버스를 볼 수 있도록 조회/프론트 처리 흐름을 정리했습니다.

## 변경 내용
- `ROUND_ACTIVE` 중 입장한 사용자에게 현재 라운드 투표권을 즉시 부여하도록 변경
- 지급 기준은 `remainingSeconds > 0`, 지급 수량은 기존과 동일한 `votesPerRound`
- 재접속/중복 탭 등으로 동일 라운드 투표권이 중복 지급되지 않도록 Redis 기반 발급 이력 관리 추가
- 소켓 `canvas:joined` 이후 현재 라운드 티켓을 재조회해 프론트 `remaining` 값이 즉시 반영되도록 수정
- `/canvas/current`는 `PLAYING` 캔버스가 있으면 해당 캔버스, 없으면 가장 최근 `FINISHED + GAME_END` 캔버스를 반환하도록 변경
- `GAME_END` 상태 bootstrap 시 종료 화면으로 즉시 덮지 않고 마지막 캔버스를 그대로 표시하도록 수정
- `GAME_END`에서는 참가자 목록 갱신을 생략하고, 투표는 기존처럼 불가능하게 유지

## 기대 효과
- 라운드 진행 중 입장한 사용자도 바로 게임에 참여할 수 있습니다.
- 게임 종료 phase 중 새로 접속한 사용자도 마지막 결과 캔버스를 자연스럽게 확인할 수 있습니다.

## 테스트 항목
- [x] `ROUND_ACTIVE` 시작 전에 입장한 사용자가 기존처럼 라운드 시작 시 `votesPerRound`만큼 투표권을 받는지 확인
<img width="410" height="260" alt="image" src="https://github.com/user-attachments/assets/7701d17b-5a57-4246-9336-35a5de5b569d" />


- [x] `ROUND_ACTIVE` 진행 중 새로 입장한 사용자가 즉시 현재 라운드 투표권을 `votesPerRound`만큼 받는지 확인
- [x] `ROUND_ACTIVE` 진행 중 입장한 사용자의 프론트 `remaining` 값이 입장 직후 재조회되어 즉시 반영되는지 확인
- [x] 같은 사용자가 새로고침/재접속/중복 탭으로 접속해도 현재 라운드 투표권이 중복 지급되지 않는지 확인
- [x] 진행 중인 `PLAYING` 캔버스가 있을 때 `/canvas/current`가 해당 캔버스를 반환하는지 확인
- [x] 진행 중인 캔버스가 없고 최근 `FINISHED + GAME_END` 캔버스가 있을 때 `/canvas/current`가 해당 마지막 캔버스를 반환하는지 확인
<img width="458" height="457" alt="image-1" src="https://github.com/user-attachments/assets/e456a675-1b85-4ded-a5e7-6fc6c517ef58" />
<br>
<img width="726" height="64" alt="image-2" src="https://github.com/user-attachments/assets/948fdfc0-4f97-4c6b-858d-93cc4342271a" />


- [x] `GAME_END` 상태에서 새로 접속한 사용자가 에러 없이 마지막 캔버스를 보는지 확인
- [x] `GAME_END` 상태에서 남은 투표권 UI가 `-`로 표시되고 실제 투표는 불가능한지 확인
<img width="930" height="1062" alt="image-4" src="https://github.com/user-attachments/assets/69ba06da-a893-4a0a-a3cc-fe49d931f6cd" />


- [x] `gameEndWaitSec` 종료 후 다음 게임으로 정상 전환되는지 확인
