### PR TITLE
feat: 라운드 및 게임 summary 저장 구조 추가

### DIFF
--- a/backend/src/database/data-source.ts
+++ b/backend/src/database/data-source.ts
@@ -8,6 +8,9 @@ import { VoteRound } from "../entities/vote-round.entity";
 import { VoteTicket } from "../entities/vote-ticket.entity";
 import { Vote } from "../entities/vote.entity";
 
+import { GameSummary } from "../entities/game-summary.entity"; // 추가: 게임 집계 엔티티
+import { RoundSummary } from "../entities/round-summary.entity"; // 추가: 라운드 집계 엔티티
+
 function readNonNegativeIntegerEnv(name: string, fallback: number): number {
   const value = Number(process.env[name]);
 
@@ -23,6 +26,15 @@ export const AppDataSource = new DataSource({
   poolErrorHandler: (error: Error) => {
     console.error("[db] postgres pool error:", error);
   },
-  entities: [Voter, Canvas, Cell, VoteRound, VoteTicket, Vote],
+  entities: [
+    Canvas,
+    Cell,
+    Vote,
+    VoteRound,
+    VoteTicket,
+    Voter,
+    GameSummary, // 추가: 게임 집계 테이블 매핑
+    RoundSummary, // 추가: 라운드 집계 테이블 매핑
+  ],
   migrations: ["src/database/migrations/*.ts"],
 });

--- a/backend/src/database/migrations/1779000000000-AddSummaryTables.ts
+++ b/backend/src/database/migrations/1779000000000-AddSummaryTables.ts
@@ -1,0 +1,142 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddSummaryTables1779000000000 implements MigrationInterface {
+  name = "AddSummaryTables1779000000000";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE "round_summary" (
+        "id" SERIAL NOT NULL,
+        "round_number" integer NOT NULL,
+        "participant_count" integer NOT NULL DEFAULT '0',
+        "total_votes" integer NOT NULL DEFAULT '0',
+        "painted_cell_count" integer NOT NULL DEFAULT '0',
+        "total_cell_count" integer NOT NULL DEFAULT '0',
+        "current_painted_cell_count" integer NOT NULL DEFAULT '0',
+        "canvas_progress_percent" numeric(5,2) NOT NULL DEFAULT '0',
+        "most_voted_cell_id" integer,
+        "most_voted_cell_x" integer,
+        "most_voted_cell_y" integer,
+        "most_voted_cell_vote_count" integer NOT NULL DEFAULT '0',
+        "random_resolved_cell_count" integer NOT NULL DEFAULT '0',
+        "created_at" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+        "updated_at" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+        "canvas_id" integer,
+        "round_id" integer,
+        CONSTRAINT "UQ_round_summary_round_id" UNIQUE ("round_id"),
+        CONSTRAINT "PK_round_summary_id" PRIMARY KEY ("id")
+      )
+    `); // 추가: 라운드 종료 집계 저장 테이블
+
+    await queryRunner.query(`
+      CREATE INDEX "IDX_round_summary_canvas_id"
+      ON "round_summary" ("canvas_id")
+    `); // 추가: 캔버스 기준 조회 최적화
+
+    await queryRunner.query(`
+      CREATE INDEX "IDX_round_summary_round_number"
+      ON "round_summary" ("round_number")
+    `); // 추가: 라운드 번호 기준 조회/정렬 지원
+
+    await queryRunner.query(`
+      CREATE TABLE "game_summary" (
+        "id" SERIAL NOT NULL,
+        "total_rounds" integer NOT NULL DEFAULT '0',
+        "participant_count" integer NOT NULL DEFAULT '0',
+        "issued_ticket_count" integer NOT NULL DEFAULT '0',
+        "total_votes" integer NOT NULL DEFAULT '0',
+        "ticket_usage_rate" numeric(5,2) NOT NULL DEFAULT '0',
+        "total_cell_count" integer NOT NULL DEFAULT '0',
+        "painted_cell_count" integer NOT NULL DEFAULT '0',
+        "empty_cell_count" integer NOT NULL DEFAULT '0',
+        "canvas_completion_percent" numeric(5,2) NOT NULL DEFAULT '0',
+        "most_voted_cell_id" integer,
+        "most_voted_cell_x" integer,
+        "most_voted_cell_y" integer,
+        "most_voted_cell_vote_count" integer NOT NULL DEFAULT '0',
+        "random_resolved_cell_count" integer NOT NULL DEFAULT '0',
+        "used_color_count" integer NOT NULL DEFAULT '0',
+        "most_selected_color" character varying(32),
+        "most_selected_color_vote_count" integer NOT NULL DEFAULT '0',
+        "most_painted_color" character varying(32),
+        "most_painted_color_cell_count" integer NOT NULL DEFAULT '0',
+        "top_voter_id" integer,
+        "top_voter_name" character varying(100),
+        "top_voter_vote_count" integer NOT NULL DEFAULT '0',
+        "hottest_round_id" integer,
+        "hottest_round_number" integer,
+        "hottest_round_vote_count" integer NOT NULL DEFAULT '0',
+        "top_voters_json" text,
+        "participants_json" text,
+        "created_at" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+        "updated_at" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+        "canvas_id" integer,
+        CONSTRAINT "UQ_game_summary_canvas_id" UNIQUE ("canvas_id"),
+        CONSTRAINT "PK_game_summary_id" PRIMARY KEY ("id")
+      )
+    `); // 추가: 게임 종료 종합 집계 저장 테이블
+
+    await queryRunner.query(`
+      CREATE INDEX "IDX_game_summary_canvas_id"
+      ON "game_summary" ("canvas_id")
+    `); // 추가: 캔버스별 단건 조회 최적화
+
+    await queryRunner.query(`
+      ALTER TABLE "round_summary"
+      ADD CONSTRAINT "FK_round_summary_canvas_id"
+      FOREIGN KEY ("canvas_id") REFERENCES "canvas"("id")
+      ON DELETE CASCADE ON UPDATE NO ACTION
+    `); // 추가: 캔버스 삭제 시 라운드 집계 정리
+
+    await queryRunner.query(`
+      ALTER TABLE "round_summary"
+      ADD CONSTRAINT "FK_round_summary_round_id"
+      FOREIGN KEY ("round_id") REFERENCES "vote_round"("id")
+      ON DELETE CASCADE ON UPDATE NO ACTION
+    `); // 추가: 라운드 삭제 시 해당 집계 정리
+
+    await queryRunner.query(`
+      ALTER TABLE "game_summary"
+      ADD CONSTRAINT "FK_game_summary_canvas_id"
+      FOREIGN KEY ("canvas_id") REFERENCES "canvas"("id")
+      ON DELETE CASCADE ON UPDATE NO ACTION
+    `); // 추가: 캔버스 삭제 시 게임 집계 정리
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "game_summary"
+      DROP CONSTRAINT "FK_game_summary_canvas_id"
+    `);
+
+    await queryRunner.query(`
+      ALTER TABLE "round_summary"
+      DROP CONSTRAINT "FK_round_summary_round_id"
+    `);
+
+    await queryRunner.query(`
+      ALTER TABLE "round_summary"
+      DROP CONSTRAINT "FK_round_summary_canvas_id"
+    `);
+
+    await queryRunner.query(`
+      DROP INDEX "public"."IDX_game_summary_canvas_id"
+    `);
+
+    await queryRunner.query(`
+      DROP TABLE "game_summary"
+    `);
+
+    await queryRunner.query(`
+      DROP INDEX "public"."IDX_round_summary_round_number"
+    `);
+
+    await queryRunner.query(`
+      DROP INDEX "public"."IDX_round_summary_canvas_id"
+    `);
+
+    await queryRunner.query(`
+      DROP TABLE "round_summary"
+    `);
+  }
+}

