### PR TITLE
feat: 라운드 통계 모달 UI 개편

### DIFF
--- a/frontend/src/pages/canvas/CanvasPage.tsx
+++ b/frontend/src/pages/canvas/CanvasPage.tsx
@@ -19,6 +19,7 @@ import type {
   RoundSummaryData,
 } from "@/features/gameplay/session/api/session.api";
 
+// to-be
 interface SummaryModalProps {
   title: string;
   onClose: () => void;
@@ -28,12 +29,12 @@ interface SummaryModalProps {
 function SummaryModal({ title, onClose, children }: SummaryModalProps) {
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/45 px-4">
-      <div className="w-full max-w-md rounded-2xl bg-white p-5 shadow-xl">
-        <div className="mb-4 flex items-center justify-between gap-3">
-          <h2 className="text-lg font-bold text-gray-900">{title}</h2>
+      <div className="w-full max-w-[560px] rounded-3xl border border-gray-200 bg-white/95 p-6 shadow-2xl backdrop-blur">
+        <div className="mb-5 flex items-center justify-between gap-3 border-b border-gray-100 pb-4">
+          <h2 className="text-xl font-bold text-gray-900">{title}</h2>
           <button
             type="button"
-            className="rounded-md px-2 py-1 text-sm text-gray-500 hover:bg-gray-100"
+            className="rounded-full px-3 py-1.5 text-sm font-medium text-gray-400 hover:bg-gray-100 hover:text-gray-700"
             onClick={onClose}
           >
             닫기
@@ -52,28 +53,76 @@ function RoundSummaryModal({
   summary: RoundSummaryData;
   onClose: () => void;
 }) {
+  const hasMostVotedCell =
+    summary.mostVotedCellX !== null && summary.mostVotedCellY !== null;
+
+  const progressPercent =
+    summary.totalCellCount > 0
+      ? ((summary.currentPaintedCellCount / summary.totalCellCount) * 100).toFixed(1)
+      : 0;
+
   return (
     <SummaryModal
-      title={`라운드 ${summary.roundNumber} 결과`}
+      title={`${summary.roundNumber} 라운드 결과`}
       onClose={onClose}
     >
-      <div className="flex flex-col gap-2 text-sm text-gray-700">
-        <div className="flex items-center justify-between gap-3">
-          <span>참여자 수</span>
-          <span>{summary.participantCount}명</span>
-        </div>
-        <div className="flex items-center justify-between gap-3">
-          <span>총 투표 수</span>
-          <span>{summary.totalVotes}</span>
-        </div>
-        <div className="flex items-center justify-between gap-3">
-          <span>반영 칸 수</span>
-          <span>{summary.paintedCellCount}</span>
-        </div>
-        <div className="flex items-center justify-between gap-3">
-          <span>진행률</span>
-          <span>{summary.canvasProgressPercent}%</span>
-        </div>
+      <div className="space-y-5">
+        <section className="space-y-1 text-center">
+          <p className="text-sm text-gray-500">이번 라운드 결과를 정리했어요</p>
+        </section>
+
+        <section className="space-y-3 text-left text-[15px] font-bold leading-7 text-gray-700">
+          <p>
+            {summary.participantCount > 0 ? (
+              <>
+                <span className="text-[22px] text-red-500">
+                  {summary.participantCount}
+                </span>
+                명이 투표에 참여했어요
+              </>
+            ) : (
+              "참여자가 없어요."
+            )}
+          </p>
+          <p>
+            이번 라운드에 총{" "}
+            <span className="text-[22px] text-red-500">{summary.totalVotes}</span>
+            {" "}표를 모았어요.
+          </p>
+          <p>
+            이번 라운드에서 총{" "}
+            <span className="text-[22px] text-red-500">
+              {summary.paintedCellCount}
+            </span>
+            {" "}개를 색칠했어요.
+          </p>
+          <p>
+            캔버스 진행도는 {" "}
+            <span className="text-[22px] text-red-500">{progressPercent}</span>
+            {" "}% 입니다.
+          </p>
+        </section>
+
+        <section className="space-y-3 rounded-2xl border border-gray-100 bg-gray-50 px-5 py-4 text-sm leading-6 text-gray-700">
+          <p>
+            가장 인기 있던 칸은{" "}
+            <span className="font-bold text-gray-900">
+              {hasMostVotedCell
+                ? `(${summary.mostVotedCellX}, ${summary.mostVotedCellY})`
+                : "없어요"}
+            </span>
+            {hasMostVotedCell ? " 예요." : ""}
+          </p>
+          <p>
+            동점 추첨으로 결정된 칸은{" "}
+            <span className="font-bold text-gray-900">
+              {summary.randomResolvedCellCount > 0
+                ? summary.randomResolvedCellCount
+                : "없어요."}
+            </span>
+            {summary.randomResolvedCellCount > 0 ? "개였어요." : ""}
+          </p>
+        </section>
       </div>
     </SummaryModal>
   );
@@ -95,7 +144,7 @@ function GameSummaryModal({
         </div>
         <div className="flex items-center justify-between gap-3">
           <span>참여자 수</span>
-          <span>{summary.participantCount}명</span>
+          <span>{summary.participantCount} 명</span>
         </div>
         <div className="flex items-center justify-between gap-3">
           <span>총 투표 수</span>


### PR DESCRIPTION
## 관련 이슈
- Close #203 

## 작업 내용

- 라운드 종료 후 노출되는 통계 모달의 UI를 개편
- 기존 모달 오픈 방식은 유지하고, 내부 콘텐츠를 문장형 결과 요약 구조로 변경
- 이번 작업은 프론트엔드만 대상이며, 캔버스 프리뷰는 제외

### 변경 사항

- 기존 key-value 형태의 라운드 통계 노출 방식을 문장형 요약 UI로 변경
- `introCanvasPreview` 기준의 타이포그래피 톤을 참고해 숫자 강조 스타일 적용
- 라운드 제목을 {라운드번호} 라운드 결과 형식으로 정리
- 참여자 수, 총 투표 수, 색칠된 셀 수, 캔버스 진행도, 최다 득표 칸, 랜덤 당선 횟수 문구 반영
- 예외 케이스 문구 처리 추가
  - 참여자 수가 0인 경우: 참여자가 없어요.
  - 최다 득표 칸이 없는 경우: 없었어요
  - 랜덤 당선 칸이 없는 경우: 없어요.

## 테스트 및 확인 사항

- 최다 득표 칸 : 동표인 경우 제일 처음 투표 된 셀을 표기

- [x] 모달이 열림 확인
- [x] 문장형 결과 UI가 의도한 디자인 톤으로 보이는지
- [x] 참여자 수 0, 최다 득표 칸 없음, 랜덤 당선 없음 케이스 문구가 자연스럽게 노출되는지
- [x] 좌표가 내부 좌표 기준으로 표시되는지

<img width="563" height="394" alt="image" src="https://github.com/user-attachments/assets/8e106f5d-ea79-4ba4-8f13-179edff27ae8" />
<img width="453" height="204" alt="image" src="https://github.com/user-attachments/assets/fe97a3b9-3b2c-4a4a-a3dd-b030506b89cb" />

## 체크리스트
- [x] 불필요한 주석 및 디버깅 코드를 제거하였는가?
- [x] 모든 테스트를 통과하였는가?
- [x] 변경 사항에 대한 문서 업데이트가 필요한가?
