### PR TITLE
feat: separate game history panel from canvas page

### DIFF
--- a/frontend/src/features/gameplay/history/components/GameHistoryPanel.tsx
+++ b/frontend/src/features/gameplay/history/components/GameHistoryPanel.tsx
@@ -1,0 +1,56 @@
+import IntroPanelButton from "@/features/gameplay/intro/components/IntroPanelButton";
+import { RoundPanelList } from "@/features/gameplay/round";
+import type { RoundSummaryData } from "@/features/gameplay/session/api/session.api";
+
+interface GameHistoryPanelProps {
+  onOpenIntroGuide: () => void;
+  onOpenLatestRoundSummary: () => void;
+  latestRoundSummary: RoundSummaryData | null;
+  isLatestRoundSummaryEnabled: boolean;
+}
+
+export default function GameHistoryPanel({
+  onOpenIntroGuide,
+  onOpenLatestRoundSummary,
+  latestRoundSummary,
+  isLatestRoundSummaryEnabled,
+}: GameHistoryPanelProps) {
+  return (
+    <aside className="flex w-[256px] shrink-0 flex-col gap-3 border-r border-gray-200 bg-white px-4 py-5">
+      <div className="px-1">
+        <p className="text-xs font-semibold uppercase tracking-[0.08em] text-gray-400">
+          History
+        </p>
+        <p className="mt-1 text-lg font-bold text-gray-900">Game History</p>
+        <p className="mt-1 text-sm text-gray-500">
+          인트로와 최근 라운드 결과를 다시 확인할 수 있어요.
+        </p>
+      </div>
+
+      <IntroPanelButton onClick={onOpenIntroGuide} />
+
+      <RoundPanelList>
+        <button
+          type="button"
+          className="w-full rounded-2xl border border-gray-200 bg-white px-4 py-4 text-left shadow-sm transition hover:border-gray-300 hover:bg-gray-50 disabled:cursor-not-allowed disabled:border-gray-100 disabled:bg-gray-50 disabled:opacity-60"
+          onClick={onOpenLatestRoundSummary}
+          disabled={!isLatestRoundSummaryEnabled || !latestRoundSummary}
+        >
+          <p className="text-xs font-semibold uppercase tracking-[0.08em] text-gray-400">
+            Round
+          </p>
+          <p className="mt-1 text-base font-bold text-gray-900">
+            {latestRoundSummary
+              ? `${latestRoundSummary.roundNumber} 라운드 결과`
+              : "최근 라운드 결과"}
+          </p>
+          <p className="mt-1 text-sm text-gray-500">
+            {isLatestRoundSummaryEnabled && latestRoundSummary
+              ? "클릭하면 최근 라운드 결과 모달을 다시 확인할 수 있어요."
+              : "ROUND_RESULT 또는 ROUND_START_WAIT 상태에서만 열 수 있어요."}
+          </p>
+        </button>
+      </RoundPanelList>
+    </aside>
+  );
+}

--- a/frontend/src/features/gameplay/history/index.ts
+++ b/frontend/src/features/gameplay/history/index.ts
@@ -1,0 +1,1 @@
+export { default as GameHistoryPanel } from "./components/GameHistoryPanel";

--- a/frontend/src/pages/canvas/CanvasPage.tsx
+++ b/frontend/src/pages/canvas/CanvasPage.tsx
@@ -6,7 +6,7 @@ import {
   PANEL_WIDTH,
 } from "@/features/gameplay/canvas";
 import { IntroGuideModal } from "@/features/gameplay/intro";
