### PR TITLE
feat: canvas batch update로 라운드 결과 다중 셀 반영 지원

### DIFF
--- a/backend/src/modules/round/round.service.ts
+++ b/backend/src/modules/round/round.service.ts
@@ -319,23 +319,11 @@ export const roundService = {
       });
     }
 
-    const representativeResolvedCell =
-      resolvedCells.length > 0
-        ? resolvedCells
-            .slice(1)
-            .reduce(
-              (best, current) =>
-                current.totalVotes > best.totalVotes ? current : best,
-              resolvedCells[0],
-            )
-        : null; // 추가: 다음 batch issue 전까지 기존 payload 호환용 대표 셀
-
-    let representativeUpdatedCell: Cell | null = null;
     let updatedCells: Cell[] = [];
 
     if (resolvedCells.length > 0) {
       const cellsToUpdate = await cellRepository.findBy({
-        id: In(resolvedCells.map((cell) => cell.cellId)), // 변경: 투표된 모든 칸 조회
+        id: In(resolvedCells.map((cell) => cell.cellId)), // 유지: 투표된 모든 칸 조회
       });
 
       const resolvedCellMap = new Map(
@@ -349,19 +337,12 @@ export const roundService = {
           continue;
         }
 
-        cell.color = resolvedCell.color; // 변경: 각 칸의 최다 득표 색 반영
+        cell.color = resolvedCell.color;
         cell.status = CellStatus.PAINTED;
       }
 
       if (cellsToUpdate.length > 0) {
-        updatedCells = await cellRepository.save(cellsToUpdate); // 변경: 여러 칸 한 번에 저장
-      }
-
-      if (representativeResolvedCell) {
-        representativeUpdatedCell =
-          updatedCells.find(
-            (cell) => cell.id === representativeResolvedCell.cellId,
-          ) ?? null;
+        updatedCells = await cellRepository.save(cellsToUpdate);
       }
     }
 
@@ -398,24 +379,17 @@ export const roundService = {
         roundId: round.id,
         roundNumber: round.roundNumber,
         endedAt: round.endedAt,
-        winningCell: representativeUpdatedCell
-          ? {
-              id: representativeUpdatedCell.id,
-              x: representativeUpdatedCell.x,
-              y: representativeUpdatedCell.y,
-              color: representativeUpdatedCell.color,
-            }
-          : null, // 변경: 임시로 대표 셀만 유지, 다음 이슈에서 batch 결과로 교체
+        winningCell: null, // 변경: 단일 당선 셀 개념 제거, batch update로 대체
       });
 
-      if (representativeUpdatedCell) {
-        io.to(`canvas:${canvasId}`).emit("canvas:updated", {
-          cellId: representativeUpdatedCell.id,
-          x: representativeUpdatedCell.x,
-          y: representativeUpdatedCell.y,
-          color: representativeUpdatedCell.color,
-        }); // 변경: 다음 이슈 전까지 기존 단일 업데이트 호환 유지
-      }
+      io.to(`canvas:${canvasId}`).emit("canvas:batch-updated", {
+        updates: updatedCells.map((cell) => ({
+          cellId: cell.id,
+          x: cell.x,
+          y: cell.y,
+          color: cell.color ?? "#000000", // 추가: batch payload에 여러 셀 반영 결과 포함
+        })),
+      });
     }
 
     return round;