--- a/backend/src/entities/game-summary.entity.ts
+++ b/backend/src/entities/game-summary.entity.ts
@@ -1,0 +1,147 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  JoinColumn,
+  OneToOne,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from "typeorm";
+import { Canvas } from "./canvas.entity";
+
+type TopVoterSummary = {
+  voterId: number;
+  name: string;
+  voteCount: number;
+};
+
+type ParticipantSummary = {
+  voterId: number;
+  name: string;
+};
+
+@Entity("game_summary")
+@Index("IDX_game_summary_canvas_id", ["canvas"], { unique: true })
+export class GameSummary {
+  @PrimaryGeneratedColumn()
+  id!: number;
+
+  @OneToOne(() => Canvas, { onDelete: "CASCADE" }) // 추가: 캔버스당 게임 summary 1개
+  @JoinColumn({ name: "canvas_id" })
+  canvas!: Canvas;
+
+  @Column({ type: "int", name: "total_rounds", default: 0 })
+  totalRounds!: number;
+
+  @Column({ type: "int", name: "participant_count", default: 0 })
+  participantCount!: number;
+
+  @Column({ type: "int", name: "issued_ticket_count", default: 0 })
+  issuedTicketCount!: number;
+
+  @Column({ type: "int", name: "total_votes", default: 0 })
+  totalVotes!: number;
+
+  @Column({
+    type: "decimal",
+    name: "ticket_usage_rate",
+    precision: 5,
+    scale: 2,
+    default: 0,
+  })
+  ticketUsageRate!: string;
+
+  @Column({ type: "int", name: "total_cell_count", default: 0 })
+  totalCellCount!: number;
+
+  @Column({ type: "int", name: "painted_cell_count", default: 0 })
+  paintedCellCount!: number;
+
+  @Column({ type: "int", name: "empty_cell_count", default: 0 })
+  emptyCellCount!: number;
+
+  @Column({
+    type: "decimal",
+    name: "canvas_completion_percent",
+    precision: 5,
+    scale: 2,
+    default: 0,
+  })
+  canvasCompletionPercent!: string;
+
+  @Column({ type: "int", name: "most_voted_cell_id", nullable: true }) // 추가: 전체 무투표면 null 가능
+  mostVotedCellId!: number | null;
+
+  @Column({ type: "int", name: "most_voted_cell_x", nullable: true })
+  mostVotedCellX!: number | null;
+
+  @Column({ type: "int", name: "most_voted_cell_y", nullable: true })
+  mostVotedCellY!: number | null;
+
+  @Column({ type: "int", name: "most_voted_cell_vote_count", default: 0 })
+  mostVotedCellVoteCount!: number;
+
+  @Column({ type: "int", name: "random_resolved_cell_count", default: 0 })
+  randomResolvedCellCount!: number;
+
+  @Column({ type: "int", name: "used_color_count", default: 0 })
+  usedColorCount!: number;
+
+  @Column({
+    type: "varchar",
+    length: 32,
+    name: "most_selected_color",
+    nullable: true,
+  })
+  mostSelectedColor!: string | null;
+
+  @Column({ type: "int", name: "most_selected_color_vote_count", default: 0 })
+  mostSelectedColorVoteCount!: number;
+
+  @Column({
+    type: "varchar",
+    length: 32,
+    name: "most_painted_color",
+    nullable: true,
+  })
+  mostPaintedColor!: string | null;
+
+  @Column({ type: "int", name: "most_painted_color_cell_count", default: 0 })
+  mostPaintedColorCellCount!: number;
+
+  @Column({ type: "int", name: "top_voter_id", nullable: true })
+  topVoterId!: number | null;
+
+  @Column({
+    type: "varchar",
+    length: 100,
+    name: "top_voter_name",
+    nullable: true,
+  })
+  topVoterName!: string | null;
+
+  @Column({ type: "int", name: "top_voter_vote_count", default: 0 })
+  topVoterVoteCount!: number;
+
+  @Column({ type: "int", name: "hottest_round_id", nullable: true })
+  hottestRoundId!: number | null;
+
+  @Column({ type: "int", name: "hottest_round_number", nullable: true })
+  hottestRoundNumber!: number | null;
+
+  @Column({ type: "int", name: "hottest_round_vote_count", default: 0 })
+  hottestRoundVoteCount!: number;
+
+  @Column({ type: "simple-json", name: "top_voters_json", nullable: true }) // 추가: 상위 투표자 목록
+  topVotersJson!: TopVoterSummary[] | null;
+
+  @Column({ type: "simple-json", name: "participants_json", nullable: true }) // 추가: 함께한 투표자 목록
+  participantsJson!: ParticipantSummary[] | null;
+
+  @CreateDateColumn({ name: "created_at" })
+  createdAt!: Date;
+
+  @UpdateDateColumn({ name: "updated_at" })
+  updatedAt!: Date;
+}

