### PR TITLE
feat: INTRO phase 전체 캔버스 안내 모달 추가

### DIFF
--- a/frontend/src/features/gameplay/intro/components/IntroCanvasPreview.tsx
+++ b/frontend/src/features/gameplay/intro/components/IntroCanvasPreview.tsx
@@ -1,0 +1,78 @@
+import { useEffect, useMemo, useRef } from "react";
+import type { Cell } from "@/features/gameplay/canvas";
+import { renderCanvas } from "@/features/gameplay/canvas/model/canvas.render";
+import { getGameConfig } from "@/shared/config/game-config";
+
+interface Props {
+  cells: Cell[];
+  gridX: number;
+  gridY: number;
+  maxSize?: number;
+}
+
+const DEFAULT_PREVIEW_SIZE = 260;
+
+export default function IntroCanvasPreview({
+  cells,
+  gridX,
+  gridY,
+  maxSize = DEFAULT_PREVIEW_SIZE,
+}: Props) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  const previewSize = useMemo(() => {
+    const longestSide = Math.max(gridX, gridY, 1);
+    const scale = maxSize / longestSide;
+
+    return {
+      width: Math.max(1, Math.round(gridX * scale)),
+      height: Math.max(1, Math.round(gridY * scale)),
+    };
+  }, [gridX, gridY, maxSize]);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas || gridX <= 0 || gridY <= 0) {
+      return;
+    }
+
+    const cellSize = getGameConfig().board.cellSize;
+
+    canvas.width = gridX * cellSize; // 추가: 실제 게임 보드와 같은 해상도로 렌더
+    canvas.height = gridY * cellSize;
+
+    const ctx = canvas.getContext("2d");
+    if (!ctx) {
+      return;
+    }
+
+    ctx.imageSmoothingEnabled = false;
+
+    renderCanvas({
+      ctx,
+      canvas,
+      cells,
+      selectedCell: null, // 추가: INTRO 프리뷰는 선택/투표 상태 없이 전체 캔버스만 표시
+      previewColor: null,
+      votingCellIds: new Set(),
+      topColorMap: new Map(),
+      timestamp: 0,
+    });
+  }, [cells, gridX, gridY]);
+
+  return (
+    <div className="w-fit">
+      <div className="rounded-2xl border border-gray-200 bg-white p-4 shadow-sm">
+        <canvas
+          ref={canvasRef}
+          className="block rounded border border-gray-100 bg-white"
+          style={{
+            width: `${previewSize.width}px`,
+            height: `${previewSize.height}px`,
+            imageRendering: "pixelated",
+          }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/features/gameplay/intro/components/IntroGuideModal.tsx
+++ b/frontend/src/features/gameplay/intro/components/IntroGuideModal.tsx
@@ -1,0 +1,208 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import type { Cell } from "@/features/gameplay/canvas";
+import type { GameConfig } from "@/shared/config/game-config";
+import IntroCanvasPreview from "./IntroCanvasPreview";
+
+interface Props {
+  open: boolean;
+  cells: Cell[];
+  gridX: number;
+  gridY: number;
+  gameConfig: GameConfig;
+  formattedGameEndTime: string | null;
+  onClose: () => void;
+}
+
+function buildDescription(config: GameConfig) {
+  return {
+    totalRounds: config.rules.totalRounds,
+    votesPerRound: config.rules.votesPerRound,
+    roundDurationSec: config.phases.roundDurationSec,
+  };
+}
+
+export default function IntroGuideModal({
+  open,
+  cells,
+  gridX,
+  gridY,
+  gameConfig,
+  formattedGameEndTime,
+  onClose,
+}: Props) {
+  const [position, setPosition] = useState(() => ({
+    x: window.innerWidth / 2 - 260,
+    y: 48,
+  }));
+
+  const modalRef = useRef<HTMLDivElement>(null);
+  const isDraggingRef = useRef(false);
+  const dragOffsetRef = useRef({ x: 0, y: 0 });
+
+  const description = useMemo(() => buildDescription(gameConfig), [gameConfig]);
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+
+    const handleMouseMove = (event: MouseEvent) => {
+      if (!isDraggingRef.current) {
+        return;
+      }
+
+      setPosition({
+        x: event.clientX - dragOffsetRef.current.x,
+        y: event.clientY - dragOffsetRef.current.y,
+      });
+    };
+
+    const handleMouseUp = () => {
+      isDraggingRef.current = false;
+    };
+
+    window.addEventListener("mousemove", handleMouseMove);
+    window.addEventListener("mouseup", handleMouseUp);
+
+    return () => {
+      window.removeEventListener("mousemove", handleMouseMove);
+      window.removeEventListener("mouseup", handleMouseUp);
+    };
+  }, [open]);
+
+  if (!open) {
+    return null;
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50"
+      onMouseDown={(event) => event.stopPropagation()}
+      onClick={(event) => event.stopPropagation()}
+    >
+      <div
+        ref={modalRef}
+        className="pointer-events-auto fixed w-[720px] max-w-[calc(100vw-24px)] rounded-3xl border border-gray-200 bg-white/95 shadow-2xl backdrop-blur"
+        style={{ top: position.y, left: position.x }}
+        onMouseDown={(event) => event.stopPropagation()}
+        onClick={(event) => event.stopPropagation()}
+      >
+        {" "}
+        <div
+          className="relative flex cursor-move items-center justify-center border-b border-gray-100 px-5 py-4"
+          onMouseDown={(event) => {
+            isDraggingRef.current = true;
+            dragOffsetRef.current = {
+              x: event.clientX - position.x,
+              y: event.clientY - position.y,
+            };
+          }}
+        >
+          <p className="text-center text-base font-semibold text-gray-900">
+            게임 안내
+          </p>
+
+          <button
+            type="button"
+            onClick={onClose}
+            className="absolute right-5 top-1/2 flex h-8 w-8 -translate-y-1/2 items-center justify-center rounded-full text-gray-400 hover:bg-gray-100 hover:text-gray-700"
+            aria-label="게임 안내 닫기"
+          >
+            ×
+          </button>
+        </div>
+        <div className="flex flex-col gap-6 px-7 py-6">
+          <section className="space-y-1 text-center">
+            <p className="text-sm text-gray-700">
+              도트를 색칠해 하나의 캔버스를 완성하세요.
+            </p>
+          </section>
+
+          <div className="mx-auto w-fit space-y-3">
+            <IntroCanvasPreview cells={cells} gridX={gridX} gridY={gridY} />
+
+            <div className="space-y-1 text-left text-sm font-bold text-gray-700">
+              <p>
+                전체 라운드 수 :{" "}
+                <span className="text-[19px]">{description.totalRounds}</span>
+              </p>
+              <p>
+                라운드 소요 시간 :{" "}
+                <span className="text-[19px]">
+                  {description.roundDurationSec}초
+                </span>
+              </p>
+              <p>
+                라운드당 투표권 수 :{" "}
+                <span className="text-[19px]">
+                  {description.votesPerRound}개
+                </span>
+              </p>
+              <p>
+                캔버스 종료 시간 :{" "}
+                <span className="text-[19px]">
+                  {formattedGameEndTime ?? "-"}
+                </span>
+              </p>
+            </div>
+          </div>
+
+          <div className="space-y-5 text-sm leading-6 text-gray-700">
+            <section className="space-y-2">
+              <h3 className="text-center font-semibold text-gray-900">
+                게임 설명
+              </h3>
+              <ul className="space-y-1 text-left">
+                <li>
+                  - 게임은 총{" "}
+                  <span className="text-[19px] font-bold text-red-500">
+                    {description.totalRounds}
+                  </span>
+                  개의 라운드로 진행됩니다.
+                </li>
+                <li>
+                  - 각 라운드는{" "}
+                  <span className="text-[19px] font-bold text-red-500">
+                    {description.roundDurationSec}
+                  </span>
+                  초 동안 진행되며, 매 라운드마다{" "}
+                  <span className="text-[19px] font-bold text-red-500">
+                    {description.votesPerRound}
+                  </span>
+                  개의 투표권이 주어집니다.
+                </li>
+                <li>
+                  - 서로 다른 칸에 투표하거나, 같은 칸에 여러 번 투표할 수
+                  있습니다.
+                </li>
+                <li>- 라운드가 끝나면 투표된 모든 칸이 반영됩니다.</li>
+                <li>
+                  - 각 칸은 가장 많은 표를 받은 색으로 칠해지며, 동점이면
+                  무작위로 결정됩니다.
+                </li>
+              </ul>
+            </section>
+
+            <section className="space-y-2">
+              <h3 className="text-center font-semibold text-gray-900">
+                투표 방법
+              </h3>
+              <ul className="space-y-1 text-left">
+                <li>- 원하는 칸을 선택합니다.</li>
+                <li>
+                  - 칠하고 싶은 색을 고른 뒤 ‘투표하기’ 버튼 또는 스페이스바로
+                  투표합니다.
+                </li>
+                <li>
+                  - 팔레트 칸을 선택한 뒤 ‘+’ 버튼을 누르면 색을 즐겨찾기에
+                  추가할 수 있습니다.
+                </li>
+                <li>- 주의: 한 번 투표한 내용은 변경할 수 없습니다.</li>
+              </ul>
+            </section>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/features/gameplay/intro/index.ts
+++ b/frontend/src/features/gameplay/intro/index.ts
@@ -1,0 +1,2 @@
+export { default as IntroGuideModal } from "./components/IntroGuideModal";
+export { default as IntroCanvasPreview } from "./components/IntroCanvasPreview";

--- a/frontend/src/pages/canvas/CanvasPage.tsx
+++ b/frontend/src/pages/canvas/CanvasPage.tsx
@@ -1,20 +1,23 @@
-import { useCallback } from "react";
+import { useCallback, useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import {
   CanvasStage,
   CanvasSurface,
   PANEL_WIDTH,
 } from "@/features/gameplay/canvas";
+import { IntroGuideModal } from "@/features/gameplay/intro"; // 추가: INTRO 안내 모달
 import {
   ErrorScreen,
   GameEndedScreen,
   LoadingScreen,
 } from "@/features/gameplay/session";
+import { GAME_PHASE } from "@/features/gameplay/session/model/game-phase.types"; // 추가: INTRO phase 판별
 import { VotePanel, VotePopup } from "@/features/gameplay/vote";
 import useCanvasPage from "./model/useCanvasPage";
 
 export default function CanvasPage() {
   const navigate = useNavigate();
+  const [introModalDismissed, setIntroModalDismissed] = useState(false); // 추가: INTRO 중 사용자가 닫은 상태 보관
 
   const handleSessionEnded = useCallback(() => {
     window.alert("세션이 종료되었습니다. 다시 로그인해 주세요.");
@@ -63,6 +66,7 @@ export default function CanvasPage() {
     participants,
     participantLoading,
     participantError,
+    gameConfig,
     gridX,
     gridY,
     viewport,
@@ -72,6 +76,16 @@ export default function CanvasPage() {
     onSessionEnded: handleSessionEnded,
     onUnauthorized: handleUnauthorized,
   });
+
+  if (phase !== GAME_PHASE.INTRO && introModalDismissed) {
+    setIntroModalDismissed(false); // 추가: INTRO이 끝났다가 다음 게임 INTRO이 오면 다시 모달 표시
+  }
+
+  useEffect(() => {
+    if (phase !== GAME_PHASE.INTRO) {
+      setIntroModalDismissed(false); // 변경: INTRO이 아닐 때 닫힘 상태 초기화
+    }
+  }, [phase]);
 
   if (loading) {
     return <LoadingScreen />;
@@ -112,6 +126,21 @@ export default function CanvasPage() {
       >
         <CanvasSurface canvasRef={canvasRef} />
       </CanvasStage>
+
+      <IntroGuideModal
+        open={
+          phase === GAME_PHASE.INTRO &&
+          !introModalDismissed &&
+          !!gameConfig &&
+          cells.length > 0
+        } // 추가: INTRO phase에서만 전체 캔버스 안내 모달 표시
+        cells={cells}
+        gridX={gridX}
+        gridY={gridY}
+        gameConfig={gameConfig!}
+        formattedGameEndTime={formattedGameEndTime}
+        onClose={() => setIntroModalDismissed(true)}
+      />
 
       {popupOpen && selectedCell && canvasId && (
         <VotePopup

--- a/frontend/src/pages/canvas/model/useCanvasGameplay.ts
+++ b/frontend/src/pages/canvas/model/useCanvasGameplay.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useRoundState, useRoundTimer } from "@/features/gameplay/round";
 import {
   useGameSession,
@@ -12,6 +12,7 @@ import {
   GAME_PHASE,
   isRoundActivePhase,
 } from "@/features/gameplay/session/model/game-phase.types";
+import type { GameConfig } from "@/shared/config/game-config";
 import { useVoteTickets } from "@/features/gameplay/vote";
 
 function formatClockTime(date: Date): string {
@@ -76,6 +77,7 @@ export default function useCanvasGameplay({
 
   const phaseTimingRef = useRef<PhaseTimingState>(DEFAULT_PHASE_TIMING);
   const localPhaseTransitionTimerRef = useRef<number | null>(null);
+  const [gameConfig, setGameConfigState] = useState<GameConfig | null>(null); // 추가: bootstrap된 현재 게임 설정 보관
 
   const clearLocalPhaseTransitionTimer = useCallback(() => {
     if (localPhaseTransitionTimerRef.current === null) {
@@ -103,6 +105,7 @@ export default function useCanvasGameplay({
   const applyBootstrap = useCallback(
     (result: SessionBootstrapResult) => {
       phaseTimingRef.current = result.phaseTiming;
+      setGameConfigState(result.gameConfig); // 추가: INTRO 모달에서 현재 게임 설정을 바로 쓸 수 있게 저장
 
       onBootstrapScene(result);
 
@@ -530,6 +533,7 @@ export default function useCanvasGameplay({
     participants,
     participantLoading,
     participantError,
+    gameConfig,
     isRoundExpiredRefValue: isRoundExpired,
   };
 }

--- a/frontend/src/pages/canvas/model/useCanvasPage.ts
+++ b/frontend/src/pages/canvas/model/useCanvasPage.ts
@@ -136,6 +136,7 @@ export default function useCanvasPage({
     participants: gameplay.participants,
     participantLoading: gameplay.participantLoading,
     participantError: gameplay.participantError,
+    gameConfig: gameplay.gameConfig,
     gridX,
     gridY,
     viewport,


### PR DESCRIPTION
## 관련 이슈
- Close #200 

## 작업 내용
## 요약
- `INTRO` phase에서 이번 게임의 전체 캔버스와 게임 설명을 함께 보여주는 안내 모달을 추가했습니다.
- 사용자는 게임 시작 전에 어떤 캔버스에서 플레이하는지와 현재 게임 규칙을 한눈에 확인할 수 있습니다.

## 변경 내용
- `INTRO` phase 전용 `IntroGuideModal` 추가
- 전체 캔버스를 축소해서 보여주는 `IntroCanvasPreview` 추가
- 현재 게임 설정값(`gameConfig`)을 사용해 라운드 수, 라운드 시간, 투표권 수, 종료 시간을 표시
- 설명 문구는 현재 게임 규칙에 맞춰 동적으로 표시되도록 구성
- 모달은 드래그 가능하며 우측 상단 닫기 버튼으로만 닫히도록 처리
- 바깥 영역 클릭으로는 닫히지 않도록 변경
- 상단 제목은 가운데 정렬, 전체 캔버스 아래 라운드 정보는 이미지 폭에 맞춰 좌측 정렬
- 게임 설명 숫자는 강조 스타일(볼드 + 빨간색 + 확대) 적용
- `CanvasPage`에서 `phase === INTRO`일 때만 모달이 노출되도록 연결
- 사용자가 닫은 경우 현재 인트로 동안은 다시 보이지 않고, 다음 인트로 진입 시 다시 표시되도록 처리

## 기대 효과
- 사용자가 게임 시작 전에 이번 캔버스의 전체 형태를 쉽게 파악할 수 있습니다.
- 현재 게임 설정값이 반영된 규칙 설명을 인트로에서 바로 확인할 수 있습니다.
- 인트로 phase의 안내 경험이 더 명확해집니다.

## 테스트 항목
- [x] `INTRO` phase에서만 안내 모달이 노출되는지 확인
<img width="735" height="925" alt="image" src="https://github.com/user-attachments/assets/76fd14d7-6491-4a6d-aed4-369fc69392f0" />

- [x] 모달이 드래그 가능한지 확인
- [x] 우측 상단 닫기 버튼이 정상 동작하는지 확인
- [x] 바깥 영역 클릭으로 모달이 닫히지 않는지 확인
- [x] 전체 캔버스가 축소된 상태로 한 화면에 정상 표시되는지 확인
- [x] 빈 캔버스와 아웃라인 캔버스가 각각 올바르게 보이는지 확인
- [x] 이미지 아래 라운드 정보가 이미지 폭 기준으로 좌측 정렬되는지 확인
- [x] 라운드 수, 투표권 수, 라운드 시간 등 설명 값이 현재 게임 설정과 일치하는지 확인
- [x] 게임 설명 숫자 강조 스타일이 정상 적용되는지 확인
- [x] `INTRO` 종료 후 모달이 자연스럽게 사라지는지 확인
- [x] 다음 게임의 `INTRO`에 다시 진입했을 때 모달이 다시 표시되는지 확인
