### PR TITLE
feat: 라운드 종료 및 게임 종료 summary 저장 지원

### DIFF
--- a/backend/src/modules/game/game.timer.ts
+++ b/backend/src/modules/game/game.timer.ts
@@ -7,6 +7,7 @@ import { AppDataSource } from "../../database/data-source";
 import { Canvas, CanvasStatus } from "../../entities/canvas.entity";
 import { VoteRound } from "../../entities/vote-round.entity";
 import { roundService } from "../round/round.service";
+import { summaryService } from "../summary/summary.service"; // 추가: 게임 summary 저장 서비스
 import { GamePhase } from "./game-phase.types";
 
 const canvasRepository = AppDataSource.getRepository(Canvas);
@@ -188,6 +189,7 @@ async function transitionToGameEnd(
     phaseEndsAt,
     reason: "game end transition",
   });
+  await summaryService.saveGameSummary(canvasId); // 추가: GAME_END 진입 시점 종합 통계 snapshot 저장
 
   scheduleGameEnd(io, canvasId, roundNumber, phaseEndsAt);
 }

--- a/backend/src/modules/round/round.service.ts
+++ b/backend/src/modules/round/round.service.ts
@@ -14,6 +14,7 @@ import { Vote } from "../../entities/vote.entity";
 import { Voter } from "../../entities/voter.entity";
 import { GamePhase } from "../game/game-phase.types";
 import { participantSessionService } from "../participant/participant-session.service";
+import { summaryService } from "../summary/summary.service"; // 추가: 라운드 summary 저장 서비스
 import { voteService } from "../vote/vote.service";
 
 const canvasRepository = AppDataSource.getRepository(Canvas);
@@ -371,6 +372,8 @@ export const roundService = {
       reason: "라운드 결과 전환",
     });
 
+    await summaryService.saveRoundSummary(canvasId, round.id); // 추가: 라운드 종료 시점 summary snapshot 저장
+
     await redisClient.del(redisKey);
     await voteService.clearIssuedVoters(round.id);
 