--- a/backend/src/entities/round-summary.entity.ts
+++ b/backend/src/entities/round-summary.entity.ts
@@ -1,0 +1,77 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  JoinColumn,
+  ManyToOne,
+  OneToOne,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from "typeorm";
+import { Canvas } from "./canvas.entity";
+import { VoteRound } from "./vote-round.entity";
+
+@Entity("round_summary")
+@Index("IDX_round_summary_canvas_id", ["canvas"])
+@Index("IDX_round_summary_round_number", ["roundNumber"])
+export class RoundSummary {
+  @PrimaryGeneratedColumn()
+  id!: number;
+
+  @ManyToOne(() => Canvas, { onDelete: "CASCADE" }) // 추가: 캔버스 단위 조회용
+  @JoinColumn({ name: "canvas_id" })
+  canvas!: Canvas;
+
+  @OneToOne(() => VoteRound, { onDelete: "CASCADE" }) // 추가: 라운드당 summary 1개
+  @JoinColumn({ name: "round_id" })
+  round!: VoteRound;
+
+  @Column({ type: "int", name: "round_number" })
+  roundNumber!: number;
+
+  @Column({ type: "int", name: "participant_count", default: 0 })
+  participantCount!: number;
+
+  @Column({ type: "int", name: "total_votes", default: 0 })
+  totalVotes!: number;
+
+  @Column({ type: "int", name: "painted_cell_count", default: 0 }) // 추가: 이번 라운드에서 반영된 칸 수
+  paintedCellCount!: number;
+
+  @Column({ type: "int", name: "total_cell_count", default: 0 })
+  totalCellCount!: number;
+
+  @Column({ type: "int", name: "current_painted_cell_count", default: 0 }) // 추가: 라운드 종료 시점 누적 색칠 칸 수
+  currentPaintedCellCount!: number;
+
+  @Column({
+    type: "decimal",
+    name: "canvas_progress_percent",
+    precision: 5,
+    scale: 2,
+    default: 0,
+  })
+  canvasProgressPercent!: string;
+
+  @Column({ type: "int", name: "most_voted_cell_id", nullable: true }) // 추가: 무투표 라운드면 null 가능
+  mostVotedCellId!: number | null;
+
+  @Column({ type: "int", name: "most_voted_cell_x", nullable: true })
+  mostVotedCellX!: number | null;
+
+  @Column({ type: "int", name: "most_voted_cell_y", nullable: true })
+  mostVotedCellY!: number | null;
+
+  @Column({ type: "int", name: "most_voted_cell_vote_count", default: 0 })
+  mostVotedCellVoteCount!: number;
+
+  @Column({ type: "int", name: "random_resolved_cell_count", default: 0 }) // 추가: 동점 추첨으로 결정된 칸 수
+  randomResolvedCellCount!: number;
+
+  @CreateDateColumn({ name: "created_at" })
+  createdAt!: Date;
+
+  @UpdateDateColumn({ name: "updated_at" })
+  updatedAt!: Date;
+}


