### PR TITLE
feat: feat/toolbox panel

### DIFF
--- a/frontend/src/features/gameplay/intro/components/IntroGuideModal.tsx
+++ b/frontend/src/features/gameplay/intro/components/IntroGuideModal.tsx
@@ -23,11 +23,11 @@ function buildDescription(config: GameConfig) {
 
 function getDefaultPosition() {
   const modalWidth = Math.min(720, window.innerWidth - 24);
-  const modalHeight = Math.min(window.innerHeight - 48, 720);
+  const modalHeight = Math.min(window.innerHeight - 80, 680);
 
   return {
     x: Math.max(12, Math.round((window.innerWidth - modalWidth) / 2)),
-    y: Math.max(24, Math.round((window.innerHeight - modalHeight) / 2)),
+    y: Math.max(12, Math.round((window.innerHeight - modalHeight) / 2)),
   };
 }
 
@@ -89,7 +89,7 @@ export default function IntroGuideModal({
     >
       <div
         ref={modalRef}
-        className="pointer-events-auto fixed flex max-h-[calc(100vh-48px)] w-[720px] max-w-[calc(100vw-24px)] flex-col overflow-hidden rounded-3xl border border-gray-200 bg-white/95 shadow-2xl backdrop-blur"
+        className="pointer-events-auto fixed flex max-h-[min(calc(100vh-80px),680px)] w-[720px] max-w-[calc(100vw-24px)] flex-col overflow-hidden rounded-3xl border border-gray-200 bg-white/95 shadow-2xl backdrop-blur"
         style={{ top: position.y, left: position.x }}
         onMouseDown={(event) => event.stopPropagation()}
         onClick={(event) => event.stopPropagation()}

--- a/frontend/src/features/gameplay/intro/components/IntroGuideModal.tsx
+++ b/frontend/src/features/gameplay/intro/components/IntroGuideModal.tsx
@@ -53,8 +53,6 @@ export default function IntroGuideModal({
       return;
     }
 
-    setPosition(getDefaultPosition());
-
     const handleMouseMove = (event: MouseEvent) => {
       if (!isDraggingRef.current) {
         return;
@@ -124,7 +122,7 @@ export default function IntroGuideModal({
           <div className="flex flex-col gap-6">
             <section className="space-y-1 text-center">
               <p className="text-sm text-gray-700">
-              도트를 색칠해 하나의 캔버스를 완성하세요.
+                도트를 색칠해 하나의 캔버스를 완성하세요.
               </p>
             </section>
 
@@ -133,23 +131,23 @@ export default function IntroGuideModal({
 
               <div className="space-y-1 text-left text-sm font-bold text-gray-700">
                 <p>
-                전체 라운드 수 :{" "}
+                  전체 라운드 수 :{" "}
                   <span className="text-[19px]">{description.totalRounds}</span>
                 </p>
                 <p>
-                라운드 소요 시간 :{" "}
+                  라운드 소요 시간 :{" "}
                   <span className="text-[19px]">
-                  {description.roundDurationSec}초
+                    {description.roundDurationSec}초
                   </span>
                 </p>
                 <p>
-                라운드당 투표권 수 :{" "}
+                  라운드당 투표권 수 :{" "}
                   <span className="text-[19px]">
-                  {description.votesPerRound}개
+                    {description.votesPerRound}개
                   </span>
                 </p>
                 <p>
-                캔버스 종료 시간 :{" "}
+                  캔버스 종료 시간 :{" "}
                   <span className="text-[19px]">
                     {formattedGameEndTime ?? "-"}
                   </span>
@@ -160,54 +158,54 @@ export default function IntroGuideModal({
             <div className="space-y-5 text-sm leading-6 text-gray-700">
               <section className="space-y-2">
                 <h3 className="text-center font-semibold text-gray-900">
-                게임 설명
+                  게임 설명
                 </h3>
                 <ul className="space-y-1 text-left">
-                <li>
-                  - 게임은 총{" "}
-                  <span className="text-[19px] font-bold text-red-500">
-                    {description.totalRounds}
-                  </span>
-                  개의 라운드로 진행됩니다.
-                </li>
-                <li>
-                  - 각 라운드는{" "}
-                  <span className="text-[19px] font-bold text-red-500">
-                    {description.roundDurationSec}
-                  </span>
-                  초 동안 진행되며, 매 라운드마다{" "}
-                  <span className="text-[19px] font-bold text-red-500">
-                    {description.votesPerRound}
-                  </span>
-                  개의 투표권이 주어집니다.
-                </li>
-                <li>
-                  - 서로 다른 칸에 투표하거나, 같은 칸에 여러 번 투표할 수
-                  있습니다.
-                </li>
-                <li>- 라운드가 끝나면 투표된 모든 칸이 반영됩니다.</li>
-                <li>
-                  - 각 칸은 가장 많은 표를 받은 색으로 칠해지며, 동점이면
-                  무작위로 결정됩니다.
-                </li>
+                  <li>
+                    - 게임은 총{" "}
+                    <span className="text-[19px] font-bold text-red-500">
+                      {description.totalRounds}
+                    </span>
+                    개의 라운드로 진행됩니다.
+                  </li>
+                  <li>
+                    - 각 라운드는{" "}
+                    <span className="text-[19px] font-bold text-red-500">
+                      {description.roundDurationSec}
+                    </span>
+                    초 동안 진행되며, 매 라운드마다{" "}
+                    <span className="text-[19px] font-bold text-red-500">
+                      {description.votesPerRound}
+                    </span>
+                    개의 투표권이 주어집니다.
+                  </li>
+                  <li>
+                    - 서로 다른 칸에 투표하거나, 같은 칸에 여러 번 투표할 수
+                    있습니다.
+                  </li>
+                  <li>- 라운드가 끝나면 투표된 모든 칸이 반영됩니다.</li>
+                  <li>
+                    - 각 칸은 가장 많은 표를 받은 색으로 칠해지며, 동점이면
+                    무작위로 결정됩니다.
+                  </li>
                 </ul>
               </section>
 
               <section className="space-y-2">
                 <h3 className="text-center font-semibold text-gray-900">
-                투표 방법
+                  투표 방법
                 </h3>
                 <ul className="space-y-1 text-left">
-                <li>- 원하는 칸을 선택합니다.</li>
-                <li>
-                  - 칠하고 싶은 색을 고른 뒤 ‘투표하기’ 버튼 또는 스페이스바로
-                  투표합니다.
-                </li>
-                <li>
-                  - 팔레트 칸을 선택한 뒤 ‘+’ 버튼을 누르면 색을 즐겨찾기에
-                  추가할 수 있습니다.
-                </li>
-                <li>- 주의: 한 번 투표한 내용은 변경할 수 없습니다.</li>
+                  <li>- 원하는 칸을 선택합니다.</li>
+                  <li>
+                    - 칠하고 싶은 색을 고른 뒤 ‘투표하기’ 버튼 또는 스페이스바로
+                    투표합니다.
+                  </li>
+                  <li>
+                    - 팔레트 칸을 선택한 뒤 ‘+’ 버튼을 누르면 색을 즐겨찾기에
+                    추가할 수 있습니다.
+                  </li>
+                  <li>- 주의: 한 번 투표한 내용은 변경할 수 없습니다.</li>
                 </ul>
               </section>
             </div>

--- a/frontend/src/features/gameplay/intro/components/IntroGuideModal.tsx
+++ b/frontend/src/features/gameplay/intro/components/IntroGuideModal.tsx
@@ -21,6 +21,16 @@ function buildDescription(config: GameConfig) {
   };
 }
 
+function getDefaultPosition() {
+  const modalWidth = Math.min(720, window.innerWidth - 24);
+  const modalHeight = Math.min(window.innerHeight - 48, 720);
+
+  return {
+    x: Math.max(12, Math.round((window.innerWidth - modalWidth) / 2)),
+    y: Math.max(24, Math.round((window.innerHeight - modalHeight) / 2)),
+  };
+}
+
 export default function IntroGuideModal({
   open,
   cells,
@@ -30,10 +40,7 @@ export default function IntroGuideModal({
   formattedGameEndTime,
   onClose,
 }: Props) {
-  const [position, setPosition] = useState(() => ({
-    x: window.innerWidth / 2 - 260,
-    y: 48,
-  }));
+  const [position, setPosition] = useState(getDefaultPosition);
 
   const modalRef = useRef<HTMLDivElement>(null);
   const isDraggingRef = useRef(false);
@@ -45,6 +52,8 @@ export default function IntroGuideModal({
     if (!open) {
       return;
     }
+
+    setPosition(getDefaultPosition());
 
     const handleMouseMove = (event: MouseEvent) => {
       if (!isDraggingRef.current) {
@@ -82,7 +91,7 @@ export default function IntroGuideModal({
     >
       <div
         ref={modalRef}
-        className="pointer-events-auto fixed w-[720px] max-w-[calc(100vw-24px)] rounded-3xl border border-gray-200 bg-white/95 shadow-2xl backdrop-blur"
+        className="pointer-events-auto fixed flex max-h-[calc(100vh-48px)] w-[720px] max-w-[calc(100vw-24px)] flex-col overflow-hidden rounded-3xl border border-gray-200 bg-white/95 shadow-2xl backdrop-blur"
         style={{ top: position.y, left: position.x }}
         onMouseDown={(event) => event.stopPropagation()}
         onClick={(event) => event.stopPropagation()}
@@ -111,48 +120,49 @@ export default function IntroGuideModal({
             ×
           </button>
         </div>
-        <div className="flex flex-col gap-6 px-7 py-6">
-          <section className="space-y-1 text-center">
-            <p className="text-sm text-gray-700">
+        <div className="min-h-0 flex-1 overflow-y-auto px-7 py-6">
+          <div className="flex flex-col gap-6">
+            <section className="space-y-1 text-center">
+              <p className="text-sm text-gray-700">
               도트를 색칠해 하나의 캔버스를 완성하세요.
-            </p>
-          </section>
+              </p>
+            </section>
 
-          <div className="mx-auto w-fit space-y-3">
-            <IntroCanvasPreview cells={cells} gridX={gridX} gridY={gridY} />
+            <div className="mx-auto w-fit space-y-3">
+              <IntroCanvasPreview cells={cells} gridX={gridX} gridY={gridY} />
 
-            <div className="space-y-1 text-left text-sm font-bold text-gray-700">
-              <p>
+              <div className="space-y-1 text-left text-sm font-bold text-gray-700">
+                <p>
                 전체 라운드 수 :{" "}
-                <span className="text-[19px]">{description.totalRounds}</span>
-              </p>
-              <p>
+                  <span className="text-[19px]">{description.totalRounds}</span>
+                </p>
+                <p>
                 라운드 소요 시간 :{" "}
-                <span className="text-[19px]">
+                  <span className="text-[19px]">
                   {description.roundDurationSec}초
-                </span>
-              </p>
-              <p>
+                  </span>
+                </p>
+                <p>
                 라운드당 투표권 수 :{" "}
-                <span className="text-[19px]">
+                  <span className="text-[19px]">
                   {description.votesPerRound}개
-                </span>
-              </p>
-              <p>
+                  </span>
+                </p>
+                <p>
                 캔버스 종료 시간 :{" "}
-                <span className="text-[19px]">
-                  {formattedGameEndTime ?? "-"}
-                </span>
-              </p>
+                  <span className="text-[19px]">
+                    {formattedGameEndTime ?? "-"}
+                  </span>
+                </p>
+              </div>
             </div>
-          </div>
 
-          <div className="space-y-5 text-sm leading-6 text-gray-700">
-            <section className="space-y-2">
-              <h3 className="text-center font-semibold text-gray-900">
+            <div className="space-y-5 text-sm leading-6 text-gray-700">
+              <section className="space-y-2">
+                <h3 className="text-center font-semibold text-gray-900">
                 게임 설명
-              </h3>
-              <ul className="space-y-1 text-left">
+                </h3>
+                <ul className="space-y-1 text-left">
                 <li>
                   - 게임은 총{" "}
                   <span className="text-[19px] font-bold text-red-500">
@@ -180,14 +190,14 @@ export default function IntroGuideModal({
                   - 각 칸은 가장 많은 표를 받은 색으로 칠해지며, 동점이면
                   무작위로 결정됩니다.
                 </li>
-              </ul>
-            </section>
+                </ul>
+              </section>
 
-            <section className="space-y-2">
-              <h3 className="text-center font-semibold text-gray-900">
+              <section className="space-y-2">
+                <h3 className="text-center font-semibold text-gray-900">
                 투표 방법
-              </h3>
-              <ul className="space-y-1 text-left">
+                </h3>
+                <ul className="space-y-1 text-left">
                 <li>- 원하는 칸을 선택합니다.</li>
                 <li>
                   - 칠하고 싶은 색을 고른 뒤 ‘투표하기’ 버튼 또는 스페이스바로
@@ -198,8 +208,9 @@ export default function IntroGuideModal({
                   추가할 수 있습니다.
                 </li>
                 <li>- 주의: 한 번 투표한 내용은 변경할 수 없습니다.</li>
-              </ul>
-            </section>
+                </ul>
+              </section>
+            </div>
           </div>
         </div>
       </div>

--- a/frontend/src/features/gameplay/intro/components/IntroPanelButton.tsx
+++ b/frontend/src/features/gameplay/intro/components/IntroPanelButton.tsx
@@ -1,0 +1,29 @@
+interface IntroPanelButtonProps {
+  onClick: () => void;
+}
+
+export default function IntroPanelButton({
+  onClick,
+}: IntroPanelButtonProps) {
+  return (
+    <button
+      type="button"
+      className="flex w-full items-center justify-between rounded-2xl border border-gray-200 bg-white px-4 py-4 text-left shadow-sm transition hover:border-gray-300 hover:bg-gray-50"
+      onClick={onClick}
+    >
+      <div className="min-w-0">
+        <p className="text-xs font-semibold uppercase tracking-[0.08em] text-gray-400">
+          Intro
+        </p>
+        <p className="mt-1 text-base font-bold text-gray-900">게임 안내</p>
+        <p className="mt-1 text-sm text-gray-500">
+          언제든지 인트로 모달을 다시 열 수 있어요.
+        </p>
+      </div>
+
+      <span className="shrink-0 rounded-full bg-gray-100 px-3 py-1 text-sm font-semibold text-gray-700">
+        열기
+      </span>
+    </button>
+  );
+}

--- a/frontend/src/features/gameplay/round/components/RoundInfo.tsx
+++ b/frontend/src/features/gameplay/round/components/RoundInfo.tsx
@@ -19,6 +19,8 @@ function getPhaseLabel(phase: GamePhase): string {
       return "라운드 결과 집계 중";
     case GAME_PHASE.GAME_END:
       return "게임 종료";
+    default:
+      return "-";
   }
 }
 

--- a/frontend/src/features/gameplay/round/components/RoundPanelList.tsx
+++ b/frontend/src/features/gameplay/round/components/RoundPanelList.tsx
@@ -1,0 +1,20 @@
+interface RoundPanelListProps {
+  children: React.ReactNode;
+}
+
+export default function RoundPanelList({ children }: RoundPanelListProps) {
+  return (
+    <section className="flex min-h-0 flex-1 flex-col overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-sm">
+      <div className="border-b border-gray-100 px-4 py-3">
+        <p className="text-xs font-semibold uppercase tracking-[0.08em] text-gray-400">
+          Round
+        </p>
+        <p className="mt-1 text-base font-bold text-gray-900">최근 라운드</p>
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-y-auto px-3 py-3">
+        <div className="space-y-3">{children}</div>
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/features/gameplay/round/components/RoundSummaryModal.tsx
+++ b/frontend/src/features/gameplay/round/components/RoundSummaryModal.tsx
@@ -1,0 +1,160 @@
+import type { MouseEvent } from "react";
+import type { RoundSummaryData } from "@/features/gameplay/session/api/session.api";
+
+interface RoundSummaryModalProps {
+  open: boolean;
+  summary: RoundSummaryData | null;
+  snapshot: string | null;
+  position: { x: number; y: number };
+  onClose: () => void;
+  onDragStart: (event: MouseEvent<HTMLDivElement>) => void;
+}
+
+function renderParticipantCopy(count: number) {
+  if (count > 0) {
+    return (
+      <>
+        <span className="text-[22px] text-red-500">{count}</span>
+        명이 투표에 참여했어요
+      </>
+    );
+  }
+
+  return "참여자가 없어요.";
+}
+
+function renderMostVotedCell(summary: RoundSummaryData) {
+  if (
+    summary.mostVotedCellX === null ||
+    summary.mostVotedCellY === null
+  ) {
+    return "없었어요";
+  }
+
+  return `(${summary.mostVotedCellX}, ${summary.mostVotedCellY})`;
+}
+
+export default function RoundSummaryModal({
+  open,
+  summary,
+  snapshot,
+  position,
+  onClose,
+  onDragStart,
+}: RoundSummaryModalProps) {
+  if (!open || !summary) {
+    return null;
+  }
+
+  const progressPercent =
+    summary.totalCellCount > 0
+      ? (
+          (summary.currentPaintedCellCount / summary.totalCellCount) *
+          100
+        ).toFixed(1)
+      : "0.0";
+
+  return (
+    <div
+      className="fixed inset-0 z-50"
+      onMouseDown={(event) => event.stopPropagation()}
+      onClick={(event) => event.stopPropagation()}
+    >
+      <div
+        className="pointer-events-auto fixed flex max-h-[calc(100vh-48px)] w-[560px] max-w-[calc(100vw-24px)] flex-col overflow-hidden rounded-3xl border border-gray-200 bg-white/95 shadow-2xl backdrop-blur"
+        style={{ top: position.y, left: position.x }}
+        onMouseDown={(event) => event.stopPropagation()}
+        onClick={(event) => event.stopPropagation()}
+      >
+        <div
+          className="relative flex cursor-move items-center justify-center border-b border-gray-100 px-5 py-4"
+          onMouseDown={onDragStart}
+        >
+          <p className="text-center text-base font-semibold text-gray-900">
+            {summary.roundNumber} 라운드 결과
+          </p>
+
+          <button
+            type="button"
+            onClick={onClose}
+            className="absolute right-5 top-1/2 flex h-8 w-8 -translate-y-1/2 items-center justify-center rounded-full text-gray-400 hover:bg-gray-100 hover:text-gray-700"
+            aria-label="라운드 결과 닫기"
+          >
+            ×
+          </button>
+        </div>
+
+        <div className="min-h-0 flex-1 overflow-y-auto px-6 py-6">
+          <div className="space-y-5">
+            {snapshot && (
+              <div className="mx-auto w-1/2 overflow-hidden rounded-2xl border border-gray-200 bg-white">
+                <img
+                  src={snapshot}
+                  alt={`${summary.roundNumber} 라운드 스냅샷`}
+                  className="block w-full bg-white"
+                  draggable={false}
+                />
+              </div>
+            )}
+
+            <section className="space-y-1 text-center">
+              <p className="text-sm text-gray-500">
+                이번 라운드 결과를 정리했어요
+              </p>
+              <p className="text-2xl font-bold text-gray-900">
+                {summary.roundNumber} 라운드 결과
+              </p>
+            </section>
+
+            <section className="space-y-3 text-left text-[15px] font-bold leading-7 text-gray-700">
+              <p>{renderParticipantCopy(summary.participantCount)}</p>
+              <p>
+                이번 라운드 총{" "}
+                <span className="text-[22px] text-red-500">
+                  {summary.totalVotes}
+                </span>
+                표가 모였어요
+              </p>
+              <p>
+                이번 라운드에서{" "}
+                <span className="text-[22px] text-red-500">
+                  {summary.paintedCellCount}
+                </span>
+                개를 색칠했어요
+              </p>
+              <p>
+                캔버스 진행도{" "}
+                <span className="text-[22px] text-red-500">
+                  {progressPercent}
+                </span>
+                %
+              </p>
+            </section>
+
+            <section className="space-y-3 rounded-2xl border border-gray-100 bg-gray-50 px-5 py-4 text-sm leading-6 text-gray-700">
+              <p>
+                가장 인기 있었던 칸은{" "}
+                <span className="font-bold text-gray-900">
+                  {renderMostVotedCell(summary)}
+                </span>
+                {summary.mostVotedCellX !== null &&
+                summary.mostVotedCellY !== null
+                  ? " 이었어요."
+                  : ""}
+              </p>
+              <p>
+                동점 추첨으로 결정된 칸은{" "}
+                <span className="font-bold text-gray-900">
+                  {summary.randomResolvedCellCount > 0
+                    ? summary.randomResolvedCellCount
+                    : "없어요."}
+                </span>
+                {summary.randomResolvedCellCount > 0 ? "개였어요." : ""}
+              </p>
+            </section>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/features/gameplay/round/index.ts
+++ b/frontend/src/features/gameplay/round/index.ts
@@ -1,4 +1,5 @@
 export { default as RoundInfo } from "./components/RoundInfo";
+export { default as RoundPanelList } from "./components/RoundPanelList";
 export { default as useRoundState } from "./hooks/useRoundState";
 export { default as useRoundTimer } from "./hooks/useRoundTimer";
 export * from "./model/round.formatters";

--- a/frontend/src/features/gameplay/round/model/roundSnapshot.capture.ts
+++ b/frontend/src/features/gameplay/round/model/roundSnapshot.capture.ts
@@ -1,0 +1,17 @@
+interface CaptureRoundSnapshotParams {
+  canvas: HTMLCanvasElement;
+  type?: "image/png" | "image/jpeg" | "image/webp";
+  quality?: number;
+}
+
+export function captureRoundSnapshot({
+  canvas,
+  type = "image/png",
+  quality,
+}: CaptureRoundSnapshotParams): string | null {
+  try {
+    return canvas.toDataURL(type, quality);
+  } catch {
+    return null;
+  }
+}

--- a/frontend/src/features/gameplay/round/model/roundSnapshot.storage.ts
+++ b/frontend/src/features/gameplay/round/model/roundSnapshot.storage.ts
@@ -1,0 +1,48 @@
+const LATEST_ROUND_SNAPSHOT_KEY = "latest-round-snapshot";
+const LATEST_ROUND_NUMBER_KEY = "latest-round-number";
+
+export interface LatestRoundSnapshot {
+  roundNumber: number | null;
+  snapshot: string | null;
+}
+
+export function getLatestRoundSnapshot(): LatestRoundSnapshot {
+  try {
+    const snapshot = window.localStorage.getItem(LATEST_ROUND_SNAPSHOT_KEY);
+    const roundNumberRaw = window.localStorage.getItem(LATEST_ROUND_NUMBER_KEY);
+
+    return {
+      snapshot,
+      roundNumber: roundNumberRaw ? Number(roundNumberRaw) : null,
+    };
+  } catch {
+    return {
+      snapshot: null,
+      roundNumber: null,
+    };
+  }
+}
+
+export function setLatestRoundSnapshot(
+  roundNumber: number,
+  snapshot: string,
+): boolean {
+  try {
+    window.localStorage.setItem(LATEST_ROUND_SNAPSHOT_KEY, snapshot);
+    window.localStorage.setItem(LATEST_ROUND_NUMBER_KEY, String(roundNumber));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function clearLatestRoundSnapshot(): void {
+  try {
+    window.localStorage.removeItem(LATEST_ROUND_SNAPSHOT_KEY);
+    window.localStorage.removeItem(LATEST_ROUND_NUMBER_KEY);
+  } catch {
+    // no-op
+  }
+}
+
+export { LATEST_ROUND_SNAPSHOT_KEY, LATEST_ROUND_NUMBER_KEY };

--- a/frontend/src/pages/canvas/CanvasPage.tsx
+++ b/frontend/src/pages/canvas/CanvasPage.tsx
@@ -260,18 +260,20 @@ export default function CanvasPage() {
         )}
       </div>
 
-      <IntroGuideModal
-        open={introGuideOpen && !!gameConfig && cells.length > 0}
-        cells={cells}
-        gridX={gridX}
-        gridY={gridY}
-        gameConfig={gameConfig!}
-        formattedGameEndTime={formattedGameEndTime}
-        onClose={() => {
-          setIntroModalDismissed(true);
-          handleCloseIntroGuide();
-        }}
-      />
+      {introGuideOpen && gameConfig && cells.length > 0 && (
+        <IntroGuideModal
+          open={true}
+          cells={cells}
+          gridX={gridX}
+          gridY={gridY}
+          gameConfig={gameConfig!}
+          formattedGameEndTime={formattedGameEndTime}
+          onClose={() => {
+            setIntroModalDismissed(true);
+            handleCloseIntroGuide();
+          }}
+        />
+      )}
 
       {popupOpen && selectedCell && canvasId && (
         <VotePopup

--- a/frontend/src/pages/canvas/CanvasPage.tsx
+++ b/frontend/src/pages/canvas/CanvasPage.tsx
@@ -1,25 +1,24 @@
-import { useCallback, useState, useEffect } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import {
   CanvasStage,
   CanvasSurface,
   PANEL_WIDTH,
 } from "@/features/gameplay/canvas";
-import { IntroGuideModal } from "@/features/gameplay/intro"; // 추가: INTRO 안내 모달
+import { IntroGuideModal } from "@/features/gameplay/intro";
+import { RoundPanelList } from "@/features/gameplay/round";
+import RoundSummaryModal from "@/features/gameplay/round/components/RoundSummaryModal";
 import {
   ErrorScreen,
   GameEndedScreen,
   LoadingScreen,
 } from "@/features/gameplay/session";
-import { GAME_PHASE } from "@/features/gameplay/session/model/game-phase.types"; // 추가: INTRO phase 판별
+import { GAME_PHASE } from "@/features/gameplay/session/model/game-phase.types";
 import { VotePanel, VotePopup } from "@/features/gameplay/vote";
+import IntroPanelButton from "@/features/gameplay/intro/components/IntroPanelButton";
 import useCanvasPage from "./model/useCanvasPage";
-import type {
-  GameSummaryData,
-  RoundSummaryData,
-} from "@/features/gameplay/session/api/session.api";
+import type { GameSummaryData } from "@/features/gameplay/session/api/session.api";
 
-// to-be
 interface SummaryModalProps {
   title: string;
   onClose: () => void;
@@ -46,88 +45,6 @@ function SummaryModal({ title, onClose, children }: SummaryModalProps) {
   );
 }
 
-function RoundSummaryModal({
-  summary,
-  onClose,
-}: {
-  summary: RoundSummaryData;
-  onClose: () => void;
-}) {
-  const hasMostVotedCell =
-    summary.mostVotedCellX !== null && summary.mostVotedCellY !== null;
-
-  const progressPercent =
-    summary.totalCellCount > 0
-      ? ((summary.currentPaintedCellCount / summary.totalCellCount) * 100).toFixed(1)
-      : 0;
-
-  return (
-    <SummaryModal
-      title={`${summary.roundNumber} 라운드 결과`}
-      onClose={onClose}
-    >
-      <div className="space-y-5">
-        <section className="space-y-1 text-center">
-          <p className="text-sm text-gray-500">이번 라운드 결과를 정리했어요</p>
-        </section>
-
-        <section className="space-y-3 text-left text-[15px] font-bold leading-7 text-gray-700">
-          <p>
-            {summary.participantCount > 0 ? (
-              <>
-                <span className="text-[22px] text-red-500">
-                  {summary.participantCount}
-                </span>
-                명이 투표에 참여했어요
-              </>
-            ) : (
-              "참여자가 없어요."
-            )}
-          </p>
-          <p>
-            이번 라운드에 총{" "}
-            <span className="text-[22px] text-red-500">{summary.totalVotes}</span>
-            {" "}표를 모았어요.
-          </p>
-          <p>
-            이번 라운드에서 총{" "}
-            <span className="text-[22px] text-red-500">
-              {summary.paintedCellCount}
-            </span>
-            {" "}개를 색칠했어요.
-          </p>
-          <p>
-            캔버스 진행도는 {" "}
-            <span className="text-[22px] text-red-500">{progressPercent}</span>
-            {" "}% 입니다.
-          </p>
-        </section>
-
-        <section className="space-y-3 rounded-2xl border border-gray-100 bg-gray-50 px-5 py-4 text-sm leading-6 text-gray-700">
-          <p>
-            가장 인기 있던 칸은{" "}
-            <span className="font-bold text-gray-900">
-              {hasMostVotedCell
-                ? `(${summary.mostVotedCellX}, ${summary.mostVotedCellY})`
-                : "없어요"}
-            </span>
-            {hasMostVotedCell ? " 예요." : ""}
-          </p>
-          <p>
-            동점 추첨으로 결정된 칸은{" "}
-            <span className="font-bold text-gray-900">
-              {summary.randomResolvedCellCount > 0
-                ? summary.randomResolvedCellCount
-                : "없어요."}
-            </span>
-            {summary.randomResolvedCellCount > 0 ? "개였어요." : ""}
-          </p>
-        </section>
-      </div>
-    </SummaryModal>
-  );
-}
-
 function GameSummaryModal({
   summary,
   onClose,
@@ -144,7 +61,7 @@ function GameSummaryModal({
         </div>
         <div className="flex items-center justify-between gap-3">
           <span>참여자 수</span>
-          <span>{summary.participantCount} 명</span>
+          <span>{summary.participantCount}명</span>
         </div>
         <div className="flex items-center justify-between gap-3">
           <span>총 투표 수</span>
@@ -220,20 +137,32 @@ export default function CanvasPage() {
     viewport,
     navigateToCoordinate,
     resetCanvasZoom,
+    introGuideOpen,
+    handleOpenIntroGuide,
+    handleCloseIntroGuide,
+    roundSummaryOpen,
+    roundSummaryPosition,
+    handleRoundSummaryDragStart,
+    handleOpenLatestRoundSummary,
+    latestRoundSummary,
+    latestRoundSnapshot,
+    isLatestRoundSummaryEnabled,
   } = useCanvasPage({
     onSessionEnded: handleSessionEnded,
     onUnauthorized: handleUnauthorized,
   });
 
-  if (phase !== GAME_PHASE.INTRO && introModalDismissed) {
-    setIntroModalDismissed(false); // 추가: INTRO이 끝났다가 다음 게임 INTRO이 오면 다시 모달 표시
-  }
-
   useEffect(() => {
-    if (phase !== GAME_PHASE.INTRO) {
-      setIntroModalDismissed(false); // 변경: INTRO이 아닐 때 닫힘 상태 초기화
+    if (phase === GAME_PHASE.INTRO && !introModalDismissed) {
+      handleOpenIntroGuide();
+      return;
     }
-  }, [phase]);
+
+    if (phase !== GAME_PHASE.INTRO) {
+      handleCloseIntroGuide();
+      setIntroModalDismissed(false);
+    }
+  }, [handleCloseIntroGuide, handleOpenIntroGuide, introModalDismissed, phase]);
 
   if (loading) {
     return <LoadingScreen />;
@@ -243,13 +172,39 @@ export default function CanvasPage() {
     return <ErrorScreen message={error} />;
   }
 
-  // test 임시 수정
-  if (gameEnded && !gameSummaryModal) {
+  if (gameEnded) {
     return <GameEndedScreen />;
   }
 
   return (
-    <div className="flex h-screen w-full">
+    <div className="flex h-screen w-full bg-gray-50">
+      <aside className="flex w-[256px] shrink-0 flex-col gap-3 border-r border-gray-200 bg-white px-4 py-5">
+        <IntroPanelButton onClick={handleOpenIntroGuide} />
+
+        <RoundPanelList>
+          <button
+            type="button"
+            className="w-full rounded-2xl border border-gray-200 bg-white px-4 py-4 text-left shadow-sm transition hover:border-gray-300 hover:bg-gray-50 disabled:cursor-not-allowed disabled:border-gray-100 disabled:bg-gray-50 disabled:opacity-60"
+            onClick={handleOpenLatestRoundSummary}
+            disabled={!isLatestRoundSummaryEnabled || !latestRoundSummary}
+          >
+            <p className="text-xs font-semibold uppercase tracking-[0.08em] text-gray-400">
+              Round
+            </p>
+            <p className="mt-1 text-base font-bold text-gray-900">
+              {latestRoundSummary
+                ? `${latestRoundSummary.roundNumber} 라운드 결과`
+                : "최근 라운드 결과"}
+            </p>
+            <p className="mt-1 text-sm text-gray-500">
+              {isLatestRoundSummaryEnabled && latestRoundSummary
+                ? "클릭하면 최근 라운드 통계 모달을 열 수 있어요."
+                : "ROUND_RESULT 또는 ROUND_START_WAIT 상태에서만 열 수 있어요."}
+            </p>
+          </button>
+        </RoundPanelList>
+      </aside>
+
       <CanvasStage
         containerRef={containerRef}
         overlay={
@@ -275,37 +230,6 @@ export default function CanvasPage() {
       >
         <CanvasSurface canvasRef={canvasRef} />
       </CanvasStage>
-
-      <IntroGuideModal
-        open={
-          phase === GAME_PHASE.INTRO &&
-          !introModalDismissed &&
-          !!gameConfig &&
-          cells.length > 0
-        } // 추가: INTRO phase에서만 전체 캔버스 안내 모달 표시
-        cells={cells}
-        gridX={gridX}
-        gridY={gridY}
-        gameConfig={gameConfig!}
-        formattedGameEndTime={formattedGameEndTime}
-        onClose={() => setIntroModalDismissed(true)}
-      />
-
-      {popupOpen && selectedCell && canvasId && (
-        <VotePopup
-          canvasId={canvasId}
-          roundId={roundId}
-          phase={phase}
-          isRoundExpired={isRoundExpired}
-          selectedCell={selectedCell}
-          votes={votes}
-          cells={cells}
-          position={popupPos}
-          onVoteSuccess={handleVoteSuccess}
-          onColorChange={handleColorChange}
-          onClose={handlePopupClose}
-        />
-      )}
 
       <div
         className="shrink-0 border-l border-gray-200 bg-white"
@@ -336,12 +260,43 @@ export default function CanvasPage() {
         )}
       </div>
 
-      {roundSummaryModal && (
-        <RoundSummaryModal
-          summary={roundSummaryModal}
-          onClose={handleCloseRoundSummaryModal}
+      <IntroGuideModal
+        open={introGuideOpen && !!gameConfig && cells.length > 0}
+        cells={cells}
+        gridX={gridX}
+        gridY={gridY}
+        gameConfig={gameConfig!}
+        formattedGameEndTime={formattedGameEndTime}
+        onClose={() => {
+          setIntroModalDismissed(true);
+          handleCloseIntroGuide();
+        }}
+      />
+
+      {popupOpen && selectedCell && canvasId && (
+        <VotePopup
+          canvasId={canvasId}
+          roundId={roundId}
+          phase={phase}
+          isRoundExpired={isRoundExpired}
+          selectedCell={selectedCell}
+          votes={votes}
+          cells={cells}
+          position={popupPos}
+          onVoteSuccess={handleVoteSuccess}
+          onColorChange={handleColorChange}
+          onClose={handlePopupClose}
         />
       )}
+
+      <RoundSummaryModal
+        open={roundSummaryOpen}
+        summary={roundSummaryModal}
+        snapshot={latestRoundSnapshot}
+        position={roundSummaryPosition}
+        onClose={handleCloseRoundSummaryModal}
+        onDragStart={handleRoundSummaryDragStart}
+      />
 
       {gameSummaryModal && (
         <GameSummaryModal

--- a/frontend/src/pages/canvas/model/useCanvasGameplay.ts
+++ b/frontend/src/pages/canvas/model/useCanvasGameplay.ts
@@ -99,9 +99,12 @@ export default function useCanvasGameplay({
   const phaseTimingRef = useRef<PhaseTimingState>(DEFAULT_PHASE_TIMING);
   const localPhaseTransitionTimerRef = useRef<number | null>(null);
   const snapshotDelayTimerRef = useRef<number | null>(null);
-  const pendingSnapshotRoundRef = useRef<{
+  const pendingRoundResultRef = useRef<{
     roundId: number;
     roundNumber: number;
+    summaryReady: boolean;
+    canvasApplied: boolean;
+    summary: RoundSummaryData | null;
   } | null>(null);
   const [gameConfig, setGameConfigState] = useState<GameConfig | null>(null);
   const [roundSummary, setRoundSummary] = useState<RoundSummaryData | null>(null);
@@ -111,6 +114,8 @@ export default function useCanvasGameplay({
   const [latestRoundSnapshot, setLatestRoundSnapshotState] = useState<string | null>(
     () => getLatestRoundSnapshot().snapshot,
   );
+  const [isLatestRoundSummaryReady, setIsLatestRoundSummaryReady] =
+    useState(false);
 
   const clearLocalPhaseTransitionTimer = useCallback(() => {
     if (localPhaseTransitionTimerRef.current === null) {
@@ -207,7 +212,7 @@ export default function useCanvasGameplay({
       if (!snapshot) {
         clearLatestRoundSnapshot();
         setLatestRoundSnapshotState(null);
-        return;
+        return false;
       }
 
       const saved = setLatestRoundSnapshot(targetRoundNumber, snapshot);
@@ -215,13 +220,41 @@ export default function useCanvasGameplay({
       if (!saved) {
         clearLatestRoundSnapshot();
         setLatestRoundSnapshotState(null);
-        return;
+        return false;
       }
 
       setLatestRoundSnapshotState(snapshot);
+      return true;
     },
     [canvasElementRef],
   );
+
+  const completePendingRoundResult = useCallback(() => {
+    const pending = pendingRoundResultRef.current;
+
+    if (!pending || !pending.summaryReady || !pending.canvasApplied) {
+      return;
+    }
+
+    clearSnapshotDelayTimer();
+
+    snapshotDelayTimerRef.current = window.setTimeout(() => {
+      snapshotDelayTimerRef.current = null;
+
+      const saved = finalizeRoundSnapshot(pending.roundNumber);
+
+      if (pending.summary) {
+        onOpenRoundSummaryModal(pending.summary);
+      }
+
+      setIsLatestRoundSummaryReady(true);
+      pendingRoundResultRef.current = null;
+
+      if (!saved) {
+        return;
+      }
+    }, 500);
+  }, [clearSnapshotDelayTimer, finalizeRoundSnapshot, onOpenRoundSummaryModal]);
 
   const applyBootstrap = useCallback(
     (result: SessionBootstrapResult) => {
@@ -481,7 +514,8 @@ export default function useCanvasGameplay({
     }) => {
       clearLocalPhaseTransitionTimer();
       clearSnapshotDelayTimer();
-      pendingSnapshotRoundRef.current = null;
+      pendingRoundResultRef.current = null;
+      setIsLatestRoundSummaryReady(false);
       setRoundSummary(null);
       setGameSummary(null);
       setRoundSummaryLoading(false);
@@ -532,9 +566,13 @@ export default function useCanvasGameplay({
       resetVoteState();
       setRoundSummary(null);
       setRoundSummaryLoading(true);
-      pendingSnapshotRoundRef.current = {
+      setIsLatestRoundSummaryReady(false);
+      pendingRoundResultRef.current = {
         roundId,
         roundNumber,
+        summaryReady: false,
+        canvasApplied: false,
+        summary: null,
       };
 
       const resultEndsAt = new Date(
@@ -581,16 +619,30 @@ export default function useCanvasGameplay({
           return;
         }
 
-        onOpenRoundSummaryModal(summary);
+        if (
+          pendingRoundResultRef.current &&
+          pendingRoundResultRef.current.roundId === readyRoundId
+        ) {
+          pendingRoundResultRef.current = {
+            ...pendingRoundResultRef.current,
+            summaryReady: true,
+            summary,
+          };
+          completePendingRoundResult();
+          return;
+        }
+
+        setIsLatestRoundSummaryReady(true);
       });
     },
-    [canvasId, onOpenRoundSummaryModal, requestRoundSummary],
+    [canvasId, completePendingRoundResult, requestRoundSummary],
   );
 
   const handleSessionEnded = useCallback(() => {
     clearLocalPhaseTransitionTimer();
     clearSnapshotDelayTimer();
-    pendingSnapshotRoundRef.current = null;
+    pendingRoundResultRef.current = null;
+    setIsLatestRoundSummaryReady(false);
     clearTickets();
     clearParticipants();
     resetRoundState();
@@ -650,7 +702,8 @@ export default function useCanvasGameplay({
   const handleGameEnded = useCallback(() => {
     clearLocalPhaseTransitionTimer();
     clearSnapshotDelayTimer();
-    pendingSnapshotRoundRef.current = null;
+    pendingRoundResultRef.current = null;
+    setIsLatestRoundSummaryReady(false);
     markGameEnded();
     clearTickets();
     clearParticipants();
@@ -685,23 +738,20 @@ export default function useCanvasGameplay({
     (payload: CanvasBatchUpdatedPayload) => {
       onCanvasBatchUpdated(payload);
 
-      if (!pendingSnapshotRoundRef.current) {
+      if (!pendingRoundResultRef.current) {
         return;
       }
 
-      const targetRound = pendingSnapshotRoundRef.current;
-      pendingSnapshotRoundRef.current = null;
-
-      clearSnapshotDelayTimer();
+      pendingRoundResultRef.current = {
+        ...pendingRoundResultRef.current,
+        canvasApplied: true,
+      };
 
       window.requestAnimationFrame(() => {
-        snapshotDelayTimerRef.current = window.setTimeout(() => {
-          snapshotDelayTimerRef.current = null;
-          finalizeRoundSnapshot(targetRound.roundNumber);
-        }, 500);
+        completePendingRoundResult();
       });
     },
-    [clearSnapshotDelayTimer, finalizeRoundSnapshot, onCanvasBatchUpdated],
+    [completePendingRoundResult, onCanvasBatchUpdated],
   );
 
   useGameplaySocket({
@@ -751,6 +801,7 @@ export default function useCanvasGameplay({
     gameConfig,
     roundSummary,
     latestRoundSnapshot,
+    isLatestRoundSummaryReady,
     gameSummary,
     roundSummaryLoading,
     gameSummaryLoading,

--- a/frontend/src/pages/canvas/model/useCanvasGameplay.ts
+++ b/frontend/src/pages/canvas/model/useCanvasGameplay.ts
@@ -1,12 +1,12 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState, type RefObject } from "react";
 import { useRoundState, useRoundTimer } from "@/features/gameplay/round";
 import {
   sessionApi,
   useGameSession,
   useGameplaySocket,
   useParticipantsState,
-  type SessionBootstrapResult,
   type PhaseTimingState,
+  type SessionBootstrapResult,
 } from "@/features/gameplay/session";
 import type {
   GameSummaryData,
@@ -21,6 +21,12 @@ import {
   GAME_PHASE,
   isRoundActivePhase,
 } from "@/features/gameplay/session/model/game-phase.types";
+import { captureRoundSnapshot } from "@/features/gameplay/round/model/roundSnapshot.capture";
+import {
+  clearLatestRoundSnapshot,
+  getLatestRoundSnapshot,
+  setLatestRoundSnapshot,
+} from "@/features/gameplay/round/model/roundSnapshot.storage";
 import type { GameConfig } from "@/shared/config/game-config";
 import { useVoteTickets } from "@/features/gameplay/vote";
 
@@ -32,6 +38,7 @@ function formatClockTime(date: Date): string {
 
 interface UseCanvasGameplayParams {
   canvasId: number | null;
+  canvasElementRef: RefObject<HTMLCanvasElement | null>;
   onBootstrapScene: (result: SessionBootstrapResult) => void;
   onCanvasUpdated: (payload: { cellId: number; color: string }) => void;
   onCanvasBatchUpdated: (payload: CanvasBatchUpdatedPayload) => void;
@@ -53,6 +60,7 @@ const DEFAULT_PHASE_TIMING: PhaseTimingState = {
 
 export default function useCanvasGameplay({
   canvasId,
+  canvasElementRef,
   onBootstrapScene,
   onCanvasUpdated,
   onCanvasBatchUpdated,
@@ -90,15 +98,19 @@ export default function useCanvasGameplay({
 
   const phaseTimingRef = useRef<PhaseTimingState>(DEFAULT_PHASE_TIMING);
   const localPhaseTransitionTimerRef = useRef<number | null>(null);
-  const [gameConfig, setGameConfigState] = useState<GameConfig | null>(null); // 추가: bootstrap된 현재 게임 설정 보관
-  const [roundSummary, setRoundSummary] = useState(
-    null as RoundSummaryData | null,
-  );
-  const [gameSummary, setGameSummary] = useState(
-    null as GameSummaryData | null,
-  );
+  const snapshotDelayTimerRef = useRef<number | null>(null);
+  const pendingSnapshotRoundRef = useRef<{
+    roundId: number;
+    roundNumber: number;
+  } | null>(null);
+  const [gameConfig, setGameConfigState] = useState<GameConfig | null>(null);
+  const [roundSummary, setRoundSummary] = useState<RoundSummaryData | null>(null);
+  const [gameSummary, setGameSummary] = useState<GameSummaryData | null>(null);
   const [roundSummaryLoading, setRoundSummaryLoading] = useState(false);
   const [gameSummaryLoading, setGameSummaryLoading] = useState(false);
+  const [latestRoundSnapshot, setLatestRoundSnapshotState] = useState<string | null>(
+    () => getLatestRoundSnapshot().snapshot,
+  );
 
   const clearLocalPhaseTransitionTimer = useCallback(() => {
     if (localPhaseTransitionTimerRef.current === null) {
@@ -107,6 +119,15 @@ export default function useCanvasGameplay({
 
     window.clearTimeout(localPhaseTransitionTimerRef.current);
     localPhaseTransitionTimerRef.current = null;
+  }, []);
+
+  const clearSnapshotDelayTimer = useCallback(() => {
+    if (snapshotDelayTimerRef.current === null) {
+      return;
+    }
+
+    window.clearTimeout(snapshotDelayTimerRef.current);
+    snapshotDelayTimerRef.current = null;
   }, []);
 
   const { remaining, setRemaining, fetchTickets, clearTickets } =
@@ -129,7 +150,6 @@ export default function useCanvasGameplay({
 
       try {
         const response = await sessionApi.getGameSummary(targetCanvasId);
-
         const nextSummary = response.data.data;
 
         setGameSummary(nextSummary);
@@ -151,7 +171,6 @@ export default function useCanvasGameplay({
         return;
       }
 
-      setGameSummaryLoading(true);
       void requestGameSummary(readyCanvasId);
     },
     [canvasId, requestGameSummary],
@@ -168,23 +187,46 @@ export default function useCanvasGameplay({
         );
 
         const nextSummary = response.data.data;
-
         setRoundSummary(nextSummary);
-        onOpenRoundSummaryModal(nextSummary);
+        return nextSummary;
       } catch (error) {
         console.error("[summary] failed to load round summary:", error);
+        return null;
       } finally {
         setRoundSummaryLoading(false);
       }
     },
-    [onOpenRoundSummaryModal],
+    [],
+  );
+
+  const finalizeRoundSnapshot = useCallback(
+    (targetRoundNumber: number) => {
+      const canvas = canvasElementRef.current;
+      const snapshot = canvas ? captureRoundSnapshot({ canvas }) : null;
+
+      if (!snapshot) {
+        clearLatestRoundSnapshot();
+        setLatestRoundSnapshotState(null);
+        return;
+      }
+
+      const saved = setLatestRoundSnapshot(targetRoundNumber, snapshot);
+
+      if (!saved) {
+        clearLatestRoundSnapshot();
+        setLatestRoundSnapshotState(null);
+        return;
+      }
+
+      setLatestRoundSnapshotState(snapshot);
+    },
+    [canvasElementRef],
   );
 
   const applyBootstrap = useCallback(
     (result: SessionBootstrapResult) => {
       phaseTimingRef.current = result.phaseTiming;
-      setGameConfigState(result.gameConfig); // 추가: INTRO 모달에서 현재 게임 설정을 바로 쓸 수 있게 저장
-
+      setGameConfigState(result.gameConfig);
       onBootstrapScene(result);
 
       setRoundState({
@@ -252,8 +294,9 @@ export default function useCanvasGameplay({
   useEffect(() => {
     return () => {
       clearLocalPhaseTransitionTimer();
+      clearSnapshotDelayTimer();
     };
-  }, [clearLocalPhaseTransitionTimer]);
+  }, [clearLocalPhaseTransitionTimer, clearSnapshotDelayTimer]);
 
   useEffect(() => {
     let cancelled = false;
@@ -325,7 +368,7 @@ export default function useCanvasGameplay({
         const waitStartedAt = phaseEndsAt;
         const waitEndsAt = new Date(
           new Date(waitStartedAt).getTime() +
-            phaseTimingRef.current.roundStartWaitSec * 1000,
+          phaseTimingRef.current.roundStartWaitSec * 1000,
         ).toISOString();
 
         setRoundState({
@@ -360,7 +403,7 @@ export default function useCanvasGameplay({
         const gameEndStartedAt = phaseEndsAt;
         const gameEndEndsAt = new Date(
           new Date(gameEndStartedAt).getTime() +
-            phaseTimingRef.current.gameEndWaitSec * 1000,
+          phaseTimingRef.current.gameEndWaitSec * 1000,
         ).toISOString();
 
         setRoundState({
@@ -381,7 +424,7 @@ export default function useCanvasGameplay({
       const waitStartedAt = phaseEndsAt;
       const waitEndsAt = new Date(
         new Date(waitStartedAt).getTime() +
-          phaseTimingRef.current.roundStartWaitSec * 1000,
+        phaseTimingRef.current.roundStartWaitSec * 1000,
       ).toISOString();
 
       setRoundState({
@@ -437,6 +480,8 @@ export default function useCanvasGameplay({
       gameEndAt: string;
     }) => {
       clearLocalPhaseTransitionTimer();
+      clearSnapshotDelayTimer();
+      pendingSnapshotRoundRef.current = null;
       setRoundSummary(null);
       setGameSummary(null);
       setRoundSummaryLoading(false);
@@ -462,6 +507,7 @@ export default function useCanvasGameplay({
     [
       clearLocalPhaseTransitionTimer,
       clearSessionError,
+      clearSnapshotDelayTimer,
       fetchTickets,
       refreshParticipants,
       resetVoteState,
@@ -481,14 +527,19 @@ export default function useCanvasGameplay({
       endedAt: string;
     }) => {
       clearLocalPhaseTransitionTimer();
+      clearSnapshotDelayTimer();
       clearTickets();
       resetVoteState();
       setRoundSummary(null);
       setRoundSummaryLoading(true);
+      pendingSnapshotRoundRef.current = {
+        roundId,
+        roundNumber,
+      };
 
       const resultEndsAt = new Date(
         new Date(endedAt).getTime() +
-          phaseTimingRef.current.roundResultDelaySec * 1000,
+        phaseTimingRef.current.roundResultDelaySec * 1000,
       ).toISOString();
 
       setRoundState({
@@ -506,6 +557,7 @@ export default function useCanvasGameplay({
     },
     [
       clearLocalPhaseTransitionTimer,
+      clearSnapshotDelayTimer,
       clearTickets,
       formattedGameEndTime,
       resetVoteState,
@@ -524,13 +576,21 @@ export default function useCanvasGameplay({
         return;
       }
 
-      void requestRoundSummary(readyCanvasId, readyRoundId);
+      void requestRoundSummary(readyCanvasId, readyRoundId).then((summary) => {
+        if (!summary) {
+          return;
+        }
+
+        onOpenRoundSummaryModal(summary);
+      });
     },
-    [canvasId, requestRoundSummary],
+    [canvasId, onOpenRoundSummaryModal, requestRoundSummary],
   );
 
   const handleSessionEnded = useCallback(() => {
     clearLocalPhaseTransitionTimer();
+    clearSnapshotDelayTimer();
+    pendingSnapshotRoundRef.current = null;
     clearTickets();
     clearParticipants();
     resetRoundState();
@@ -544,6 +604,7 @@ export default function useCanvasGameplay({
   }, [
     clearLocalPhaseTransitionTimer,
     clearParticipants,
+    clearSnapshotDelayTimer,
     clearTickets,
     onSessionEnded,
     resetRoundState,
@@ -588,6 +649,8 @@ export default function useCanvasGameplay({
 
   const handleGameEnded = useCallback(() => {
     clearLocalPhaseTransitionTimer();
+    clearSnapshotDelayTimer();
+    pendingSnapshotRoundRef.current = null;
     markGameEnded();
     clearTickets();
     clearParticipants();
@@ -602,6 +665,7 @@ export default function useCanvasGameplay({
   }, [
     clearLocalPhaseTransitionTimer,
     clearParticipants,
+    clearSnapshotDelayTimer,
     clearTickets,
     markGameEnded,
     onGameEndedCleanup,
@@ -610,6 +674,36 @@ export default function useCanvasGameplay({
     resetVoteState,
   ]);
 
+  const handleCanvasUpdatedWithSnapshot = useCallback(
+    (payload: { cellId: number; color: string }) => {
+      onCanvasUpdated(payload);
+    },
+    [onCanvasUpdated],
+  );
+
+  const handleCanvasBatchUpdatedWithSnapshot = useCallback(
+    (payload: CanvasBatchUpdatedPayload) => {
+      onCanvasBatchUpdated(payload);
+
+      if (!pendingSnapshotRoundRef.current) {
+        return;
+      }
+
+      const targetRound = pendingSnapshotRoundRef.current;
+      pendingSnapshotRoundRef.current = null;
+
+      clearSnapshotDelayTimer();
+
+      window.requestAnimationFrame(() => {
+        snapshotDelayTimerRef.current = window.setTimeout(() => {
+          snapshotDelayTimerRef.current = null;
+          finalizeRoundSnapshot(targetRound.roundNumber);
+        }, 500);
+      });
+    },
+    [clearSnapshotDelayTimer, finalizeRoundSnapshot, onCanvasBatchUpdated],
+  );
+
   useGameplaySocket({
     canvasId,
     onCanvasJoined: handleCanvasJoined,
@@ -617,8 +711,8 @@ export default function useCanvasGameplay({
     onRoundEnded: handleRoundEnded,
     onRoundSummaryReady: handleRoundSummaryReady,
     onGameSummaryReady: handleGameSummaryReady,
-    onCanvasUpdated,
-    onCanvasBatchUpdated,
+    onCanvasUpdated: handleCanvasUpdatedWithSnapshot,
+    onCanvasBatchUpdated: handleCanvasBatchUpdatedWithSnapshot,
     onVoteUpdate: handleVoteUpdate,
     onTimerUpdate: handleTimerUpdate,
     onParticipantsUpdated: handleParticipantsUpdated,
@@ -656,6 +750,7 @@ export default function useCanvasGameplay({
     participantError,
     gameConfig,
     roundSummary,
+    latestRoundSnapshot,
     gameSummary,
     roundSummaryLoading,
     gameSummaryLoading,

--- a/frontend/src/pages/canvas/model/useCanvasGameplay.ts
+++ b/frontend/src/pages/canvas/model/useCanvasGameplay.ts
@@ -114,7 +114,8 @@ export default function useCanvasGameplay({
   const [latestRoundSnapshot, setLatestRoundSnapshotState] = useState<string | null>(
     () => getLatestRoundSnapshot().snapshot,
   );
-  const [isLatestRoundSummaryReady, setIsLatestRoundSummaryReady] =
+
+  const [canOpenLatestRoundSummary, setCanOpenLatestRoundSummary] =
     useState(false);
 
   const clearLocalPhaseTransitionTimer = useCallback(() => {
@@ -247,7 +248,7 @@ export default function useCanvasGameplay({
         onOpenRoundSummaryModal(pending.summary);
       }
 
-      setIsLatestRoundSummaryReady(true);
+      setCanOpenLatestRoundSummary(true);
       pendingRoundResultRef.current = null;
 
       if (!saved) {
@@ -515,8 +516,6 @@ export default function useCanvasGameplay({
       clearLocalPhaseTransitionTimer();
       clearSnapshotDelayTimer();
       pendingRoundResultRef.current = null;
-      setIsLatestRoundSummaryReady(false);
-      setRoundSummary(null);
       setGameSummary(null);
       setRoundSummaryLoading(false);
       setGameSummaryLoading(false);
@@ -564,9 +563,8 @@ export default function useCanvasGameplay({
       clearSnapshotDelayTimer();
       clearTickets();
       resetVoteState();
-      setRoundSummary(null);
       setRoundSummaryLoading(true);
-      setIsLatestRoundSummaryReady(false);
+      setCanOpenLatestRoundSummary(false);
       pendingRoundResultRef.current = {
         roundId,
         roundNumber,
@@ -632,7 +630,7 @@ export default function useCanvasGameplay({
           return;
         }
 
-        setIsLatestRoundSummaryReady(true);
+        setCanOpenLatestRoundSummary(true);
       });
     },
     [canvasId, completePendingRoundResult, requestRoundSummary],
@@ -642,7 +640,7 @@ export default function useCanvasGameplay({
     clearLocalPhaseTransitionTimer();
     clearSnapshotDelayTimer();
     pendingRoundResultRef.current = null;
-    setIsLatestRoundSummaryReady(false);
+    setCanOpenLatestRoundSummary(false);
     clearTickets();
     clearParticipants();
     resetRoundState();
@@ -703,7 +701,7 @@ export default function useCanvasGameplay({
     clearLocalPhaseTransitionTimer();
     clearSnapshotDelayTimer();
     pendingRoundResultRef.current = null;
-    setIsLatestRoundSummaryReady(false);
+    setCanOpenLatestRoundSummary(false);
     markGameEnded();
     clearTickets();
     clearParticipants();
@@ -801,7 +799,7 @@ export default function useCanvasGameplay({
     gameConfig,
     roundSummary,
     latestRoundSnapshot,
-    isLatestRoundSummaryReady,
+    canOpenLatestRoundSummary,
     gameSummary,
     roundSummaryLoading,
     gameSummaryLoading,

--- a/frontend/src/pages/canvas/model/useCanvasGameplay.ts
+++ b/frontend/src/pages/canvas/model/useCanvasGameplay.ts
@@ -44,6 +44,7 @@ interface UseCanvasGameplayParams {
   onCanvasBatchUpdated: (payload: CanvasBatchUpdatedPayload) => void;
   onOpenRoundSummaryModal: (summary: RoundSummaryData) => void;
   onOpenGameSummaryModal: (summary: GameSummaryData) => void;
+  onRoundEndedCleanup: () => void;
   onGameEndedCleanup: () => void;
   onSessionEnded: () => void;
   onUnauthorized: (message: string) => void;
@@ -66,6 +67,7 @@ export default function useCanvasGameplay({
   onCanvasBatchUpdated,
   onOpenRoundSummaryModal,
   onOpenGameSummaryModal,
+  onRoundEndedCleanup,
   onGameEndedCleanup,
   onSessionEnded,
   onUnauthorized,
@@ -561,6 +563,7 @@ export default function useCanvasGameplay({
     }) => {
       clearLocalPhaseTransitionTimer();
       clearSnapshotDelayTimer();
+      onRoundEndedCleanup();
       clearTickets();
       resetVoteState();
       setRoundSummaryLoading(true);
@@ -594,6 +597,7 @@ export default function useCanvasGameplay({
     [
       clearLocalPhaseTransitionTimer,
       clearSnapshotDelayTimer,
+      onRoundEndedCleanup,
       clearTickets,
       formattedGameEndTime,
       resetVoteState,

--- a/frontend/src/pages/canvas/model/useCanvasPage.ts
+++ b/frontend/src/pages/canvas/model/useCanvasPage.ts
@@ -28,7 +28,7 @@ function getDefaultRoundSummaryModalPosition() {
   };
 }
 
-function isRoundSummaryEnabled(phase: GamePhase) {
+function isRoundSummaryPhase(phase: GamePhase) {
   return (
     phase === GAME_PHASE.ROUND_RESULT || phase === GAME_PHASE.ROUND_START_WAIT
   );
@@ -187,18 +187,27 @@ export default function useCanvasPage({
   }, [gameplay.isRoundExpiredRefValue]);
 
   useEffect(() => {
-    if (!isRoundSummaryEnabled(gameplay.phase)) {
+    if (!isRoundSummaryPhase(gameplay.phase)) {
       handleCloseRoundSummaryModal();
     }
   }, [gameplay.phase, handleCloseRoundSummaryModal]);
 
   const handleOpenLatestRoundSummary = useCallback(() => {
-    if (!gameplay.roundSummary || !isRoundSummaryEnabled(gameplay.phase)) {
+    if (
+      !gameplay.roundSummary ||
+      !isRoundSummaryPhase(gameplay.phase) ||
+      !gameplay.isLatestRoundSummaryReady
+    ) {
       return;
     }
 
     handleOpenRoundSummaryModal(gameplay.roundSummary);
-  }, [gameplay.phase, gameplay.roundSummary, handleOpenRoundSummaryModal]);
+  }, [
+    gameplay.isLatestRoundSummaryReady,
+    gameplay.phase,
+    gameplay.roundSummary,
+    handleOpenRoundSummaryModal,
+  ]);
 
   const handlePopupClose = useCallback(() => {
     clearSelectedCell();
@@ -262,6 +271,7 @@ export default function useCanvasPage({
     latestRoundSummary: gameplay.roundSummary,
     latestRoundSnapshot:
       gameplay.latestRoundSnapshot ?? latestStoredRoundSnapshot.snapshot,
-    isLatestRoundSummaryEnabled: isRoundSummaryEnabled(gameplay.phase),
+    isLatestRoundSummaryEnabled:
+      isRoundSummaryPhase(gameplay.phase) && gameplay.isLatestRoundSummaryReady,
   };
 }

--- a/frontend/src/pages/canvas/model/useCanvasPage.ts
+++ b/frontend/src/pages/canvas/model/useCanvasPage.ts
@@ -111,6 +111,12 @@ export default function useCanvasPage({
     [setCanvasId, setGridX, setGridY, updateCells],
   );
 
+  const handleRoundEndedCleanup = useCallback(() => {
+    clearSelectedCell();
+    resetPreviewColor();
+    closePopup();
+  }, [clearSelectedCell, resetPreviewColor, closePopup]);
+
   const handleGameEndedCleanup = useCallback(() => {
     clearSelectedCell();
   }, [clearSelectedCell]);
@@ -179,6 +185,7 @@ export default function useCanvasPage({
     onCanvasBatchUpdated: handleCanvasBatchUpdated,
     onOpenRoundSummaryModal: handleOpenRoundSummaryModal,
     onOpenGameSummaryModal: handleOpenGameSummaryModal,
+    onRoundEndedCleanup: handleRoundEndedCleanup,
     onGameEndedCleanup: handleGameEndedCleanup,
     onSessionEnded,
     onUnauthorized,

--- a/frontend/src/pages/canvas/model/useCanvasPage.ts
+++ b/frontend/src/pages/canvas/model/useCanvasPage.ts
@@ -117,9 +117,13 @@ export default function useCanvasPage({
 
   const handleOpenRoundSummaryModal = useCallback((summary: RoundSummaryData) => {
     setRoundSummaryModal(summary);
+
+    if (!roundSummaryOpen) {
+      setRoundSummaryPosition(getDefaultRoundSummaryModalPosition());
+    }
+
     setRoundSummaryOpen(true);
-    setRoundSummaryPosition(getDefaultRoundSummaryModalPosition());
-  }, []);
+  }, [roundSummaryOpen]);
 
   const handleOpenGameSummaryModal = useCallback((summary: GameSummaryData) => {
     setGameSummaryModal(summary);

--- a/frontend/src/pages/canvas/model/useCanvasPage.ts
+++ b/frontend/src/pages/canvas/model/useCanvasPage.ts
@@ -5,12 +5,33 @@ import type {
   RoundSummaryData,
 } from "@/features/gameplay/session/api/session.api";
 import type { SessionBootstrapResult } from "@/features/gameplay/session";
+import { getLatestRoundSnapshot } from "@/features/gameplay/round/model/roundSnapshot.storage";
+import {
+  GAME_PHASE,
+  type GamePhase,
+} from "@/features/gameplay/session/model/game-phase.types";
 import useCanvasGameplay from "./useCanvasGameplay";
 import useCanvasScene from "./useCanvasScene";
 
 interface UseCanvasPageParams {
   onSessionEnded: () => void;
   onUnauthorized: (message: string) => void;
+}
+
+function getDefaultRoundSummaryModalPosition() {
+  const modalWidth = Math.min(560, window.innerWidth - 24);
+  const modalHeight = Math.min(window.innerHeight - 48, 720);
+
+  return {
+    x: Math.max(12, Math.round((window.innerWidth - modalWidth) / 2)),
+    y: Math.max(24, Math.round((window.innerHeight - modalHeight) / 2)),
+  };
+}
+
+function isRoundSummaryEnabled(phase: GamePhase) {
+  return (
+    phase === GAME_PHASE.ROUND_RESULT || phase === GAME_PHASE.ROUND_START_WAIT
+  );
 }
 
 export default function useCanvasPage({
@@ -23,6 +44,11 @@ export default function useCanvasPage({
     useState<RoundSummaryData | null>(null);
   const [gameSummaryModal, setGameSummaryModal] =
     useState<GameSummaryData | null>(null);
+  const [introGuideOpen, setIntroGuideOpen] = useState(false);
+  const [roundSummaryOpen, setRoundSummaryOpen] = useState(false);
+  const [roundSummaryPosition, setRoundSummaryPosition] = useState(
+    getDefaultRoundSummaryModalPosition,
+  );
 
   const {
     popupOpen,
@@ -89,27 +115,61 @@ export default function useCanvasPage({
     clearSelectedCell();
   }, [clearSelectedCell]);
 
-  const handleOpenRoundSummaryModal = useCallback(
-    (summary: RoundSummaryData) => {
-      setRoundSummaryModal(summary);
-    },
-    [],
-  );
+  const handleOpenRoundSummaryModal = useCallback((summary: RoundSummaryData) => {
+    setRoundSummaryModal(summary);
+    setRoundSummaryOpen(true);
+    setRoundSummaryPosition(getDefaultRoundSummaryModalPosition());
+  }, []);
 
   const handleOpenGameSummaryModal = useCallback((summary: GameSummaryData) => {
     setGameSummaryModal(summary);
   }, []);
 
   const handleCloseRoundSummaryModal = useCallback(() => {
-    setRoundSummaryModal(null);
+    setRoundSummaryOpen(false);
+    setRoundSummaryPosition(getDefaultRoundSummaryModalPosition());
   }, []);
 
   const handleCloseGameSummaryModal = useCallback(() => {
     setGameSummaryModal(null);
   }, []);
 
+  const handleOpenIntroGuide = useCallback(() => {
+    setIntroGuideOpen(true);
+  }, []);
+
+  const handleCloseIntroGuide = useCallback(() => {
+    setIntroGuideOpen(false);
+  }, []);
+
+  const handleRoundSummaryDragStart = useCallback(
+    (event: React.MouseEvent<HTMLDivElement>) => {
+      event.preventDefault();
+
+      const dragOffsetX = event.clientX - roundSummaryPosition.x;
+      const dragOffsetY = event.clientY - roundSummaryPosition.y;
+
+      const handleMouseMove = (moveEvent: MouseEvent) => {
+        setRoundSummaryPosition({
+          x: moveEvent.clientX - dragOffsetX,
+          y: moveEvent.clientY - dragOffsetY,
+        });
+      };
+
+      const handleMouseUp = () => {
+        window.removeEventListener("mousemove", handleMouseMove);
+        window.removeEventListener("mouseup", handleMouseUp);
+      };
+
+      window.addEventListener("mousemove", handleMouseMove);
+      window.addEventListener("mouseup", handleMouseUp);
+    },
+    [roundSummaryPosition.x, roundSummaryPosition.y],
+  );
+
   const gameplay = useCanvasGameplay({
     canvasId,
+    canvasElementRef: canvasRef,
     onBootstrapScene: applyBootstrapScene,
     onCanvasUpdated: handleCanvasUpdated,
     onCanvasBatchUpdated: handleCanvasBatchUpdated,
@@ -126,10 +186,26 @@ export default function useCanvasPage({
     isRoundExpiredRef.current = gameplay.isRoundExpiredRefValue;
   }, [gameplay.isRoundExpiredRefValue]);
 
+  useEffect(() => {
+    if (!isRoundSummaryEnabled(gameplay.phase)) {
+      handleCloseRoundSummaryModal();
+    }
+  }, [gameplay.phase, handleCloseRoundSummaryModal]);
+
+  const handleOpenLatestRoundSummary = useCallback(() => {
+    if (!gameplay.roundSummary || !isRoundSummaryEnabled(gameplay.phase)) {
+      return;
+    }
+
+    handleOpenRoundSummaryModal(gameplay.roundSummary);
+  }, [gameplay.phase, gameplay.roundSummary, handleOpenRoundSummaryModal]);
+
   const handlePopupClose = useCallback(() => {
     clearSelectedCell();
     closePopup();
   }, [clearSelectedCell, closePopup]);
+
+  const latestStoredRoundSnapshot = getLatestRoundSnapshot();
 
   return {
     canvasRef,
@@ -176,5 +252,16 @@ export default function useCanvasPage({
     viewport,
     navigateToCoordinate,
     resetCanvasZoom,
+    introGuideOpen,
+    handleOpenIntroGuide,
+    handleCloseIntroGuide,
+    roundSummaryOpen,
+    roundSummaryPosition,
+    handleRoundSummaryDragStart,
+    handleOpenLatestRoundSummary,
+    latestRoundSummary: gameplay.roundSummary,
+    latestRoundSnapshot:
+      gameplay.latestRoundSnapshot ?? latestStoredRoundSnapshot.snapshot,
+    isLatestRoundSummaryEnabled: isRoundSummaryEnabled(gameplay.phase),
   };
 }

--- a/frontend/src/pages/canvas/model/useCanvasPage.ts
+++ b/frontend/src/pages/canvas/model/useCanvasPage.ts
@@ -197,18 +197,13 @@ export default function useCanvasPage({
   }, [gameplay.phase, handleCloseRoundSummaryModal]);
 
   const handleOpenLatestRoundSummary = useCallback(() => {
-    if (
-      !gameplay.roundSummary ||
-      !isRoundSummaryPhase(gameplay.phase) ||
-      !gameplay.isLatestRoundSummaryReady
-    ) {
+    if (!gameplay.roundSummary || !gameplay.canOpenLatestRoundSummary) {
       return;
     }
 
     handleOpenRoundSummaryModal(gameplay.roundSummary);
   }, [
-    gameplay.isLatestRoundSummaryReady,
-    gameplay.phase,
+    gameplay.canOpenLatestRoundSummary,
     gameplay.roundSummary,
     handleOpenRoundSummaryModal,
   ]);
@@ -275,7 +270,6 @@ export default function useCanvasPage({
     latestRoundSummary: gameplay.roundSummary,
     latestRoundSnapshot:
       gameplay.latestRoundSnapshot ?? latestStoredRoundSnapshot.snapshot,
-    isLatestRoundSummaryEnabled:
-      isRoundSummaryPhase(gameplay.phase) && gameplay.isLatestRoundSummaryReady,
+    isLatestRoundSummaryEnabled: gameplay.canOpenLatestRoundSummary,
   };
 }


### PR DESCRIPTION
## 관련 이슈
- Close #176 

## 작업 내용
- 좌측 영역에 툴박스 추가
- 인트로 패널 클릭시 인트로 가이드 모달 확인 가능
- 라운드 패널 클릭시 이전 라운드 결과 확인 가능
- 인트로 및 라운드 결과 모달에 스크롤 기능 추가
- 라운드 진행 중인 동안 이전 라운드 통계 모달을 확인할 수 있음
- 라운드 종료 시 흐름 정리
  1. 백엔드에서 먼저 투표 집계, 셀 색상 결정, `round summary` 저장
  2. 소켓 이벤트를 아래 순서로 emit
      - `round:ended` : 프론트에서 `ROUND_RESULT`로 페이즈 변경
      - `canvas:batch-updated` : 프론트에서 셀 색상 반영
      - `round-summary:ready`
   3. 프론트에서 셀 선택을 해제하고 스냅샷을 저장
   4. 스냅샷 저장 확인 후 라운드 모달 오픈

## 테스트 및 확인 사항
- [x] 툴 박스의 패널 클릭 시 각 모달 오픈 여부 확인
- [x] 라운드 진행 중 이전 라운드 결과 확인
- [x] 셀에 반영된 부분만 스냅샷에 찍히는지 확인
- [x] 모달에 스크롤 기능 확인

  <details>
  <summary> 스크린샷 </summary>

  - 게임 시작시 인트로 모달 오픈
  <img width="1532" height="922" alt="image" src="https://github.com/user-attachments/assets/f855f398-837b-4708-ad57-4a9b09a4a510" />

  - 게임 진행 중 인트로 모달 확인
  <img width="1571" height="809" alt="image" src="https://github.com/user-attachments/assets/d2f862aa-7ad3-4e24-a5bd-fb6833fa3cb5" />

  - 게임 진행 중 이전 라운드 결과 모달 확인
  <img width="1550" height="831" alt="image" src="https://github.com/user-attachments/assets/8448a17f-fe6b-4207-8222-86d2e5860e51" />

  </details>

## 추가 필요 수정 사항
- 툴박스 디자인은 추후 변경
- 스냅샷 저장을 완료 할때까지 캔버스를 클릭할 수 없어야함.
  - 라운드 집계 중에는 캔버스 클릭 불가, 라운드 진행 및 라운드 시작 대기 중에는 클릭 가능.
  <details>
  <summary> 오류 확인 </summary>
  
  <img width="1036" height="890" alt="image" src="https://github.com/user-attachments/assets/1c8dc036-14fe-4d5a-8669-4f0d6dd26fc8" />
  
  </details>


- 투표권 디자인 변경 필요 

## 체크리스트
- [x] 불필요한 주석 및 디버깅 코드를 제거하였는가?
- [x] 모든 테스트를 통과하였는가?
- [x] 변경 사항에 대한 문서 업데이트가 필요한가?
