### PR TITLE
feat: round/game summary 조회 API 및 ready 이벤트 추가

### DIFF
--- a/backend/src/modules/canvas/canvas.controller.ts
+++ b/backend/src/modules/canvas/canvas.controller.ts
@@ -158,10 +158,11 @@ export const canvasController = {
 
       const summary = await summaryService.getGameSummary(canvasId);
 
-      return res.json(serializeGameSummary(summary));
+      return res.json({
+        data: serializeGameSummary(summary),
+      });
     } catch (err) {
       return res.status(400).json({ message: String(err) });
     }
   },
-
 };

--- a/backend/src/modules/canvas/canvas.controller.ts
+++ b/backend/src/modules/canvas/canvas.controller.ts
@@ -4,6 +4,8 @@ import { getCanvasGameConfigSnapshot } from "../../config/game.config";
 import { Canvas } from "../../entities/canvas.entity";
 import { Cell } from "../../entities/cell.entity";
 import { canvasService } from "./canvas.service";
+import { GameSummary } from "../../entities/game-summary.entity";
+import { summaryService } from "../summary/summary.service";
 
 interface CreateCanvasRequestBody {
   profileKey?: string;
@@ -34,6 +36,44 @@ function serializeCell(cell: Cell) {
     status: cell.status,
   };
 }
+
+// 게임 summary 응답 구조를 명시적으로 고정
+function serializeGameSummary(summary: GameSummary) {
+  return {
+    id: summary.id,
+    canvasId: summary.canvas.id,
+    totalRounds: summary.totalRounds,
+    participantCount: summary.participantCount,
+    issuedTicketCount: summary.issuedTicketCount,
+    totalVotes: summary.totalVotes,
+    ticketUsageRate: summary.ticketUsageRate,
+    totalCellCount: summary.totalCellCount,
+    paintedCellCount: summary.paintedCellCount,
+    emptyCellCount: summary.emptyCellCount,
+    canvasCompletionPercent: summary.canvasCompletionPercent,
+    mostVotedCellId: summary.mostVotedCellId,
+    mostVotedCellX: summary.mostVotedCellX,
+    mostVotedCellY: summary.mostVotedCellY,
+    mostVotedCellVoteCount: summary.mostVotedCellVoteCount,
+    randomResolvedCellCount: summary.randomResolvedCellCount,
+    usedColorCount: summary.usedColorCount,
+    mostSelectedColor: summary.mostSelectedColor,
+    mostSelectedColorVoteCount: summary.mostSelectedColorVoteCount,
+    mostPaintedColor: summary.mostPaintedColor,
+    mostPaintedColorCellCount: summary.mostPaintedColorCellCount,
+    topVoterId: summary.topVoterId,
+    topVoterName: summary.topVoterName,
+    topVoterVoteCount: summary.topVoterVoteCount,
+    hottestRoundId: summary.hottestRoundId,
+    hottestRoundNumber: summary.hottestRoundNumber,
+    hottestRoundVoteCount: summary.hottestRoundVoteCount,
+    topVoters: summary.topVotersJson,
+    participants: summary.participantsJson,
+    createdAt: summary.createdAt,
+    updatedAt: summary.updatedAt,
+  };
+}
+
 
 export const canvasController = {
   async create(req: Request, res: Response) {
@@ -107,4 +147,21 @@ export const canvasController = {
       return res.status(500).json({ message: String(err) });
     }
   },
+
+  async getSummary(req: Request, res: Response) {
+    try {
+      const canvasId = parseInt(String(req.params["canvasId"]));
+
+      if (isNaN(canvasId)) {
+        return res.status(400).json({ message: "존재하지 않는 캔버스입니다." });
+      }
+
+      const summary = await summaryService.getGameSummary(canvasId);
+
+      return res.json(serializeGameSummary(summary));
+    } catch (err) {
+      return res.status(400).json({ message: String(err) });
+    }
+  },
+
 };

--- a/backend/src/modules/canvas/canvas.router.ts
+++ b/backend/src/modules/canvas/canvas.router.ts
@@ -16,5 +16,7 @@ router.get(
     authMiddleware,
     canvasController.getCurrentParticipantList,
 );
