### PR TITLE
feat: game summary를 raw 데이터 기준으로 독립 집계

### DIFF
--- a/backend/src/modules/summary/summary.service.ts
+++ b/backend/src/modules/summary/summary.service.ts
@@ -38,7 +38,7 @@ function toPercent(numerator: number, denominator: number): string {
     return "0.00";
   }
 
-  return ((numerator / denominator) * 100).toFixed(2); // 추가: summary 컬럼 형식에 맞춰 소수점 2자리 문자열 반환
+  return ((numerator / denominator) * 100).toFixed(2);
 }
 
 function buildMostVotedCell(
@@ -67,6 +67,44 @@ function buildMostVotedCell(
   return topCell;
 }
 
+function countRandomResolvedCellsFromVotes(votes: Vote[]): number {
+  const colorBucketsByRoundCell = new Map<string, Map<string, number>>();
+
+  for (const vote of votes) {
+    const roundCellKey = `${vote.round.id}:${vote.cell.id}`;
+    const colorBuckets =
+      colorBucketsByRoundCell.get(roundCellKey) ?? new Map<string, number>();
+
+    colorBuckets.set(vote.color, (colorBuckets.get(vote.color) ?? 0) + 1);
+    colorBucketsByRoundCell.set(roundCellKey, colorBuckets);
+  }
+
+  let randomResolvedCellCount = 0;
+
+  for (const colorBuckets of colorBucketsByRoundCell.values()) {
+    let maxVotes = 0;
+    let maxCountColors = 0;
+
+    for (const voteCount of colorBuckets.values()) {
+      if (voteCount > maxVotes) {
+        maxVotes = voteCount;
+        maxCountColors = 1;
+        continue;
+      }
+
+      if (voteCount === maxVotes) {
+        maxCountColors += 1;
+      }
+    }
+
+    if (maxCountColors > 1) {
+      randomResolvedCellCount += 1;
+    }
+  }
+
+  return randomResolvedCellCount;
+}
+
 export const summaryService = {
   async saveRoundSummary(
     canvasId: number,
@@ -91,7 +129,7 @@ export const summaryService = {
     const [votes, totalCellCount, currentPaintedCellCount] = await Promise.all([
       voteRepository.find({
         where: { round: { id: roundId } },
-        relations: ["cell", "voter"],
+        relations: ["cell", "voter", "round"],
       }),
       cellRepository.count({
         where: { canvas: { id: canvasId } },
@@ -154,7 +192,7 @@ export const summaryService = {
       }
 
       if (maxCountColors > 1) {
-        randomResolvedCellCount += 1; // 추가: 칸 내부 색상 동점으로 랜덤 선택된 경우 집계
+        randomResolvedCellCount += 1;
       }
     }
 
@@ -177,7 +215,7 @@ export const summaryService = {
       randomResolvedCellCount,
     });
 
-    return roundSummaryRepository.save(summary); // 추가: 라운드 종료 시점 snapshot 저장
+    return roundSummaryRepository.save(summary);
   },
 
   async saveGameSummary(canvasId: number): Promise<GameSummary> {
@@ -320,16 +358,7 @@ export const summaryService = {
 
     const totalCellCount = cells.length;
     const emptyCellCount = Math.max(0, totalCellCount - paintedCellCount);
-
-    const roundSummaries = await roundSummaryRepository.find({
-      where: { canvas: { id: canvasId } },
-      order: { roundNumber: "ASC" },
-    });
-
-    const randomResolvedCellCount = roundSummaries.reduce(
-      (sum, summary) => sum + summary.randomResolvedCellCount,
-      0,
-    ); // 추가: 게임 전체 랜덤 추첨 칸 수는 라운드 summary 누적합 사용
+    const randomResolvedCellCount = countRandomResolvedCellsFromVotes(votes);
 
     const nextSummary = gameSummaryRepository.create({
       id: existingSummary?.id,
@@ -366,12 +395,12 @@ export const summaryService = {
           voterId: voter.voterId,
           name: voter.name,
           voteCount: voter.voteCount,
-        })), // 추가: 상위 투표자 목록 저장
+        })),
       participantsJson: Array.from(participantMap.values()).sort((a, b) =>
         a.name.localeCompare(b.name),
-      ), // 추가: 함께한 투표자 목록 저장
+      ),
     });
 
-    return gameSummaryRepository.save(nextSummary); // 추가: 게임 종료 시점 summary upsert
+    return gameSummaryRepository.save(nextSummary);
   },
 };


### PR DESCRIPTION
## 관련 이슈
- Close #195 

## 요약
- `game_summary`가 `round_summary`에 의존하지 않도록 정리했습니다.
- 게임 집계는 이제 `vote`, `vote_ticket`, `vote_round`, `cell`, `voter` raw 데이터를 직접 읽어 독립적으로 계산합니다.

## 변경 내용
- `game_summary` 계산 로직에서 `round_summary` 참조 제거
- `randomResolvedCellCount`를 `round_summary` 합산이 아니라 raw `vote` 데이터를 라운드/칸별로 다시 계산하는 방식으로 변경
- 게임 종료 통계가 라운드 summary 저장 성공 여부와 무관하게 계산되도록 구조 정리

## 기대 효과
- 일부 라운드 summary 저장이 실패해도 게임 summary는 영향을 받지 않습니다.
- 라운드 집계와 게임 집계의 책임이 분리됩니다.
- 게임 종료 통계의 신뢰도가 높아집니다.

## 테스트 항목
- [x] `game_summary`가 `round_summary` 없이도 정상 저장되는지 확인
- [x] 일부 `round_summary` 데이터가 없더라도 `game_summary`가 정상 계산되는지 확인
- [x] 라운드 집계의 랜덤 다수 투표 집계 삭제 후 게임 집계 확인 - 다수 랜덤 투표 값 업데이트 확인
<img width="696" height="359" alt="image" src="https://github.com/user-attachments/assets/3a9ae57d-e7b0-4cc9-ab2e-fa7c13cb9497" />

<img width="274" height="64" alt="image" src="https://github.com/user-attachments/assets/88d3778e-b850-480d-abdc-65888b37b06f" />
