### PR TITLE
feat: summary ready 이벤트 기반 결과 조회 복구 및 모달 표시 연결

### DIFF
--- a/frontend/src/features/gameplay/session/api/session.api.ts
+++ b/frontend/src/features/gameplay/session/api/session.api.ts
@@ -43,6 +43,79 @@ export interface ParticipantListResponse {
   participants: ParticipantItem[];
 }
 
+export interface RoundSummaryData {
+  id: number;
+  canvasId: number;
+  roundId: number;
+  roundNumber: number;
+  participantCount: number;
+  totalVotes: number;
+  paintedCellCount: number;
+  totalCellCount: number;
+  currentPaintedCellCount: number;
+  canvasProgressPercent: string;
+  mostVotedCellId: number | null;
+  mostVotedCellX: number | null;
+  mostVotedCellY: number | null;
+  mostVotedCellVoteCount: number;
+  randomResolvedCellCount: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface GameSummaryTopVoter {
+  voterId: number;
+  name: string;
+  voteCount: number;
+}
+
+export interface GameSummaryParticipant {
+  voterId: number;
+  name: string;
+}
+
+export interface GameSummaryData {
+  id: number;
+  canvasId: number;
+  totalRounds: number;
+  participantCount: number;
+  issuedTicketCount: number;
+  totalVotes: number;
+  ticketUsageRate: string;
+  totalCellCount: number;
+  paintedCellCount: number;
+  emptyCellCount: number;
+  canvasCompletionPercent: string;
+  mostVotedCellId: number | null;
+  mostVotedCellX: number | null;
+  mostVotedCellY: number | null;
+  mostVotedCellVoteCount: number;
+  randomResolvedCellCount: number;
+  usedColorCount: number;
+  mostSelectedColor: string | null;
+  mostSelectedColorVoteCount: number;
+  mostPaintedColor: string | null;
+  mostPaintedColorCellCount: number;
+  topVoterId: number | null;
+  topVoterName: string | null;
+  topVoterVoteCount: number;
+  hottestRoundId: number | null;
+  hottestRoundNumber: number | null;
+  hottestRoundVoteCount: number;
+  topVoters: GameSummaryTopVoter[] | null;
+  participants: GameSummaryParticipant[] | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface RoundSummaryResponse {
+  data: RoundSummaryData;
+}
+
+export interface GameSummaryResponse {
+  data: GameSummaryData;
+}
+
 export interface CreateCanvasRequest {
   profileKey?: string;
 }
@@ -52,6 +125,12 @@ export const sessionApi = {
 
   getActiveRound: (canvasId: number) =>
     api.get<RoundStateResponse>(`/canvas/${canvasId}/rounds/active`),
+
+  getRoundSummary: (canvasId: number, roundId: number) =>
+    api.get<RoundSummaryResponse>(`/canvas/${canvasId}/rounds/${roundId}/summary`),
+
+  getGameSummary: (canvasId: number) =>
+    api.get<GameSummaryResponse>(`/canvas/${canvasId}/summary`),
 
   getTickets: (roundId: number) => voteApi.getTickets(roundId),
 

--- a/frontend/src/features/gameplay/session/hooks/useGameplayBootstrap.ts
+++ b/frontend/src/features/gameplay/session/hooks/useGameplayBootstrap.ts
@@ -83,15 +83,18 @@ export function useGameplayBootstrap() {
 
     setGameConfig(gameConfig);
 
-    let roundState: RoundStateResponse | null = null;
+        let roundState: RoundStateResponse | null = null;
     let remaining: number | null = null;
     let votes: Record<string, number> = {};
 
-    if (isRoundActivePhase(canvas.phase)) {
+    if (
+      isRoundActivePhase(canvas.phase) ||
+      canvas.phase === GAME_PHASE.ROUND_RESULT
+    ) {
       const roundRes = await sessionApi.getActiveRound(canvas.id);
       roundState = roundRes.data;
 
-      if (roundState.round?.id) {
+      if (isRoundActivePhase(canvas.phase) && roundState.round?.id) {
         const [ticketsRes, voteStatusRes] = await Promise.all([
           voteApi.getTickets(roundState.round.id),
           voteApi.getStatus(roundState.round.id),

--- a/frontend/src/features/gameplay/session/hooks/useGameplaySocket.ts
+++ b/frontend/src/features/gameplay/session/hooks/useGameplaySocket.ts
@@ -1,12 +1,14 @@
 import { useEffect } from "react";
 import socket from "@/shared/lib/socket";
 import {
-  CanvasBatchUpdatedPayload, // 추가: batch canvas update payload 타입
+  CanvasBatchUpdatedPayload,
   CanvasJoinedPayload,
   CanvasUpdatedPayload,
+  GameSummaryReadyPayload,
   ParticipantsUpdatedPayload,
   RoundEndedPayload,
   RoundStartedPayload,
+  RoundSummaryReadyPayload,
   SessionEndedPayload,
   TimerUpdatePayload,
   VoteUpdatePayload,
@@ -17,8 +19,10 @@ interface UseGameplaySocketParams {
   onCanvasJoined: (payload: CanvasJoinedPayload) => void;
   onRoundStarted: (payload: RoundStartedPayload) => void;
   onRoundEnded: (payload: RoundEndedPayload) => void;
+  onRoundSummaryReady: (payload: RoundSummaryReadyPayload) => void;
+  onGameSummaryReady: (payload: GameSummaryReadyPayload) => void;
   onCanvasUpdated: (payload: CanvasUpdatedPayload) => void;
-  onCanvasBatchUpdated: (payload: CanvasBatchUpdatedPayload) => void; // 추가: batch update 핸들러
+  onCanvasBatchUpdated: (payload: CanvasBatchUpdatedPayload) => void;
   onVoteUpdate: (payload: VoteUpdatePayload) => void;
   onTimerUpdate: (payload: TimerUpdatePayload) => void;
   onParticipantsUpdated: (payload: ParticipantsUpdatedPayload) => void;
@@ -31,8 +35,10 @@ export function useGameplaySocket({
   onCanvasJoined,
   onRoundStarted,
   onRoundEnded,
+  onRoundSummaryReady,
+  onGameSummaryReady,
   onCanvasUpdated,
-  onCanvasBatchUpdated, // 추가: batch update 핸들러 주입
+  onCanvasBatchUpdated,
   onVoteUpdate,
   onTimerUpdate,
   onParticipantsUpdated,
@@ -43,8 +49,10 @@ export function useGameplaySocket({
     socket.on("canvas:joined", onCanvasJoined);
     socket.on("round:started", onRoundStarted);
     socket.on("round:ended", onRoundEnded);
+    socket.on("round-summary:ready", onRoundSummaryReady);
+    socket.on("game-summary:ready", onGameSummaryReady);
     socket.on("canvas:updated", onCanvasUpdated);
-    socket.on("canvas:batch-updated", onCanvasBatchUpdated); // 추가: batch update 이벤트 구독
+    socket.on("canvas:batch-updated", onCanvasBatchUpdated);
     socket.on("vote:update", onVoteUpdate);
     socket.on("timer:update", onTimerUpdate);
     socket.on("participants:updated", onParticipantsUpdated);
@@ -61,8 +69,10 @@ export function useGameplaySocket({
       socket.off("canvas:joined", onCanvasJoined);
       socket.off("round:started", onRoundStarted);
       socket.off("round:ended", onRoundEnded);
+      socket.off("round-summary:ready", onRoundSummaryReady);
+      socket.off("game-summary:ready", onGameSummaryReady);
       socket.off("canvas:updated", onCanvasUpdated);
-      socket.off("canvas:batch-updated", onCanvasBatchUpdated); // 추가: batch update 이벤트 해제
+      socket.off("canvas:batch-updated", onCanvasBatchUpdated);
       socket.off("vote:update", onVoteUpdate);
       socket.off("timer:update", onTimerUpdate);
       socket.off("participants:updated", onParticipantsUpdated);
@@ -73,13 +83,15 @@ export function useGameplaySocket({
     };
   }, [
     canvasId,
-    onCanvasBatchUpdated, // 추가: effect dependency
+    onCanvasBatchUpdated,
     onCanvasJoined,
     onCanvasUpdated,
     onGameEnded,
+    onGameSummaryReady,
     onParticipantsUpdated,
     onRoundEnded,
     onRoundStarted,
+    onRoundSummaryReady,
     onSessionEnded,
     onTimerUpdate,
     onVoteUpdate,

--- a/frontend/src/features/gameplay/session/model/socket.types.ts
+++ b/frontend/src/features/gameplay/session/model/socket.types.ts
@@ -64,3 +64,15 @@ export interface ParticipantsUpdatedPayload {
 export interface SessionEndedPayload {
   reason?: string;
 }
+
+export interface RoundSummaryReadyPayload {
+  canvasId: number;
+  roundId: number;
+  roundNumber: number;
+  summaryId: number;
+}
+
+export interface GameSummaryReadyPayload {
+  canvasId: number;
+  summaryId: number;
+}

--- a/frontend/src/pages/canvas/CanvasPage.tsx
+++ b/frontend/src/pages/canvas/CanvasPage.tsx
@@ -166,7 +166,8 @@ export default function CanvasPage() {
     return <ErrorScreen message={error} />;
   }
 
-  if (gameEnded) {
+  // test 임시 수정
+  if (gameEnded && !gameSummaryModal) {
     return <GameEndedScreen />;
   }
 
@@ -242,6 +243,7 @@ export default function CanvasPage() {
           />
         )}
       </div>
+
       {roundSummaryModal && (
         <RoundSummaryModal
           summary={roundSummaryModal}

--- a/frontend/src/pages/canvas/CanvasPage.tsx
+++ b/frontend/src/pages/canvas/CanvasPage.tsx
@@ -1,17 +1,98 @@
 import { useCallback } from "react";
 import { useNavigate } from "react-router-dom";
-import {
-  CanvasStage,
-  CanvasSurface,
-  PANEL_WIDTH,
-} from "@/features/gameplay/canvas";
-import {
-  ErrorScreen,
-  GameEndedScreen,
-  LoadingScreen,
-} from "@/features/gameplay/session";
+import { CanvasStage, CanvasSurface, PANEL_WIDTH } from "@/features/gameplay/canvas";
+import { ErrorScreen, GameEndedScreen, LoadingScreen } from "@/features/gameplay/session";
 import { VotePanel, VotePopup } from "@/features/gameplay/vote";
 import useCanvasPage from "./model/useCanvasPage";
+import type { GameSummaryData, RoundSummaryData } from "@/features/gameplay/session/api/session.api";
+
+interface SummaryModalProps {
+  title: string;
+  onClose: () => void;
+  children: React.ReactNode;
+}
+
+function SummaryModal({ title, onClose, children }: SummaryModalProps) {
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/45 px-4">
+      <div className="w-full max-w-md rounded-2xl bg-white p-5 shadow-xl">
+        <div className="mb-4 flex items-center justify-between gap-3">
+          <h2 className="text-lg font-bold text-gray-900">{title}</h2>
+          <button
+            type="button"
+            className="rounded-md px-2 py-1 text-sm text-gray-500 hover:bg-gray-100"
+            onClick={onClose}
+          >
+            닫기
+          </button>
+        </div>
+        <div>{children}</div>
+      </div>
+    </div>
+  );
+}
+
+function RoundSummaryModal({
+  summary,
+  onClose,
+}: {
+  summary: RoundSummaryData;
+  onClose: () => void;
+}) {
+  return (
+    <SummaryModal title={`라운드 ${summary.roundNumber} 결과`} onClose={onClose}>
+      <div className="flex flex-col gap-2 text-sm text-gray-700">
+        <div className="flex items-center justify-between gap-3">
+          <span>참여자 수</span>
+          <span>{summary.participantCount}명</span>
+        </div>
+        <div className="flex items-center justify-between gap-3">
+          <span>총 투표 수</span>
+          <span>{summary.totalVotes}</span>
+        </div>
+        <div className="flex items-center justify-between gap-3">
+          <span>반영 칸 수</span>
+          <span>{summary.paintedCellCount}</span>
+        </div>
+        <div className="flex items-center justify-between gap-3">
+          <span>진행률</span>
+          <span>{summary.canvasProgressPercent}%</span>
+        </div>
+      </div>
+    </SummaryModal>
+  );
+}
+
+function GameSummaryModal({
+  summary,
+  onClose,
+}: {
+  summary: GameSummaryData;
+  onClose: () => void;
+}) {
+  return (
+    <SummaryModal title="게임 종료 결과" onClose={onClose}>
+      <div className="flex flex-col gap-2 text-sm text-gray-700">
+        <div className="flex items-center justify-between gap-3">
+          <span>총 라운드 수</span>
+          <span>{summary.totalRounds}</span>
+        </div>
+        <div className="flex items-center justify-between gap-3">
+          <span>참여자 수</span>
+          <span>{summary.participantCount}명</span>
+        </div>
+        <div className="flex items-center justify-between gap-3">
+          <span>총 투표 수</span>
+          <span>{summary.totalVotes}</span>
+        </div>
+        <div className="flex items-center justify-between gap-3">
+          <span>완성도</span>
+          <span>{summary.canvasCompletionPercent}%</span>
+        </div>
+      </div>
+    </SummaryModal>
+  );
+}
 
 export default function CanvasPage() {
   const navigate = useNavigate();
@@ -63,6 +144,10 @@ export default function CanvasPage() {
     participants,
     participantLoading,
     participantError,
+    roundSummaryModal,
+    gameSummaryModal,
+    handleCloseRoundSummaryModal,
+    handleCloseGameSummaryModal,
     gridX,
     gridY,
     viewport,
@@ -157,6 +242,19 @@ export default function CanvasPage() {
           />
         )}
       </div>
+      {roundSummaryModal && (
+        <RoundSummaryModal
+          summary={roundSummaryModal}
+          onClose={handleCloseRoundSummaryModal}
+        />
+      )}
+
+      {gameSummaryModal && (
+        <GameSummaryModal
+          summary={gameSummaryModal}
+          onClose={handleCloseGameSummaryModal}
+        />
+      )}
     </div>
   );
 }

--- a/frontend/src/pages/canvas/model/useCanvasGameplay.ts
+++ b/frontend/src/pages/canvas/model/useCanvasGameplay.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useRoundState, useRoundTimer } from "@/features/gameplay/round";
 import {
   sessionApi,
@@ -8,6 +8,10 @@ import {
   type SessionBootstrapResult,
   type PhaseTimingState,
 } from "@/features/gameplay/session";
+import type {
+  GameSummaryData,
+  RoundSummaryData,
+} from "@/features/gameplay/session/api/session.api";
 import type {
   CanvasBatchUpdatedPayload,
   GameSummaryReadyPayload,
@@ -29,7 +33,9 @@ interface UseCanvasGameplayParams {
   canvasId: number | null;
   onBootstrapScene: (result: SessionBootstrapResult) => void;
   onCanvasUpdated: (payload: { cellId: number; color: string }) => void;
-  onCanvasBatchUpdated: (payload: CanvasBatchUpdatedPayload) => void; // 변경: 실제 socket payload 타입과 맞춤
+  onCanvasBatchUpdated: (payload: CanvasBatchUpdatedPayload) => void;
+  onOpenRoundSummaryModal: (summary: RoundSummaryData) => void;
+  onOpenGameSummaryModal: (summary: GameSummaryData) => void;
   onGameEndedCleanup: () => void;
   onSessionEnded: () => void;
   onUnauthorized: (message: string) => void;
@@ -48,7 +54,9 @@ export default function useCanvasGameplay({
   canvasId,
   onBootstrapScene,
   onCanvasUpdated,
-  onCanvasBatchUpdated, // 추가: batch canvas update handler 수신
+  onCanvasBatchUpdated,
+  onOpenRoundSummaryModal,
+  onOpenGameSummaryModal,
   onGameEndedCleanup,
   onSessionEnded,
   onUnauthorized,
@@ -81,6 +89,10 @@ export default function useCanvasGameplay({
 
   const phaseTimingRef = useRef<PhaseTimingState>(DEFAULT_PHASE_TIMING);
   const localPhaseTransitionTimerRef = useRef<number | null>(null);
+  const [roundSummary, setRoundSummary] = useState(null as RoundSummaryData | null);
+  const [gameSummary, setGameSummary] = useState(null as GameSummaryData | null);
+  const [roundSummaryLoading, setRoundSummaryLoading] = useState(false);
+  const [gameSummaryLoading, setGameSummaryLoading] = useState(false);
 
   const clearLocalPhaseTransitionTimer = useCallback(() => {
     if (localPhaseTransitionTimerRef.current === null) {
@@ -104,6 +116,63 @@ export default function useCanvasGameplay({
     applyParticipantCount,
     clearParticipants,
   } = useParticipantsState();
+
+  const requestGameSummary = useCallback(
+    async (targetCanvasId: number) => {
+      setGameSummaryLoading(true);
+
+      try {
+        const response = await sessionApi.getGameSummary(targetCanvasId);
+
+        const nextSummary = response.data.data;
+
+        setGameSummary(nextSummary);
+        onOpenGameSummaryModal(nextSummary);
+      } catch (error) {
+        console.error("[summary] failed to load game summary:", error);
+      } finally {
+        setGameSummaryLoading(false);
+      }
+    },
+    [onOpenGameSummaryModal],
+  );
+
+  const handleGameSummaryReady = useCallback(
+    (payload: GameSummaryReadyPayload) => {
+      const readyCanvasId = payload.canvasId;
+
+      if (!canvasId || canvasId !== readyCanvasId) {
+        return;
+      }
+
+      setGameSummaryLoading(true);
+      void requestGameSummary(readyCanvasId);
+    },
+    [canvasId, requestGameSummary],
+  );
+
+  const requestRoundSummary = useCallback(
+    async (targetCanvasId: number, targetRoundId: number) => {
+      setRoundSummaryLoading(true);
+
+      try {
+        const response = await sessionApi.getRoundSummary(
+          targetCanvasId,
+          targetRoundId,
+        );
+
+        const nextSummary = response.data.data;
+
+        setRoundSummary(nextSummary);
+        onOpenRoundSummaryModal(nextSummary);
+      } catch (error) {
+        console.error("[summary] failed to load round summary:", error);
+      } finally {
+        setRoundSummaryLoading(false);
+      }
+    },
+    [onOpenRoundSummaryModal],
+  );
 
   const applyBootstrap = useCallback(
     (result: SessionBootstrapResult) => {
@@ -137,10 +206,23 @@ export default function useCanvasGameplay({
 
       applyVoteUpdate(result.votes);
       setRemaining(result.remaining);
+
+      if (
+        result.round.phase === GAME_PHASE.ROUND_RESULT &&
+        result.round.roundId !== null
+      ) {
+        void requestRoundSummary(result.canvasId, result.round.roundId);
+      }
+
+      if (result.round.phase === GAME_PHASE.GAME_END) {
+        void requestGameSummary(result.canvasId);
+      }
     },
     [
       applyVoteUpdate,
       onBootstrapScene,
+      requestGameSummary,
+      requestRoundSummary,
       setPhaseTimerState,
       setRemaining,
       setRoundState,
@@ -348,6 +430,10 @@ export default function useCanvasGameplay({
       gameEndAt: string;
     }) => {
       clearLocalPhaseTransitionTimer();
+      setRoundSummary(null);
+      setGameSummary(null);
+      setRoundSummaryLoading(false);
+      setGameSummaryLoading(false);
 
       setRoundState({
         phase: GAME_PHASE.ROUND_ACTIVE,
@@ -390,6 +476,8 @@ export default function useCanvasGameplay({
       clearLocalPhaseTransitionTimer();
       clearTickets();
       resetVoteState();
+      setRoundSummary(null);
+      setRoundSummaryLoading(true);
 
       const resultEndsAt = new Date(
         new Date(endedAt).getTime() +
@@ -420,15 +508,11 @@ export default function useCanvasGameplay({
     ],
   );
 
-  const requestRoundSummary = useCallback(
-    async (targetCanvasId: number, targetRoundId: number) => {
-      await sessionApi.getRoundSummary(targetCanvasId, targetRoundId);
-    },
-    [],
-  );
-
   const handleRoundSummaryReady = useCallback(
-    ({ canvasId: readyCanvasId, roundId: readyRoundId }: RoundSummaryReadyPayload) => {
+    (payload: RoundSummaryReadyPayload) => {
+      const readyCanvasId = payload.canvasId;
+      const readyRoundId = payload.roundId;
+
       if (!canvasId || canvasId !== readyCanvasId) {
         return;
       }
@@ -438,22 +522,27 @@ export default function useCanvasGameplay({
     [canvasId, requestRoundSummary],
   );
 
-
-  const requestGameSummary = useCallback(async (targetCanvasId: number) => {
-    await sessionApi.getGameSummary(targetCanvasId);
-  }, []);
-
-  const handleGameSummaryReady = useCallback(
-    ({ canvasId: readyCanvasId }: GameSummaryReadyPayload) => {
-      if (!canvasId || canvasId !== readyCanvasId) {
-        return;
-      }
-
-      void requestGameSummary(readyCanvasId);
-    },
-    [canvasId, requestGameSummary],
-  );
-
+  const handleSessionEnded = useCallback(() => {
+    clearLocalPhaseTransitionTimer();
+    clearTickets();
+    clearParticipants();
+    resetRoundState();
+    resetRoundTimer();
+    resetVoteState();
+    setRoundSummary(null);
+    setGameSummary(null);
+    setRoundSummaryLoading(false);
+    setGameSummaryLoading(false);
+    onSessionEnded();
+  }, [
+    clearLocalPhaseTransitionTimer,
+    clearParticipants,
+    clearTickets,
+    onSessionEnded,
+    resetRoundState,
+    resetRoundTimer,
+    resetVoteState,
+  ]);
 
   const handleVoteUpdate = useCallback(
     ({ votes }: { votes: Record<string, number> }) => {
@@ -490,24 +579,6 @@ export default function useCanvasGameplay({
     [applyParticipantCount, refreshParticipants],
   );
 
-  const handleSessionEnded = useCallback(() => {
-    clearLocalPhaseTransitionTimer();
-    clearTickets();
-    clearParticipants();
-    resetRoundState();
-    resetRoundTimer();
-    resetVoteState();
-    onSessionEnded();
-  }, [
-    clearLocalPhaseTransitionTimer,
-    clearParticipants,
-    clearTickets,
-    onSessionEnded,
-    resetRoundState,
-    resetRoundTimer,
-    resetVoteState,
-  ]);
-
   const handleGameEnded = useCallback(() => {
     clearLocalPhaseTransitionTimer();
     markGameEnded();
@@ -517,6 +588,10 @@ export default function useCanvasGameplay({
     resetRoundState();
     resetRoundTimer();
     resetVoteState();
+    setRoundSummary(null);
+    setGameSummary(null);
+    setRoundSummaryLoading(false);
+    setGameSummaryLoading(false);
   }, [
     clearLocalPhaseTransitionTimer,
     clearParticipants,
@@ -572,6 +647,10 @@ export default function useCanvasGameplay({
     participants,
     participantLoading,
     participantError,
+    roundSummary,
+    gameSummary,
+    roundSummaryLoading,
+    gameSummaryLoading,
     isRoundExpiredRefValue: isRoundExpired,
   };
 }

--- a/frontend/src/pages/canvas/model/useCanvasGameplay.ts
+++ b/frontend/src/pages/canvas/model/useCanvasGameplay.ts
@@ -1,13 +1,18 @@
 import { useCallback, useEffect, useRef } from "react";
 import { useRoundState, useRoundTimer } from "@/features/gameplay/round";
 import {
+  sessionApi,
   useGameSession,
   useGameplaySocket,
   useParticipantsState,
   type SessionBootstrapResult,
   type PhaseTimingState,
 } from "@/features/gameplay/session";
-import type { CanvasBatchUpdatedPayload } from "@/features/gameplay/session/model/socket.types"; // 추가: batch payload 타입 사용
+import type {
+  CanvasBatchUpdatedPayload,
+  GameSummaryReadyPayload,
+  RoundSummaryReadyPayload,
+} from "@/features/gameplay/session/model/socket.types";
 import {
   GAME_PHASE,
   isRoundActivePhase,
@@ -231,7 +236,7 @@ export default function useCanvasGameplay({
         const waitStartedAt = phaseEndsAt;
         const waitEndsAt = new Date(
           new Date(waitStartedAt).getTime() +
-            phaseTimingRef.current.roundStartWaitSec * 1000,
+          phaseTimingRef.current.roundStartWaitSec * 1000,
         ).toISOString();
 
         setRoundState({
@@ -266,7 +271,7 @@ export default function useCanvasGameplay({
         const gameEndStartedAt = phaseEndsAt;
         const gameEndEndsAt = new Date(
           new Date(gameEndStartedAt).getTime() +
-            phaseTimingRef.current.gameEndWaitSec * 1000,
+          phaseTimingRef.current.gameEndWaitSec * 1000,
         ).toISOString();
 
         setRoundState({
@@ -287,7 +292,7 @@ export default function useCanvasGameplay({
       const waitStartedAt = phaseEndsAt;
       const waitEndsAt = new Date(
         new Date(waitStartedAt).getTime() +
-          phaseTimingRef.current.roundStartWaitSec * 1000,
+        phaseTimingRef.current.roundStartWaitSec * 1000,
       ).toISOString();
 
       setRoundState({
@@ -388,7 +393,7 @@ export default function useCanvasGameplay({
 
       const resultEndsAt = new Date(
         new Date(endedAt).getTime() +
-          phaseTimingRef.current.roundResultDelaySec * 1000,
+        phaseTimingRef.current.roundResultDelaySec * 1000,
       ).toISOString();
 
       setRoundState({
@@ -414,6 +419,41 @@ export default function useCanvasGameplay({
       totalRounds,
     ],
   );
+
+  const requestRoundSummary = useCallback(
+    async (targetCanvasId: number, targetRoundId: number) => {
+      await sessionApi.getRoundSummary(targetCanvasId, targetRoundId);
+    },
+    [],
+  );
+
+  const handleRoundSummaryReady = useCallback(
+    ({ canvasId: readyCanvasId, roundId: readyRoundId }: RoundSummaryReadyPayload) => {
+      if (!canvasId || canvasId !== readyCanvasId) {
+        return;
+      }
+
+      void requestRoundSummary(readyCanvasId, readyRoundId);
+    },
+    [canvasId, requestRoundSummary],
+  );
+
+
+  const requestGameSummary = useCallback(async (targetCanvasId: number) => {
+    await sessionApi.getGameSummary(targetCanvasId);
+  }, []);
+
+  const handleGameSummaryReady = useCallback(
+    ({ canvasId: readyCanvasId }: GameSummaryReadyPayload) => {
+      if (!canvasId || canvasId !== readyCanvasId) {
+        return;
+      }
+
+      void requestGameSummary(readyCanvasId);
+    },
+    [canvasId, requestGameSummary],
+  );
+
 
   const handleVoteUpdate = useCallback(
     ({ votes }: { votes: Record<string, number> }) => {
@@ -493,8 +533,10 @@ export default function useCanvasGameplay({
     onCanvasJoined: handleCanvasJoined,
     onRoundStarted: handleRoundStarted,
     onRoundEnded: handleRoundEnded,
+    onRoundSummaryReady: handleRoundSummaryReady,
+    onGameSummaryReady: handleGameSummaryReady,
     onCanvasUpdated,
-    onCanvasBatchUpdated, // 추가: batch update 이벤트 연결
+    onCanvasBatchUpdated,
     onVoteUpdate: handleVoteUpdate,
     onTimerUpdate: handleTimerUpdate,
     onParticipantsUpdated: handleParticipantsUpdated,

--- a/frontend/src/pages/canvas/model/useCanvasPage.ts
+++ b/frontend/src/pages/canvas/model/useCanvasPage.ts
@@ -1,5 +1,6 @@
-import { useCallback, useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useVotePopup, useVoteState } from "@/features/gameplay/vote";
+import type { GameSummaryData, RoundSummaryData } from "@/features/gameplay/session/api/session.api";
 import type { SessionBootstrapResult } from "@/features/gameplay/session";
 import useCanvasGameplay from "./useCanvasGameplay";
 import useCanvasScene from "./useCanvasScene";
@@ -14,6 +15,9 @@ export default function useCanvasPage({
   onUnauthorized,
 }: UseCanvasPageParams) {
   const isRoundExpiredRef = useRef(false);
+
+  const [roundSummaryModal, setRoundSummaryModal] = useState<RoundSummaryData | null>(null);
+  const [gameSummaryModal, setGameSummaryModal] = useState<GameSummaryData | null>(null);
 
   const {
     popupOpen,
@@ -80,11 +84,35 @@ export default function useCanvasPage({
     clearSelectedCell();
   }, [clearSelectedCell]);
 
+  const handleOpenRoundSummaryModal = useCallback(
+    (summary: RoundSummaryData) => {
+      setRoundSummaryModal(summary);
+    },
+    [],
+  );
+
+  const handleOpenGameSummaryModal = useCallback(
+    (summary: GameSummaryData) => {
+      setGameSummaryModal(summary);
+    },
+    [],
+  );
+
+  const handleCloseRoundSummaryModal = useCallback(() => {
+    setRoundSummaryModal(null);
+  }, []);
+
+  const handleCloseGameSummaryModal = useCallback(() => {
+    setGameSummaryModal(null);
+  }, []);
+
   const gameplay = useCanvasGameplay({
     canvasId,
     onBootstrapScene: applyBootstrapScene,
     onCanvasUpdated: handleCanvasUpdated,
-    onCanvasBatchUpdated: handleCanvasBatchUpdated, // 추가: batch update를 gameplay socket에 연결
+    onCanvasBatchUpdated: handleCanvasBatchUpdated,
+    onOpenRoundSummaryModal: handleOpenRoundSummaryModal,
+    onOpenGameSummaryModal: handleOpenGameSummaryModal,
     onGameEndedCleanup: handleGameEndedCleanup,
     onSessionEnded,
     onUnauthorized,
@@ -136,6 +164,10 @@ export default function useCanvasPage({
     participants: gameplay.participants,
     participantLoading: gameplay.participantLoading,
     participantError: gameplay.participantError,
+    roundSummaryModal,
+    gameSummaryModal,
+    handleCloseRoundSummaryModal,
+    handleCloseGameSummaryModal,
     gridX,
     gridY,
     viewport,


### PR DESCRIPTION
## 관련 이슈
- Close #198 

## 작업 내용

#### useGameplayBootstrap.ts
- ROUND_RESULT 상태에서도 getActiveRound를 호출하도록 변경해 새로고침/재접속 시 마지막 roundId를 복구할 수 있게 수정

#### useCanvasGameplay.ts
- round/game summary 상태 및 loading 상태 추가
- round-summary:ready, game-summary:ready 이벤트 수신 후 summary 조회 API를 호출하도록 연결
- bootstrap 시 현재 phase가 ROUND_RESULT, GAME_END인 경우 summary를 자동 조회하도록 복구 로직 추가
- summary 조회 성공 시 상위 콜백을 통해 결과 모달을 열도록 연결
- 라운드 시작, 세션 종료, 게임 종료 시 summary 상태를 초기화하도록 정리

#### useCanvasPage.ts
- round/game summary 모달 상태 추가
- summary 모달 open/close 핸들러를 정의하고 useCanvasGameplay.ts에 전달하도록 연결

#### CanvasPage.tsx
- 공통 summary 모달, 라운드 결과 모달, 게임 종료 결과 모달 추가
- round/game summary 모달 렌더링 연결
- 게임 종료 결과 모달이 열려 있는 동안에는 GameEndedScreen으로 즉시 전환되지 않도록 조건 분기 추가

## 테스트 및 확인 사항
- [x] ROUND_RESULT 상태 진입 후 round-summary:ready 이벤트 수신 시 라운드 summary API가 호출되는지 확인

<img width="1061" height="641" alt="image" src="https://github.com/user-attachments/assets/03b6feaf-daa8-42db-aaee-024e689e5f7a" />

- [x]  라운드 summary 조회 성공 후 결과 모달이 자동으로 열리는지 확인

<img width="1040" height="880" alt="image" src="https://github.com/user-attachments/assets/ea81195e-955d-4545-b5ee-1a693f6f7000" />

- [x]  라운드 결과 모달에 참여자 수 / 총 투표 수 / 반영 칸 수 / 진행률이 정상 표시되는지 확인

<img width="716" height="537" alt="image" src="https://github.com/user-attachments/assets/9f842c48-322f-414f-bf38-3871c088fffa" />

- [x]  GAME_END 상태 진입 후 game-summary:ready 이벤트 수신 시 게임 summary API가 호출되는지 확인

- [x]  게임 summary 조회 성공 후 게임 종료 결과 모달이 자동으로 열리는지 확인
- [x]  게임 종료 결과 모달에 총 라운드 수 / 참여자 수 / 총 투표 수 / 완성도가 정상 표시되는지 확인
- [x]  ROUND_RESULT 상태에서 새로고침 시 마지막 roundId가 복구되고 라운드 결과 모달이 다시 열리는지 확인
- [x]  세션 종료 시 summary 상태가 초기화되는지 확인
- [x]  게임 종료 결과 모달이 열려 있는 동안 GameEndedScreen으로 바로 전환되지 않는지 확인
- [x]  게임 종료 결과 모달 닫기 후 GameEndedScreen으로 전환되는지 확인
- [x]  기존 투표 / 타이머 / 참가자 / 캔버스 업데이트 흐름에 영향이 없는지 확인

## 체크리스트
- [ ] 불필요한 주석 및 디버깅 코드를 제거하였는가?
- [ ] 모든 테스트를 통과하였는가?
- [ ] 변경 사항에 대한 문서 업데이트가 필요한가?