### PR DESCRIPTION
## 관련 이슈
- Close #190 

## 작업 내용
- 라운드 집계와 게임 종료 종합 통계를 저장할 수 있도록 summary 엔티티와 마이그레이션을 추가했습니다.
- 이번 작업은 통계 계산 로직을 붙이기 전 단계로, summary snapshot을 저장할 구조를 마련하는 데 집중했습니다.

## 변경 내용
- `RoundSummary` 엔티티 추가
- `GameSummary` 엔티티 추가
- backend data source에 신규 summary 엔티티 등록
- `round_summary`, `game_summary` 테이블 생성 migration 추가
- 라운드/게임 집계에 필요한 핵심 숫자 컬럼과 JSON 컬럼 구조 정의

## 설계 방향
- 원본 데이터는 기존 `vote`, `vote_ticket`, `vote_round`, `cell`, `voter` 테이블을 source of truth로 유지
- 라운드 종료 시 `round_summary` snapshot 저장
- 게임 종료 시 `game_summary` snapshot 저장
- 이후 summary 조회 API와 통계 모달은 이 저장 구조를 기반으로 구현 예정

## 기대 효과
- 라운드 종료/게임 종료 시점의 집계 결과를 별도 summary 구조로 저장할 수 있습니다.
- 통계 계산 로직과 조회/UI 로직을 분리하기 쉬워집니다.
- 이후 통계 모달/장표 작업의 기반이 마련됩니다.

## 마이그레이션 파일 적용
- docker compose exec backend npm run migration:run
<img width="1048" height="207" alt="image" src="https://github.com/user-attachments/assets/737cdcf8-5b79-4f97-a0ca-b22ac1adc9e5" />

(이하 신규 엔티티 및 제약 조건 생략)

## 테스트 항목
- [x] `round_summary` 엔티티가 data source에 정상 등록되는지 확인
- [x] `game_summary` 엔티티가 data source에 정상 등록되는지 확인
- [x] 마이그레이션 실행 시 `round_summary` 테이블이 정상 생성되는지 확인
- [x] 마이그레이션 실행 시 `game_summary` 테이블이 정상 생성되는지 확인
- [x] `round_summary.round_id` unique 제약조건이 정상 생성되는지 확인
- [x] `game_summary.canvas_id` unique 제약조건이 정상 생성되는지 확인
- [x] `round_summary.canvas_id`, `round_summary.round_number` 인덱스가 정상 생성되는지 확인
- [x] `game_summary.canvas_id` 인덱스가 정상 생성되는지 확인
- [x] FK 제약조건이 `canvas`, `vote_round`와 정상 연결되는지 확인

## 참고
- 이번 PR에는 실제 통계 계산/저장 로직과 summary 조회 API는 포함하지 않았습니다.
- 다음 단계에서 라운드 종료/게임 종료 시 summary를 계산해 저장하는 서비스 로직을 추가할 예정입니다.