+router.get("/:canvasId/summary", authMiddleware, canvasController.getSummary);
+
 
 export default router;

--- a/backend/src/modules/game/game.timer.ts
+++ b/backend/src/modules/game/game.timer.ts
@@ -29,10 +29,10 @@ function getGameEndAt(
 
   return new Date(
     roundStartedAt.getTime() +
-      remainingRoundsIncludingCurrent * config.phases.roundDurationSec * 1000 +
-      Math.max(0, remainingRoundsIncludingCurrent - 1) *
-        config.phases.roundResultDelaySec *
-        1000,
+    remainingRoundsIncludingCurrent * config.phases.roundDurationSec * 1000 +
+    Math.max(0, remainingRoundsIncludingCurrent - 1) *
+    config.phases.roundResultDelaySec *
+    1000,
   );
 }
 
@@ -189,7 +189,13 @@ async function transitionToGameEnd(
     phaseEndsAt,
     reason: "game end transition",
   });
-  await summaryService.saveGameSummary(canvasId); // 추가: GAME_END 진입 시점 종합 통계 snapshot 저장
+
+  const gameSummary = await summaryService.saveGameSummary(canvasId);
+
+  io.to(`canvas:${canvasId}`).emit("game-summary:ready", {
+    canvasId,
+    summaryId: gameSummary.id,
+  });
 
   scheduleGameEnd(io, canvasId, roundNumber, phaseEndsAt);
 }