--- a/frontend/src/features/gameplay/session/hooks/useGameplaySocket.ts
+++ b/frontend/src/features/gameplay/session/hooks/useGameplaySocket.ts
@@ -1,6 +1,7 @@
 import { useEffect } from "react";
 import socket from "@/shared/lib/socket";
 import {
+  CanvasBatchUpdatedPayload, // 추가: batch canvas update payload 타입
   CanvasJoinedPayload,
   CanvasUpdatedPayload,
   ParticipantsUpdatedPayload,
@@ -17,6 +18,7 @@ interface UseGameplaySocketParams {
   onRoundStarted: (payload: RoundStartedPayload) => void;
   onRoundEnded: (payload: RoundEndedPayload) => void;
   onCanvasUpdated: (payload: CanvasUpdatedPayload) => void;
+  onCanvasBatchUpdated: (payload: CanvasBatchUpdatedPayload) => void; // 추가: batch update 핸들러
   onVoteUpdate: (payload: VoteUpdatePayload) => void;
   onTimerUpdate: (payload: TimerUpdatePayload) => void;
   onParticipantsUpdated: (payload: ParticipantsUpdatedPayload) => void;
@@ -30,6 +32,7 @@ export function useGameplaySocket({
   onRoundStarted,
   onRoundEnded,
   onCanvasUpdated,
+  onCanvasBatchUpdated, // 추가: batch update 핸들러 주입
   onVoteUpdate,
   onTimerUpdate,
   onParticipantsUpdated,
@@ -41,6 +44,7 @@ export function useGameplaySocket({
     socket.on("round:started", onRoundStarted);
     socket.on("round:ended", onRoundEnded);
     socket.on("canvas:updated", onCanvasUpdated);
+    socket.on("canvas:batch-updated", onCanvasBatchUpdated); // 추가: batch update 이벤트 구독
     socket.on("vote:update", onVoteUpdate);
     socket.on("timer:update", onTimerUpdate);
     socket.on("participants:updated", onParticipantsUpdated);
@@ -58,6 +62,7 @@ export function useGameplaySocket({
       socket.off("round:started", onRoundStarted);
       socket.off("round:ended", onRoundEnded);
       socket.off("canvas:updated", onCanvasUpdated);
+      socket.off("canvas:batch-updated", onCanvasBatchUpdated); // 추가: batch update 이벤트 해제
       socket.off("vote:update", onVoteUpdate);
       socket.off("timer:update", onTimerUpdate);
       socket.off("participants:updated", onParticipantsUpdated);
@@ -68,6 +73,7 @@ export function useGameplaySocket({
     };
   }, [
     canvasId,
+    onCanvasBatchUpdated, // 추가: effect dependency
     onCanvasJoined,
     onCanvasUpdated,
     onGameEnded,

--- a/frontend/src/features/gameplay/session/model/socket.types.ts
+++ b/frontend/src/features/gameplay/session/model/socket.types.ts
@@ -27,6 +27,19 @@ export interface CanvasUpdatedPayload {
   color: string;
 }
 
+// 추가: 여러 셀을 한 번에 반영하기 위한 batch item
+export interface CanvasBatchUpdatedCellPayload {
+  cellId: number;
+  x: number;
+  y: number;
+  color: string;
+}
+
+// 추가: 라운드 종료 후 여러 셀을 한 번에 반영하는 batch payload
+export interface CanvasBatchUpdatedPayload {
+  updates: CanvasBatchUpdatedCellPayload[];
+}
+
 export interface VoteUpdatePayload {
   roundId: number;
   cellId: number;

--- a/frontend/src/pages/canvas/model/useCanvasGameplay.ts
+++ b/frontend/src/pages/canvas/model/useCanvasGameplay.ts
@@ -7,6 +7,7 @@ import {
   type SessionBootstrapResult,
   type PhaseTimingState,
 } from "@/features/gameplay/session";
+import type { CanvasBatchUpdatedPayload } from "@/features/gameplay/session/model/socket.types"; // 추가: batch payload 타입 사용
 import {
   GAME_PHASE,
   isRoundActivePhase,
@@ -23,6 +24,7 @@ interface UseCanvasGameplayParams {
   canvasId: number | null;
   onBootstrapScene: (result: SessionBootstrapResult) => void;
   onCanvasUpdated: (payload: { cellId: number; color: string }) => void;
+  onCanvasBatchUpdated: (payload: CanvasBatchUpdatedPayload) => void; // 변경: 실제 socket payload 타입과 맞춤
   onGameEndedCleanup: () => void;
   onSessionEnded: () => void;
   onUnauthorized: (message: string) => void;
@@ -41,6 +43,7 @@ export default function useCanvasGameplay({
   canvasId,
   onBootstrapScene,
   onCanvasUpdated,
+  onCanvasBatchUpdated, // 추가: batch canvas update handler 수신
   onGameEndedCleanup,
   onSessionEnded,
   onUnauthorized,
@@ -491,6 +494,7 @@ export default function useCanvasGameplay({
     onRoundStarted: handleRoundStarted,
     onRoundEnded: handleRoundEnded,
     onCanvasUpdated,
+    onCanvasBatchUpdated, // 추가: batch update 이벤트 연결
     onVoteUpdate: handleVoteUpdate,
     onTimerUpdate: handleTimerUpdate,
     onParticipantsUpdated: handleParticipantsUpdated,

--- a/frontend/src/pages/canvas/model/useCanvasPage.ts
+++ b/frontend/src/pages/canvas/model/useCanvasPage.ts
@@ -54,6 +54,7 @@ export default function useCanvasPage({
     handleMouseLeave,
     handleWheel,
     handleCanvasUpdated,
+    handleCanvasBatchUpdated, // 추가: batch canvas update handler
     clearSelectedCell,
   } = useCanvasScene({
     previewColorRef,
@@ -83,6 +84,7 @@ export default function useCanvasPage({
     canvasId,
     onBootstrapScene: applyBootstrapScene,
     onCanvasUpdated: handleCanvasUpdated,
+    onCanvasBatchUpdated: handleCanvasBatchUpdated, // 추가: batch update를 gameplay socket에 연결
     onGameEndedCleanup: handleGameEndedCleanup,
     onSessionEnded,
     onUnauthorized,

--- a/frontend/src/pages/canvas/model/useCanvasScene.ts
+++ b/frontend/src/pages/canvas/model/useCanvasScene.ts
@@ -1,4 +1,10 @@
-import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
 import {
   Cell,
   useCanvasInteraction,
@@ -6,6 +12,7 @@ import {
   useCanvasRenderer,
   useCanvasViewport,
 } from "@/features/gameplay/canvas";
+import type { CanvasBatchUpdatedPayload } from "@/features/gameplay/session/model/socket.types"; // 추가: batch canvas update payload
 import { getGameConfig } from "@/shared/config/game-config";
 
 interface UseCanvasSceneParams {
@@ -233,10 +240,14 @@ export default function useCanvasScene({
 
       pendingZoomAdjustmentRef.current = {
         contentX:
-          (container.scrollLeft + container.clientWidth / 2 - canvas.offsetLeft) /
+          (container.scrollLeft +
+            container.clientWidth / 2 -
+            canvas.offsetLeft) /
           currentZoom,
         contentY:
-          (container.scrollTop + container.clientHeight / 2 - canvas.offsetTop) /
+          (container.scrollTop +
+            container.clientHeight / 2 -
+            canvas.offsetTop) /
           currentZoom,
         viewportOffsetX: container.clientWidth / 2,
         viewportOffsetY: container.clientHeight / 2,
@@ -315,6 +326,54 @@ export default function useCanvasScene({
     [closePopup, isRoundExpiredRef, updateCells],
   );
 
+  const handleCanvasBatchUpdated = useCallback(
+    ({ updates }: CanvasBatchUpdatedPayload) => {
+      if (updates.length === 0) {
+        return;
+      }
+
+      const updateMap = new Map(
+        updates.map((update) => [update.cellId, update]),
+      ); // 추가: 셀 id 기준으로 batch update lookup 생성
+
+      updateCells((prev) =>
+        prev.map((cell) => {
+          const nextUpdate = updateMap.get(cell.id);
+
+          if (!nextUpdate) {
+            return cell;
+          }
+
+          return {
+            ...cell,
+            color: nextUpdate.color,
+            status: "painted",
+          };
+        }),
+      );
+
+      if (selectedCellRef.current) {
+        const selectedUpdate = updateMap.get(selectedCellRef.current.id);
+
+        if (selectedUpdate) {
+          const nextSelectedCell: Cell = {
+            ...selectedCellRef.current,
+            color: selectedUpdate.color,
+            status: "painted",
+          };
+
+          setSelectedCell(nextSelectedCell);
+          selectedCellRef.current = nextSelectedCell;
+
+          if (!isRoundExpiredRef.current) {
+            closePopup();
+          }
+        }
+      }
+    },
+    [closePopup, isRoundExpiredRef, updateCells],
+  );
+
   const clearSelectedCell = useCallback(() => {
     setSelectedCell(null);
     selectedCellRef.current = null;
@@ -339,8 +398,9 @@ export default function useCanvasScene({
     handleMouseMove,
     handleMouseUp,
     handleMouseLeave,
-    handleWheel,
+    handleWheel, // 추가: CanvasPage에서 사용하는 wheel zoom 핸들러 반환
     handleCanvasUpdated,
+    handleCanvasBatchUpdated, // 유지: 여러 셀을 한 번에 반영하는 batch handler 노출
     clearSelectedCell,
   };
 }


### PR DESCRIPTION
## 관련 이슈
- Close #187 

## 작업 내용
- 라운드 종료 후 여러 칸이 반영되는 결과를 `canvas:batch-updated` 이벤트로 전달하도록 변경했습니다.
- 프론트는 batch payload를 받아 여러 셀을 한 번에 갱신하도록 정리했습니다.

## 변경 내용
- 소켓 타입에 `CanvasBatchUpdatedPayload` 추가
- `useGameplaySocket`에서 `canvas:batch-updated` 이벤트 구독 지원
- `useCanvasScene`에 여러 셀을 한 번에 반영하는 `handleCanvasBatchUpdated` 추가
- `useCanvasPage`, `useCanvasGameplay`에서 batch canvas update 핸들러 연결
- 백엔드 `round.service`에서 기존 단일 대표 셀 업데이트 대신 `canvas:batch-updated` 이벤트 emit
- `round:ended`의 단일 `winningCell` 의존은 제거하고, 실제 캔버스 반영은 batch update 기준으로 전환

## 기대 효과
- 한 라운드 결과로 여러 칸이 바뀌는 규칙을 프론트/백엔드가 일관되게 처리할 수 있습니다.
- 기존 단일 셀 update 반복보다 라운드 결과 전달 구조가 더 명확해집니다.
- 이후 라운드 통계 및 결과 모달 작업과 연결하기 쉬워집니다.

## 테스트 항목
- [x] 한 라운드에서 여러 칸에 투표했을 때 라운드 종료 후 여러 칸이 동시에 반영되는지 확인
- [x] 같은 칸에 여러 색으로 투표했을 때 최다 득표 색으로 칠해지는지 확인
- [x] 같은 칸에서 색상 득표 수가 동점이면 랜덤하게 색이 선택되는지 확인
- [x] 이미 칠해진 칸도 다음 라운드에서 다시 색이 바뀔 수 있는지 확인
- [x] 라운드 종료 시 소켓에서 `canvas:batch-updated` 이벤트가 한 번만 오는지 확인
- [x] `canvas:batch-updated` payload 안에 여러 셀 정보가 포함되는지 확인
- [x] 프론트에서 batch update를 받아 여러 셀이 한 번에 갱신되는지 확인
- [x] `/canvas/current` 재조회 시 batch 반영 결과가 실제 DB 상태와 일치하는지 확인
<img width="612" height="139" alt="image" src="https://github.com/user-attachments/assets/c2044487-83c9-47a2-9f41-dd0a799fcfbf" />