@@ -379,7 +382,6 @@ export const roundService = {
         roundId: round.id,
         roundNumber: round.roundNumber,
         endedAt: round.endedAt,
-        winningCell: null, // 변경: 단일 당선 셀 개념 제거, batch update로 대체
       });
 
       io.to(`canvas:${canvasId}`).emit("canvas:batch-updated", {

--- a/backend/src/modules/summary/summary.service.ts
+++ b/backend/src/modules/summary/summary.service.ts
@@ -1,0 +1,377 @@
+import { AppDataSource } from "../../database/data-source";
+import { Cell, CellStatus } from "../../entities/cell.entity";
+import { Canvas } from "../../entities/canvas.entity";
+import { GameSummary } from "../../entities/game-summary.entity";
+import { RoundSummary } from "../../entities/round-summary.entity";
+import { VoteRound } from "../../entities/vote-round.entity";
+import { VoteTicket } from "../../entities/vote-ticket.entity";
+import { Vote } from "../../entities/vote.entity";
+
+const canvasRepository = AppDataSource.getRepository(Canvas);
+const cellRepository = AppDataSource.getRepository(Cell);
+const voteRepository = AppDataSource.getRepository(Vote);
+const voteTicketRepository = AppDataSource.getRepository(VoteTicket);
+const voteRoundRepository = AppDataSource.getRepository(VoteRound);
+const roundSummaryRepository = AppDataSource.getRepository(RoundSummary);
+const gameSummaryRepository = AppDataSource.getRepository(GameSummary);
+
+type TopCellAggregate = {
+  cellId: number;
+  x: number;
+  y: number;
+  voteCount: number;
+};
+
+type TopColorAggregate = {
+  color: string;
+  voteCount: number;
+};
+
+type TopVoterAggregate = {
+  voterId: number;
+  name: string;
+  voteCount: number;
+};
+
+function toPercent(numerator: number, denominator: number): string {
+  if (denominator <= 0) {
+    return "0.00";
+  }
+
+  return ((numerator / denominator) * 100).toFixed(2); // 추가: summary 컬럼 형식에 맞춰 소수점 2자리 문자열 반환
+}
+
+function buildMostVotedCell(
+  cellVoteMap: Map<
+    number,
+    {
+      x: number;
+      y: number;
+      voteCount: number;
+    }
+  >,
+): TopCellAggregate | null {
+  let topCell: TopCellAggregate | null = null;
+
+  for (const [cellId, value] of cellVoteMap.entries()) {
+    if (!topCell || value.voteCount > topCell.voteCount) {
+      topCell = {
+        cellId,
+        x: value.x,
+        y: value.y,
+        voteCount: value.voteCount,
+      };
+    }
+  }
+
+  return topCell;
+}
+
+export const summaryService = {
+  async saveRoundSummary(
+    canvasId: number,
+    roundId: number,
+  ): Promise<RoundSummary> {
+    const round = await voteRoundRepository.findOne({
+      where: { id: roundId, canvas: { id: canvasId } },
+    });
+
+    if (!round) {
+      throw new Error("Round was not found.");
+    }
+
+    const canvas = await canvasRepository.findOne({
+      where: { id: canvasId },
+    });
+
+    if (!canvas) {
+      throw new Error("Canvas was not found.");
+    }
+
+    const [votes, totalCellCount, currentPaintedCellCount] = await Promise.all([
+      voteRepository.find({
+        where: { round: { id: roundId } },
+        relations: ["cell", "voter"],
+      }),
+      cellRepository.count({
+        where: { canvas: { id: canvasId } },
+      }),
+      cellRepository.count({
+        where: { canvas: { id: canvasId }, status: CellStatus.PAINTED },
+      }),
+    ]);
+
+    const participantIds = new Set<number>();
+    const paintedCellIds = new Set<number>();
+    const cellVoteMap = new Map<
+      number,
+      {
+        x: number;
+        y: number;
+        voteCount: number;
+      }
+    >();
+    const colorBucketsByCell = new Map<number, Map<string, number>>();
+
+    for (const vote of votes) {
+      participantIds.add(vote.voter.id);
+      paintedCellIds.add(vote.cell.id);
+
+      const cellAggregate = cellVoteMap.get(vote.cell.id);
+
+      if (cellAggregate) {
+        cellAggregate.voteCount += 1;
+      } else {
+        cellVoteMap.set(vote.cell.id, {
+          x: vote.cell.x,
+          y: vote.cell.y,
+          voteCount: 1,
+        });
+      }
+
+      const colorBuckets =
+        colorBucketsByCell.get(vote.cell.id) ?? new Map<string, number>();
+      colorBuckets.set(vote.color, (colorBuckets.get(vote.color) ?? 0) + 1);
+      colorBucketsByCell.set(vote.cell.id, colorBuckets);
+    }
+
+    let randomResolvedCellCount = 0;
+
+    for (const colorBuckets of colorBucketsByCell.values()) {
+      let maxVotes = 0;
+      let maxCountColors = 0;
+
+      for (const voteCount of colorBuckets.values()) {
+        if (voteCount > maxVotes) {
+          maxVotes = voteCount;
+          maxCountColors = 1;
+          continue;
+        }
+
+        if (voteCount === maxVotes) {
+          maxCountColors += 1;
+        }
+      }
+
+      if (maxCountColors > 1) {
+        randomResolvedCellCount += 1; // 추가: 칸 내부 색상 동점으로 랜덤 선택된 경우 집계
+      }
+    }
+
+    const mostVotedCell = buildMostVotedCell(cellVoteMap);
+
+    const summary = roundSummaryRepository.create({
+      canvas: { id: canvasId },
+      round: { id: roundId },
+      roundNumber: round.roundNumber,
+      participantCount: participantIds.size,
+      totalVotes: votes.length,
+      paintedCellCount: paintedCellIds.size,
+      totalCellCount,
+      currentPaintedCellCount,
+      canvasProgressPercent: toPercent(currentPaintedCellCount, totalCellCount),
+      mostVotedCellId: mostVotedCell?.cellId ?? null,
+      mostVotedCellX: mostVotedCell?.x ?? null,
+      mostVotedCellY: mostVotedCell?.y ?? null,
+      mostVotedCellVoteCount: mostVotedCell?.voteCount ?? 0,
+      randomResolvedCellCount,
+    });
+
+    return roundSummaryRepository.save(summary); // 추가: 라운드 종료 시점 snapshot 저장
+  },
+
+  async saveGameSummary(canvasId: number): Promise<GameSummary> {
+    const canvas = await canvasRepository.findOne({
+      where: { id: canvasId },
+    });
+
+    if (!canvas) {
+      throw new Error("Canvas was not found.");
+    }
+
+    const [votes, tickets, rounds, cells, existingSummary] = await Promise.all([
+      voteRepository.find({
+        where: { round: { canvas: { id: canvasId } } },
+        relations: ["cell", "voter", "round"],
+      }),
+      voteTicketRepository.find({
+        where: { round: { canvas: { id: canvasId } } },
+      }),
+      voteRoundRepository.find({
+        where: { canvas: { id: canvasId } },
+      }),
+      cellRepository.find({
+        where: { canvas: { id: canvasId } },
+      }),
+      gameSummaryRepository.findOne({
+        where: { canvas: { id: canvasId } },
+      }),
+    ]);
+
+    const participantMap = new Map<number, { voterId: number; name: string }>();
+    const voterCountMap = new Map<number, TopVoterAggregate>();
+    const cellVoteMap = new Map<
+      number,
+      { x: number; y: number; voteCount: number }
+    >();
+    const colorVoteMap = new Map<string, number>();
+    const roundVoteMap = new Map<
+      number,
+      { roundNumber: number; voteCount: number }
+    >();
+
+    for (const vote of votes) {
+      participantMap.set(vote.voter.id, {
+        voterId: vote.voter.id,
+        name: vote.voter.nickname,
+      });
+
+      const voterAggregate = voterCountMap.get(vote.voter.id);
+      if (voterAggregate) {
+        voterAggregate.voteCount += 1;
+      } else {
+        voterCountMap.set(vote.voter.id, {
+          voterId: vote.voter.id,
+          name: vote.voter.nickname,
+          voteCount: 1,
+        });
+      }
+
+      const cellAggregate = cellVoteMap.get(vote.cell.id);
+      if (cellAggregate) {
+        cellAggregate.voteCount += 1;
+      } else {
+        cellVoteMap.set(vote.cell.id, {
+          x: vote.cell.x,
+          y: vote.cell.y,
+          voteCount: 1,
+        });
+      }
+
+      colorVoteMap.set(vote.color, (colorVoteMap.get(vote.color) ?? 0) + 1);
+
+      const roundAggregate = roundVoteMap.get(vote.round.id);
+      if (roundAggregate) {
+        roundAggregate.voteCount += 1;
+      } else {
+        roundVoteMap.set(vote.round.id, {
+          roundNumber: vote.round.roundNumber,
+          voteCount: 1,
+        });
+      }
+    }
+
+    const mostVotedCell = buildMostVotedCell(cellVoteMap);
+
+    let mostSelectedColor: TopColorAggregate | null = null;
+    for (const [color, voteCount] of colorVoteMap.entries()) {
+      if (!mostSelectedColor || voteCount > mostSelectedColor.voteCount) {
+        mostSelectedColor = { color, voteCount };
+      }
+    }
+
+    const paintedColorMap = new Map<string, number>();
+    let paintedCellCount = 0;
+
+    for (const cell of cells) {
+      if (cell.status !== CellStatus.PAINTED || !cell.color) {
+        continue;
+      }
+
+      paintedCellCount += 1;
+      paintedColorMap.set(
+        cell.color,
+        (paintedColorMap.get(cell.color) ?? 0) + 1,
+      );
+    }
+
+    let mostPaintedColor: TopColorAggregate | null = null;
+    for (const [color, count] of paintedColorMap.entries()) {
+      if (!mostPaintedColor || count > mostPaintedColor.voteCount) {
+        mostPaintedColor = { color, voteCount: count };
+      }
+    }
+
+    let topVoter: TopVoterAggregate | null = null;
+    for (const voterAggregate of voterCountMap.values()) {
+      if (!topVoter || voterAggregate.voteCount > topVoter.voteCount) {
+        topVoter = voterAggregate;
+      }
+    }
+
+    let hottestRound: {
+      roundId: number;
+      roundNumber: number;
+      voteCount: number;
+    } | null = null;
+
+    for (const round of rounds) {
+      const roundAggregate = roundVoteMap.get(round.id);
+      const voteCount = roundAggregate?.voteCount ?? 0;
+
+      if (!hottestRound || voteCount > hottestRound.voteCount) {
+        hottestRound = {
+          roundId: round.id,
+          roundNumber: round.roundNumber,
+          voteCount,
+        };
+      }
+    }
+
+    const totalCellCount = cells.length;
+    const emptyCellCount = Math.max(0, totalCellCount - paintedCellCount);
+
+    const roundSummaries = await roundSummaryRepository.find({
+      where: { canvas: { id: canvasId } },
+      order: { roundNumber: "ASC" },
+    });
+
+    const randomResolvedCellCount = roundSummaries.reduce(
+      (sum, summary) => sum + summary.randomResolvedCellCount,
+      0,
+    ); // 추가: 게임 전체 랜덤 추첨 칸 수는 라운드 summary 누적합 사용
+
+    const nextSummary = gameSummaryRepository.create({
+      id: existingSummary?.id,
+      canvas: { id: canvasId },
+      totalRounds: rounds.length,
+      participantCount: participantMap.size,
+      issuedTicketCount: tickets.length,
+      totalVotes: votes.length,
+      ticketUsageRate: toPercent(votes.length, tickets.length),
+      totalCellCount,
+      paintedCellCount,
+      emptyCellCount,
+      canvasCompletionPercent: toPercent(paintedCellCount, totalCellCount),
+      mostVotedCellId: mostVotedCell?.cellId ?? null,
+      mostVotedCellX: mostVotedCell?.x ?? null,
+      mostVotedCellY: mostVotedCell?.y ?? null,
+      mostVotedCellVoteCount: mostVotedCell?.voteCount ?? 0,
+      randomResolvedCellCount,
+      usedColorCount: colorVoteMap.size,
+      mostSelectedColor: mostSelectedColor?.color ?? null,
+      mostSelectedColorVoteCount: mostSelectedColor?.voteCount ?? 0,
+      mostPaintedColor: mostPaintedColor?.color ?? null,
+      mostPaintedColorCellCount: mostPaintedColor?.voteCount ?? 0,
+      topVoterId: topVoter?.voterId ?? null,
+      topVoterName: topVoter?.name ?? null,
+      topVoterVoteCount: topVoter?.voteCount ?? 0,
+      hottestRoundId: hottestRound?.roundId ?? null,
+      hottestRoundNumber: hottestRound?.roundNumber ?? null,
+      hottestRoundVoteCount: hottestRound?.voteCount ?? 0,
+      topVotersJson: Array.from(voterCountMap.values())
+        .sort((a, b) => b.voteCount - a.voteCount)
+        .slice(0, 10)
+        .map((voter) => ({
+          voterId: voter.voterId,
+          name: voter.name,
+          voteCount: voter.voteCount,
+        })), // 추가: 상위 투표자 목록 저장
+      participantsJson: Array.from(participantMap.values()).sort((a, b) =>
+        a.name.localeCompare(b.name),
+      ), // 추가: 함께한 투표자 목록 저장
+    });
+
+    return gameSummaryRepository.save(nextSummary); // 추가: 게임 종료 시점 summary upsert
+  },
+};

--- a/frontend/src/features/gameplay/session/model/socket.types.ts
+++ b/frontend/src/features/gameplay/session/model/socket.types.ts
@@ -17,7 +17,6 @@ export interface RoundEndedPayload {
   roundId: number;
   roundNumber: number;
   endedAt: string;
-  winningCell: { id: number; x: number; y: number; color: string } | null;
 }
 
 export interface CanvasUpdatedPayload {


### PR DESCRIPTION
## 관련 이슈
- Close #192 

## 작업 내용
- 라운드 종료 시 `round_summary`를 계산해 저장하고, 게임 종료 시 `game_summary`를 계산해 저장하는 로직을 추가했습니다.
- summary 계산 책임을 별도 서비스로 분리해 이후 통계 조회 API와 통계 모달 작업의 기반을 마련했습니다.

## 변경 내용
- `summary.service` 추가
- 라운드 종료 시점 `round_summary` 계산 및 저장 로직 추가
- 게임 종료 시점 `game_summary` 계산 및 저장 로직 추가
- 참여 인원 수, 총 투표 수, 반영된 칸 수, 진행도, 가장 표를 많이 받은 칸, 랜덤 추첨 칸 수 등 라운드 집계 계산
- 총 라운드 수, 총 지급 투표권 수, 총 투표 수, 투표권 사용률, 완성도, 색상 통계, 최다 투표 유저, 가장 뜨거웠던 라운드 등 게임 집계 계산
- 기존 `round:ended` payload에서 더 이상 사용하지 않는 `winningCell` 제거

## 기대 효과
- 라운드 결과와 게임 종료 통계를 snapshot 형태로 DB에 저장할 수 있습니다.
- 이후 summary 조회 API와 프론트 통계 모달 구현이 단순해집니다.
- 통계 계산 로직이 라운드/게임 전환 로직과 분리되어 유지보수가 쉬워집니다.

## 테스트 항목
- [x] 라운드 종료 시 `round_summary`가 정상 저장되는지 확인
<img width="1296" height="50" alt="image" src="https://github.com/user-attachments/assets/b2297d56-3b3f-469c-b6da-39bc6cefc5b2" />

- [x] `round_summary`의 투표 인원 수, 총 투표 수, 반영된 칸 수가 기대값과 일치하는지 확인
- [x] `round_summary`의 가장 표를 많이 받은 칸과 랜덤 추첨 칸 수가 기대값과 일치하는지 확인
- [x] 게임 종료 시 `game_summary`가 정상 저장되는지 확인

- [x] `game_summary`의 총 투표 수, 총 지급 투표권 수, 투표권 사용률이 기대값과 일치하는지 확인
<img width="1345" height="32" alt="image" src="https://github.com/user-attachments/assets/3309f910-0554-44b9-90c5-869f66093dc5" />

- [x] `game_summary`의 완성도, 색칠된 칸 수, 빈 칸 수가 기대값과 일치하는지 확인
- [x] `game_summary`의 색상 통계, 최다 투표 유저, 가장 뜨거웠던 라운드가 기대값과 일치하는지 확인

## 참고
- 이번 PR은 summary 계산/저장까지를 다루며, summary 조회 API와 통계 장표 UI는 다음 단계에서 이어서 작업할 예정입니다.