-import { RoundPanelList } from "@/features/gameplay/round";
+import { GameHistoryPanel } from "@/features/gameplay/history";
 import RoundSummaryModal from "@/features/gameplay/round/components/RoundSummaryModal";
 import {
   ErrorScreen,
@@ -15,7 +15,6 @@ import {
 } from "@/features/gameplay/session";
 import { GAME_PHASE } from "@/features/gameplay/session/model/game-phase.types";
 import { VotePanel, VotePopup } from "@/features/gameplay/vote";
-import IntroPanelButton from "@/features/gameplay/intro/components/IntroPanelButton";
 import useCanvasPage from "./model/useCanvasPage";
 import type { GameSummaryData } from "@/features/gameplay/session/api/session.api";
 
@@ -178,32 +177,12 @@ export default function CanvasPage() {
 
   return (
     <div className="flex h-screen w-full bg-gray-50">
-      <aside className="flex w-[256px] shrink-0 flex-col gap-3 border-r border-gray-200 bg-white px-4 py-5">
-        <IntroPanelButton onClick={handleOpenIntroGuide} />
-
-        <RoundPanelList>
-          <button
-            type="button"
-            className="w-full rounded-2xl border border-gray-200 bg-white px-4 py-4 text-left shadow-sm transition hover:border-gray-300 hover:bg-gray-50 disabled:cursor-not-allowed disabled:border-gray-100 disabled:bg-gray-50 disabled:opacity-60"
-            onClick={handleOpenLatestRoundSummary}
-            disabled={!isLatestRoundSummaryEnabled || !latestRoundSummary}
-          >
-            <p className="text-xs font-semibold uppercase tracking-[0.08em] text-gray-400">
-              Round
-            </p>
-            <p className="mt-1 text-base font-bold text-gray-900">
-              {latestRoundSummary
-                ? `${latestRoundSummary.roundNumber} 라운드 결과`
-                : "최근 라운드 결과"}
-            </p>
-            <p className="mt-1 text-sm text-gray-500">
-              {isLatestRoundSummaryEnabled && latestRoundSummary
-                ? "클릭하면 최근 라운드 통계 모달을 열 수 있어요."
-                : "ROUND_RESULT 또는 ROUND_START_WAIT 상태에서만 열 수 있어요."}
-            </p>
-          </button>
-        </RoundPanelList>
-      </aside>
+      <GameHistoryPanel
+        onOpenIntroGuide={handleOpenIntroGuide}
+        onOpenLatestRoundSummary={handleOpenLatestRoundSummary}
+        latestRoundSummary={latestRoundSummary}
+        isLatestRoundSummaryEnabled={isLatestRoundSummaryEnabled}
+      />
 
       <CanvasStage
         containerRef={containerRef}


### PR DESCRIPTION
## 관련 이슈
- Close #207 

## 작업 배경

캔버스 페이지의 왼쪽 사이드 영역은 현재 CanvasPage 내부에 직접 작성되어 있어
역할이 명확하지 않고, 향후 게임 히스토리 확장 구조로 가져가기 어려운 상태였다.

이번 작업에서는 기존 왼쪽 패널의 역할을 `Game History Panel`로 재정의하고,
CanvasPage가 직접 왼쪽 패널 UI를 책임지지 않도록 컴포넌트를 분리했다.

## 변경 사항

- `GameHistoryPanel` 컴포넌트 생성
- CanvasPage 내부의 왼쪽 사이드바 마크업 제거
- CanvasPage에서 `GameHistoryPanel`을 주입하는 구조로 변경
- 기존 인트로 버튼 / 최신 라운드 결과 버튼 기능은 유지
- 왼쪽 패널 상단 카피를 `Game History` 기준으로 정리

## 주요 구현 포인트

- 이번 단계에서는 기능 확장보다 컴포넌트 경계 정리에 집중함
- 현재 지원 범위는 기존과 동일하게:
  - 인트로 가이드 진입
  - 최신 라운드 결과 재오픈
- 다중 라운드 히스토리, 게임 종료 통계 진입, 백엔드 스냅샷 연동은 포함하지 않음
- `CanvasPage`는 레이아웃과 상태 전달만 담당하고,
  패널의 UI 책임은 `GameHistoryPanel`이 담당하도록 정리함

## 테스트 방법

- 캔버스 페이지 진입 후 왼쪽 패널이 정상 렌더링되는지 확인
- 인트로 버튼 클릭 시 가이드 모달이 열리는지 확인
- 최신 라운드 결과 버튼 활성/비활성 상태 확인
- 최신 라운드 결과 버튼 클릭 시 기존과 동일하게 결과 모달이 열리는지 확인
- 중앙 캔버스 / 오른쪽 VotePanel / 팝업 동작에 영향이 없는지 확인

## 확인이 필요한 사항

- `Game History Panel` 상단 카피/명칭을 이대로 유지할지
- 추후 게임 종료 통계 진입 버튼을 같은 패널 내부에 추가할지
- `RoundPanelList` 네이밍을 다음 작업에서 함께 정리할지