@@ -528,7 +534,7 @@ async function resumeRoundActive(io: Server, canvas: Canvas): Promise<void> {
 
   const roundEndsAt = new Date(
     activeRound.startedAt.getTime() +
-      canvasGameConfig.phases.roundDurationSec * 1000,
+    canvasGameConfig.phases.roundDurationSec * 1000,
   );
 
   if (roundEndsAt.getTime() <= Date.now()) {

--- a/backend/src/modules/round/round.controller.ts
+++ b/backend/src/modules/round/round.controller.ts
@@ -89,12 +89,16 @@ export const roundController = {
       const roundId = parseInt(String(req.params["roundId"]));
 
       if (isNaN(canvasId) || isNaN(roundId)) {
-        return res.status(400).json({ message: "존재하지 않는 캔버스 또는 라운드입니다." });
+        return res
+          .status(400)
+          .json({ message: "존재하지 않는 캔버스 또는 라운드입니다." });
       }
 
       const summary = await summaryService.getRoundSummary(canvasId, roundId);
 
-      return res.json(serializeRoundSummary(summary));
+      return res.json({
+        data: serializeRoundSummary(summary),
+      });
     } catch (err) {
       return res.status(400).json({ message: String(err) });
     }

--- a/backend/src/modules/round/round.controller.ts
+++ b/backend/src/modules/round/round.controller.ts
@@ -1,6 +1,31 @@
 import { Request, Response } from "express";
 import { Server } from "socket.io";
 import { roundService } from "./round.service";
+import { RoundSummary } from "../../entities/round-summary.entity";
+import { summaryService } from "../summary/summary.service";
+
+// 엔티티를 그대로 노출하지 않고 API 응답 필드를 명시적으로 고정
+function serializeRoundSummary(summary: RoundSummary) {
+  return {
+    id: summary.id,
+    canvasId: summary.canvas.id,
+    roundId: summary.round.id,
+    roundNumber: summary.roundNumber,
+    participantCount: summary.participantCount,
+    totalVotes: summary.totalVotes,
+    paintedCellCount: summary.paintedCellCount,
+    totalCellCount: summary.totalCellCount,
+    currentPaintedCellCount: summary.currentPaintedCellCount,
+    canvasProgressPercent: summary.canvasProgressPercent,
+    mostVotedCellId: summary.mostVotedCellId,
+    mostVotedCellX: summary.mostVotedCellX,
+    mostVotedCellY: summary.mostVotedCellY,
+    mostVotedCellVoteCount: summary.mostVotedCellVoteCount,
+    randomResolvedCellCount: summary.randomResolvedCellCount,
+    createdAt: summary.createdAt,
+    updatedAt: summary.updatedAt,
+  };
+}
 
 export const roundController = {
   async startRound(req: Request, res: Response) {
@@ -55,6 +80,23 @@ export const roundController = {
       return res.json(roundState);
     } catch (err) {
       return res.status(500).json({ message: String(err) });
+    }
+  },
+
+  async getRoundSummary(req: Request, res: Response) {
+    try {
+      const canvasId = parseInt(String(req.params["canvasId"]));
+      const roundId = parseInt(String(req.params["roundId"]));
+
+      if (isNaN(canvasId) || isNaN(roundId)) {
+        return res.status(400).json({ message: "존재하지 않는 캔버스 또는 라운드입니다." });
+      }
+
+      const summary = await summaryService.getRoundSummary(canvasId, roundId);
+
+      return res.json(serializeRoundSummary(summary));
+    } catch (err) {
+      return res.status(400).json({ message: String(err) });
     }
   },
 };

--- a/backend/src/modules/round/round.router.ts
+++ b/backend/src/modules/round/round.router.ts
@@ -7,5 +7,6 @@ const router = Router({ mergeParams: true });
 router.post("/", authMiddleware, roundController.startRound);
 router.post("/:roundId/end", authMiddleware, roundController.endRound);
 router.get("/active", authMiddleware, roundController.getActiveRound);
+router.get("/:roundId/summary", authMiddleware, roundController.getRoundSummary);
 
 export default router;

--- a/backend/src/modules/round/round.service.ts
+++ b/backend/src/modules/round/round.service.ts
@@ -80,10 +80,10 @@ function getActiveGameEndAt(
 
   return new Date(
     roundStartedAt.getTime() +
-      remainingRoundsIncludingCurrent * config.phases.roundDurationSec * 1000 +
-      Math.max(0, remainingRoundsIncludingCurrent - 1) *
-        config.phases.roundResultDelaySec *
-        1000,
+    remainingRoundsIncludingCurrent * config.phases.roundDurationSec * 1000 +
+    Math.max(0, remainingRoundsIncludingCurrent - 1) *
+    config.phases.roundResultDelaySec *
+    1000,
   );
 }
 
@@ -96,9 +96,9 @@ function getWaitingGameEndAt(
 
   return new Date(
     roundEndedAt.getTime() +
-      config.phases.roundResultDelaySec * 1000 +
-      futureRounds * config.phases.roundDurationSec * 1000 +
-      Math.max(0, futureRounds - 1) * config.phases.roundResultDelaySec * 1000,
+    config.phases.roundResultDelaySec * 1000 +
+    futureRounds * config.phases.roundDurationSec * 1000 +
+    Math.max(0, futureRounds - 1) * config.phases.roundResultDelaySec * 1000,
   );
 }
 
@@ -129,7 +129,7 @@ export const roundService = {
     const roundStartedAt = new Date();
     const roundEndsAt = new Date(
       roundStartedAt.getTime() +
-        canvasGameConfig.phases.roundDurationSec * 1000,
+      canvasGameConfig.phases.roundDurationSec * 1000,
     );
 
     const round = voteRoundRepository.create({
@@ -245,7 +245,7 @@ export const roundService = {
     const redisKey = `vote:round:${roundId}`;
     const voteData = await redisClient.hGetAll(redisKey);
 
-    const voteBuckets = new Map<number, Map<string, number>>(); // 추가: 칸별 색상 득표 집계
+    const voteBuckets = new Map<number, Map<string, number>>();
 
     const addVoteBucket = (cellId: number, color: string, count: number) => {
       const colorBuckets = voteBuckets.get(cellId) ?? new Map<string, number>();
@@ -278,11 +278,11 @@ export const roundService = {
       });
 
       for (const vote of votes) {
-        addVoteBucket(vote.cell.id, vote.color, 1); // 추가: Redis 집계가 비어 있으면 DB 기준 fallback
+        addVoteBucket(vote.cell.id, vote.color, 1);
       }
     }
 
-    const resolvedCells: ResolvedRoundCell[] = []; // 추가: 이번 라운드에 반영될 모든 칸
+    const resolvedCells: ResolvedRoundCell[] = [];
 
     for (const [cellId, colorBuckets] of voteBuckets.entries()) {
       let totalVotes = 0;
@@ -324,7 +324,7 @@ export const roundService = {
 
     if (resolvedCells.length > 0) {
       const cellsToUpdate = await cellRepository.findBy({
-        id: In(resolvedCells.map((cell) => cell.cellId)), // 유지: 투표된 모든 칸 조회
+        id: In(resolvedCells.map((cell) => cell.cellId)),
       });
 
       const resolvedCellMap = new Map(
@@ -353,7 +353,7 @@ export const roundService = {
 
     const roundResultEndsAt = new Date(
       round.endedAt.getTime() +
-        canvasGameConfig.phases.roundResultDelaySec * 1000,
+      canvasGameConfig.phases.roundResultDelaySec * 1000,
     );
 
     await canvasRepository.update(canvasId, {
@@ -372,7 +372,7 @@ export const roundService = {
       reason: "라운드 결과 전환",
     });
 
-    await summaryService.saveRoundSummary(canvasId, round.id); // 추가: 라운드 종료 시점 summary snapshot 저장
+    const roundSummary = await summaryService.saveRoundSummary(canvasId, round.id);
 
     await redisClient.del(redisKey);
     await voteService.clearIssuedVoters(round.id);
@@ -389,8 +389,15 @@ export const roundService = {
           cellId: cell.id,
           x: cell.x,
           y: cell.y,
-          color: cell.color ?? "#000000", // 추가: batch payload에 여러 셀 반영 결과 포함
+          color: cell.color ?? "#000000",
         })),
+      });
+
+      io.to(`canvas:${canvasId}`).emit("round-summary:ready", {
+        canvasId,
+        roundId: round.id,
+        roundNumber: round.roundNumber,
+        summaryId: roundSummary.id,
       });
     }
 
@@ -418,7 +425,7 @@ export const roundService = {
       const remainingSeconds = Math.max(
         0,
         canvasGameConfig.phases.roundDurationSec -
-          Math.floor((now.getTime() - activeRound.startedAt.getTime()) / 1000),
+        Math.floor((now.getTime() - activeRound.startedAt.getTime()) / 1000),
       );
 
       const gameEndAt = getActiveGameEndAt(
@@ -459,7 +466,7 @@ export const roundService = {
 
     const waitingDeadline = new Date(
       lastRound.endedAt.getTime() +
-        canvasGameConfig.phases.roundResultDelaySec * 1000,
+      canvasGameConfig.phases.roundResultDelaySec * 1000,
     );
 
     if (now >= waitingDeadline) {

--- a/backend/src/modules/summary/summary.service.ts
+++ b/backend/src/modules/summary/summary.service.ts
@@ -160,7 +160,7 @@ export const summaryService = {
     });
 
     if (!round) {
-      throw new Error("Round was not found.");
+      throw new Error("해당 캔버스에 속한 라운드가 존재하지 않습니다.");
     }
 
     const canvas = await canvasRepository.findOne({
@@ -168,7 +168,7 @@ export const summaryService = {
     });
 
     if (!canvas) {
-      throw new Error("Canvas was not found.");
+      throw new Error("캔버스가 존재하지 않습니다.");
     }
 
     const [votes, totalCellCount, currentPaintedCellCount] = await Promise.all([
@@ -269,7 +269,7 @@ export const summaryService = {
     });
 
     if (!canvas) {
-      throw new Error("Canvas was not found.");
+      throw new Error("캔버스가 존재하지 않습니다.");
     }
 
     const [votes, tickets, rounds, cells, existingSummary] = await Promise.all([

--- a/backend/src/modules/summary/summary.service.ts
+++ b/backend/src/modules/summary/summary.service.ts
@@ -106,6 +106,51 @@ function countRandomResolvedCellsFromVotes(votes: Vote[]): number {
 }
 
 export const summaryService = {
+  async getRoundSummary(
+    canvasId: number,
+    roundId: number,
+  ): Promise<RoundSummary> {
+    const round = await voteRoundRepository.findOne({
+      where: { id: roundId, canvas: { id: canvasId } },
+    });
+
+    if (!round) {
+      throw new Error("해당 캔버스에 속한 라운드가 존재하지 않습니다.");
+    }
+
+    const summary = await roundSummaryRepository.findOne({
+      where: { canvas: { id: canvasId }, round: { id: roundId } },
+      relations: ["canvas", "round"],
+    });
+
+    if (!summary) {
+      throw new Error("라운드 summary가 존재하지 않습니다.");
+    }
+
+    return summary;
+  },
+
+  async getGameSummary(canvasId: number): Promise<GameSummary> {
+    const canvas = await canvasRepository.findOne({
+      where: { id: canvasId },
+    });
+
+    if (!canvas) {
+      throw new Error("캔버스가 존재하지 않습니다.");
+    }
+
+    const summary = await gameSummaryRepository.findOne({
+      where: { canvas: { id: canvasId } },
+      relations: ["canvas"],
+    });
+
+    if (!summary) {
+      throw new Error("게임 summary가 존재하지 않습니다.");
+    }
+
+    return summary;
+  },
+
   async saveRoundSummary(
     canvasId: number,
     roundId: number,


### PR DESCRIPTION
## 관련 이슈
- Close #197 

## 작업 내용

- summary.service.ts에 라운드/게임 summary 조회 메서드 추가
- round.controller.ts, round.router.ts에 라운드 summary 조회 API 추가
- canvas.controller.ts, canvas.router.ts에 게임 summary 조회 API 추가
- 라운드 summary 조회 응답을 data 래퍼 형태로 반환하도록 정리
- 게임 summary 조회 응답을 data 래퍼 형태로 반환하도록 정리
- round.service.ts에서 saveRoundSummary(...) 성공 후 round-summary:ready 이벤트 emit 추가
- game.timer.ts에서 saveGameSummary(...) 성공 후 game-summary:ready 이벤트 emit 추가
- 잘못된 ID 및 존재하지 않는 대상에 대한 400 응답 처리 정리
- summary 저장/조회 관련 에러 메시지 한글 문구 정리

## 테스트 및 확인 사항

- [x]  GET /canvas/:canvasId/rounds/:roundId/summary가 200과 data 래퍼 형태로 응답하는지 확인
<img width="577" height="652" alt="image" src="https://github.com/user-attachments/assets/9abc09ab-69c1-4e95-a00b-254c27fea29e" />

- [x]  라운드 summary 응답 필드가 저장된 round_summary 값과 일치하는지 확인
- [x]  GET /canvas/:canvasId/summary가 200과 data 래퍼 형태로 응답하는지 확인
<img width="542" height="1025" alt="image" src="https://github.com/user-attachments/assets/9daaef95-0ddf-4e83-bdfe-e4909db22857" />

- [x]  게임 summary 응답 필드가 저장된 game_summary 값과 일치하는지 확인
<img width="422" height="132" alt="image" src="https://github.com/user-attachments/assets/6dd58727-f860-47d5-a49e-312362ca62dc" />

<img width="841" height="71" alt="image" src="https://github.com/user-attachments/assets/d9adc1b0-d192-45ed-8d76-9aa4f189262d" />

- [x]  존재하지 않는 canvas/round 또는 소속이 맞지 않는 round 요청 시 400이 반환되는지 확인
<img width="578" height="451" alt="image" src="https://github.com/user-attachments/assets/4ffee254-1ae4-44d9-b790-6f62264ffa29" />
- [x]  라운드 종료 후 round-summary:ready 이벤트가 emit되는지 확인

- [x]  round-summary:ready payload에 canvasId, roundId, roundNumber, summaryId가 포함되는지 확인
<img width="642" height="192" alt="image" src="https://github.com/user-attachments/assets/f979f7dc-3db2-482e-83e1-f63cb481105b" />

- [x]  게임 종료 후 game-summary:ready 이벤트가 emit되는지 확인

- [x]  game-summary:ready payload에 canvasId, summaryId가 포함되는지 확인
<img width="442" height="135" alt="image" src="https://github.com/user-attachments/assets/ce2b63f4-b5ca-4acd-a3d7-e043d729e8ed" />

- [x]  summary 저장 실패 시 ready 이벤트가 emit되지 않는지 확인
- [x]  기존 라운드/캔버스 관련 API가 영향 없이 동작하는지 확인

![녹화_2026_04_14_14_45_07_812](https://github.com/user-attachments/assets/249c7f31-16a0-4abb-a436-8a44673920a2)
