### PR TITLE
feat: 캔버스 chunk 조회 API 추가 및 bootstrap 셀 로딩 분리

### DIFF
--- a/backend/src/modules/canvas/canvas.controller.ts
+++ b/backend/src/modules/canvas/canvas.controller.ts
@@ -6,6 +6,7 @@ import { Cell } from "../../entities/cell.entity";
 import { canvasService } from "./canvas.service";
 import { GameSummary } from "../../entities/game-summary.entity";
 import { summaryService } from "../summary/summary.service";
+import type { GetCanvasChunksQuery } from "./dto/get-canvas-chunks.dto";
 
 interface CreateCanvasRequestBody {
   profileKey?: string;
@@ -103,10 +104,9 @@ export const canvasController = {
           .json({ message: "진행 중인 캔버스가 없습니다." });
       }
 
-      const cells = await canvasService.getCells(canvas.id);
       return res.json({
         canvas: serializeCanvas(canvas),
-        cells: cells.map(serializeCell),
+        cells: [],
         gameConfig: getCanvasGameConfigSnapshot(canvas),
       });
     } catch (err) {
@@ -159,6 +159,54 @@ export const canvasController = {
 
       return res.json({
         data: serializeGameSummary(summary),
+      });
+    } catch (err) {
+      return res.status(400).json({ message: String(err) });
+    }
+  },
+
+  async getChunks(req: Request, res: Response) {
+    try {
+      const canvasId = parseInt(String(req.params["canvasId"]), 10);
+      const query = req.query as Partial<
+        Record<keyof GetCanvasChunksQuery, string>
+      >;
+
+      const startChunkX = parseInt(String(query.startChunkX), 10);
+      const endChunkX = parseInt(String(query.endChunkX), 10);
+      const startChunkY = parseInt(String(query.startChunkY), 10);
+      const endChunkY = parseInt(String(query.endChunkY), 10);
+      const chunkSize =
+        query.chunkSize !== undefined
+          ? parseInt(String(query.chunkSize), 10)
+          : undefined;
+
+      if (
+        !Number.isFinite(canvasId) ||
+        !Number.isFinite(startChunkX) ||
+        !Number.isFinite(endChunkX) ||
+        !Number.isFinite(startChunkY) ||
+        !Number.isFinite(endChunkY)
+      ) {
+        return res
+          .status(400)
+          .json({ message: "chunk 조회 파라미터가 올바르지 않습니다." });
+      }
+
+      const result = await canvasService.getChunkCells({
+        canvasId,
+        startChunkX,
+        endChunkX,
+        startChunkY,
+        endChunkY,
+        chunkSize,
+      });
+
+      return res.json({
+        chunkSize: result.chunkSize,
+        ranges: result.ranges,
+        bounds: result.bounds,
+        cells: result.cells.map(serializeCell),
       });
     } catch (err) {
       return res.status(400).json({ message: String(err) });

--- a/backend/src/modules/canvas/canvas.router.ts
+++ b/backend/src/modules/canvas/canvas.router.ts
@@ -4,19 +4,19 @@ import { authMiddleware } from "../../middlewares/auth.middleware";
 
 const router = Router();
 
-router.post("/", authMiddleware, canvasController.create);
+// TO-BE
 router.get("/current", authMiddleware, canvasController.getCurrent);
+router.get("/:canvasId/chunks", authMiddleware, canvasController.getChunks);
 router.get(
-    "/current/participants/count",
-    authMiddleware,
-    canvasController.getCurrentParticipantCount,
+  "/current/participants/count",
+  authMiddleware,
+  canvasController.getCurrentParticipantCount,
 );
 router.get(
-    "/current/participants",
-    authMiddleware,
-    canvasController.getCurrentParticipantList,
+  "/current/participants",
+  authMiddleware,
+  canvasController.getCurrentParticipantList,
 );
 router.get("/:canvasId/summary", authMiddleware, canvasController.getSummary);
-
 
 export default router;

--- a/backend/src/modules/canvas/canvas.service.ts
+++ b/backend/src/modules/canvas/canvas.service.ts
@@ -16,8 +16,19 @@ const canvasRepository = AppDataSource.getRepository(Canvas);
 const cellRepository = AppDataSource.getRepository(Cell);
 const voteRoundRepository = AppDataSource.getRepository(VoteRound);
 
+const DEFAULT_CHUNK_SIZE = 64;
+
 interface CreateCanvasOptions {
   profileKey?: string | null;
+}
+
+interface GetChunkCellsParams {
+  canvasId: number;
+  startChunkX: number;
+  endChunkX: number;
+  startChunkY: number;
+  endChunkY: number;
+  chunkSize?: number;
 }
 
 function logPhaseChange(params: {
@@ -222,5 +233,94 @@ export const canvasService = {
       },
       order: { phaseStartedAt: "DESC" },
     });
+  },
+
+  async getChunkCells({
+    canvasId,
+    startChunkX,
+    endChunkX,
+    startChunkY,
+    endChunkY,
+    chunkSize = DEFAULT_CHUNK_SIZE,
+  }: GetChunkCellsParams): Promise<{
+    chunkSize: number;
+    ranges: {
+      startChunkX: number;
+      endChunkX: number;
+      startChunkY: number;
+      endChunkY: number;
+    };
+    bounds: {
+      minCellX: number;
+      maxCellX: number;
+      minCellY: number;
+      maxCellY: number;
+    };
+    cells: Cell[];
+  }> {
+    const canvas = await canvasRepository.findOne({
+      where: { id: canvasId },
+    });
+
+    if (!canvas) {
+      throw new Error("Canvas was not found.");
+    }
+
+    if (
+      startChunkX < 0 ||
+      endChunkX < startChunkX ||
+      startChunkY < 0 ||
+      endChunkY < startChunkY ||
+      chunkSize <= 0
+    ) {
+      throw new Error("잘못된 chunk 범위입니다.");
+    }
+
+    const minCellX = startChunkX * chunkSize;
+    const maxCellX = Math.min(
+      canvas.gridX - 1,
+      (endChunkX + 1) * chunkSize - 1,
+    );
+    const minCellY = startChunkY * chunkSize;
+    const maxCellY = Math.min(
+      canvas.gridY - 1,
+      (endChunkY + 1) * chunkSize - 1,
+    );
+
+    const cells =
+      minCellX > maxCellX || minCellY > maxCellY
+        ? []
+        : await cellRepository
+            .createQueryBuilder("cell")
+            .where("cell.canvas_id = :canvasId", { canvasId })
+            .andWhere("cell.status = :status", { status: CellStatus.PAINTED })
+            .andWhere("cell.x BETWEEN :minCellX AND :maxCellX", {
+              minCellX,
+              maxCellX,
+            })
+            .andWhere("cell.y BETWEEN :minCellY AND :maxCellY", {
+              minCellY,
+              maxCellY,
+            })
+            .orderBy("cell.y", "ASC")
+            .addOrderBy("cell.x", "ASC")
+            .getMany();
+
+    return {
+      chunkSize,
+      ranges: {
+        startChunkX,
+        endChunkX,
+        startChunkY,
+        endChunkY,
+      },
+      bounds: {
+        minCellX,
+        maxCellX,
+        minCellY,
+        maxCellY,
+      },
+      cells,
+    };
   },
 };

--- a/backend/src/modules/canvas/dto/get-canvas-chunks.dto.ts
+++ b/backend/src/modules/canvas/dto/get-canvas-chunks.dto.ts
@@ -1,0 +1,7 @@
+export interface GetCanvasChunksQuery {
+  startChunkX: number;
+  endChunkX: number;
+  startChunkY: number;
+  endChunkY: number;
+  chunkSize?: number;
+}

--- a/backend/src/modules/round/round.service.ts
+++ b/backend/src/modules/round/round.service.ts
@@ -277,7 +277,7 @@ export const roundService = {
         continue;
       }
 
-      addVoteBucket("${x}:${y}", color, count);
+      addVoteBucket(`${x}:${y}`, color, count);
     }
 
     if (voteBuckets.size === 0) {

--- a/frontend/src/features/gameplay/canvas/api/canvas.api.ts
+++ b/frontend/src/features/gameplay/canvas/api/canvas.api.ts
@@ -1,8 +1,15 @@
+// TO-BE
 import api from "@/shared/api/client";
-import { CanvasCurrentResponse } from "../model/canvas.types";
+import type {
+  CanvasChunkQuery,
+  CanvasChunkResponse,
+  CanvasCurrentResponse,
+} from "../model/canvas.types";
 
 export const canvasApi = {
   getCurrent: () => api.get<CanvasCurrentResponse>("/canvas/current"),
+  getChunks: (canvasId: number, params: CanvasChunkQuery) =>
+    api.get<CanvasChunkResponse>(`/canvas/${canvasId}/chunks`, { params }),
 };
 
-export type { CanvasCurrentResponse };
+export type { CanvasChunkQuery, CanvasChunkResponse, CanvasCurrentResponse };

--- a/frontend/src/features/gameplay/canvas/model/canvas.types.ts
+++ b/frontend/src/features/gameplay/canvas/model/canvas.types.ts
@@ -39,3 +39,30 @@ export interface Viewport {
   width: number;
   height: number;
 }
+
+export interface CanvasChunkQuery {
+  startChunkX: number;
+  endChunkX: number;
+  startChunkY: number;
+  endChunkY: number;
+  chunkSize?: number;
+}
+
+export interface CanvasChunkBounds {
+  minCellX: number;
+  maxCellX: number;
+  minCellY: number;
+  maxCellY: number;
+}
+
+export interface CanvasChunkResponse {
+  chunkSize: number;
+  ranges: {
+    startChunkX: number;
+    endChunkX: number;
+    startChunkY: number;
+    endChunkY: number;
+  };
+  bounds: CanvasChunkBounds;
+  cells: Cell[];
+}

--- a/frontend/src/features/gameplay/session/hooks/useGameplayBootstrap.ts
+++ b/frontend/src/features/gameplay/session/hooks/useGameplayBootstrap.ts
@@ -79,7 +79,7 @@ function getFallbackPhaseDuration(
 export function useGameplayBootstrap() {
   const bootstrap = useCallback(async (): Promise<SessionBootstrapResult> => {
     const { data } = await sessionApi.getCurrentCanvas();
-    const { canvas, cells, gameConfig } = data;
+    const { canvas, gameConfig } = data;
     const { phases, rules } = gameConfig;
 
     setGameConfig(gameConfig);
@@ -156,7 +156,7 @@ export function useGameplayBootstrap() {
       gridX: canvas.gridX,
       gridY: canvas.gridY,
       backgroundImageUrl: getBackgroundImageUrl(canvas.backgroundAssetKey),
-      cells,
+      cells: [],
       round,
       votes,
       remaining,

--- a/frontend/src/features/gameplay/session/model/session.types.ts
+++ b/frontend/src/features/gameplay/session/model/session.types.ts
@@ -1,6 +1,6 @@
 import type { Cell } from "@/features/gameplay/canvas";
+import type { GamePhase } from "@/features/gameplay/session/model/game-phase.types";
 import type { GameConfig } from "@/shared/config/game-config";
-import type { GamePhase } from "./game-phase.types";
 
 export interface RoundInfoState {
   phase: GamePhase;
@@ -15,7 +15,6 @@ export interface RoundInfoState {
   phaseStartedAt: string | null;
   phaseEndsAt: string | null;
 }
-
 export interface PhaseTimingState {
   introPhaseSec: number;
   roundStartWaitSec: number;
@@ -26,8 +25,8 @@ export interface PhaseTimingState {
 export interface VoteSessionState {
   votes: Record<string, number>;
   remaining: number | null;
-  votingCellIds: Set<number>;
-  topColorMap: Map<number, string>;
+  votingCellIds: Set<string>;
+  topColorMap: Map<string, string>;
 }
 
 export interface CanvasSessionState {

--- a/frontend/src/pages/canvas/model/useCanvasPage.ts
+++ b/frontend/src/pages/canvas/model/useCanvasPage.ts
@@ -1,4 +1,6 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+// TO-BE
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { canvasApi } from "@/features/gameplay/canvas";
 import { useVotePopup, useVoteState } from "@/features/gameplay/vote";
 import type {
   GameSummaryData,
@@ -11,6 +13,9 @@ import {
 } from "@/features/gameplay/session/model/game-phase.types";
 import useCanvasGameplay from "./useCanvasGameplay";
 import useCanvasScene from "./useCanvasScene";
+
+const DEFAULT_CHUNK_SIZE = 64;
+const VIEWPORT_PREFETCH_MARGIN = 1;
 
 interface UseCanvasPageParams {
   onSessionEnded: () => void;
@@ -33,11 +38,54 @@ function isRoundSummaryPhase(phase: GamePhase) {
   );
 }
 
+function buildChunkRequest(
+  viewport: { left: number; top: number; width: number; height: number },
+  cellSize: number,
+  gridX: number,
+  gridY: number,
+  chunkSize: number,
+) {
+  const maxX = Math.max(0, gridX - 1);
+  const maxY = Math.max(0, gridY - 1);
+
+  const startCellX = Math.max(0, Math.floor(viewport.left / cellSize));
+  const startCellY = Math.max(0, Math.floor(viewport.top / cellSize));
+  const endCellX = Math.min(
+    maxX,
+    Math.floor((viewport.left + viewport.width) / cellSize),
+  );
+  const endCellY = Math.min(
+    maxY,
+    Math.floor((viewport.top + viewport.height) / cellSize),
+  );
+
+  return {
+    startChunkX: Math.max(
+      0,
+      Math.floor(startCellX / chunkSize) - VIEWPORT_PREFETCH_MARGIN,
+    ),
+    endChunkX: Math.max(
+      0,
+      Math.floor(endCellX / chunkSize) + VIEWPORT_PREFETCH_MARGIN,
+    ),
+    startChunkY: Math.max(
+      0,
+      Math.floor(startCellY / chunkSize) - VIEWPORT_PREFETCH_MARGIN,
+    ),
+    endChunkY: Math.max(
+      0,
+      Math.floor(endCellY / chunkSize) + VIEWPORT_PREFETCH_MARGIN,
+    ),
+    chunkSize,
+  };
+}
+
 export default function useCanvasPage({
   onSessionEnded,
   onUnauthorized,
 }: UseCanvasPageParams) {
   const isRoundExpiredRef = useRef(false);
+  const chunkRequestKeyRef = useRef<string | null>(null);
 
   const [roundSummaryModal, setRoundSummaryModal] =
     useState<RoundSummaryData | null>(null);
@@ -88,7 +136,7 @@ export default function useCanvasPage({
     handleMouseLeave,
     handleWheel,
     handleCanvasUpdated,
-    handleCanvasBatchUpdated, // 추가: batch canvas update handler
+    handleCanvasBatchUpdated,
     clearSelectedCell,
   } = useCanvasScene({
     previewColorRef,
@@ -112,6 +160,48 @@ export default function useCanvasPage({
     },
     [setCanvasId, setGridX, setGridY, updateCells],
   );
+
+  const chunkRequest = useMemo(() => {
+    if (!canvasId || gridX <= 0 || gridY <= 0 || !viewport) {
+      return null;
+    }
+
+    return buildChunkRequest(viewport, 1, gridX, gridY, DEFAULT_CHUNK_SIZE);
+  }, [canvasId, gridX, gridY, viewport]);
+
+  useEffect(() => {
+    if (!canvasId || !chunkRequest) {
+      return;
+    }
+
+    const requestKey = JSON.stringify(chunkRequest);
+    if (chunkRequestKeyRef.current === requestKey) {
+      return;
+    }
+
+    chunkRequestKeyRef.current = requestKey;
+
+    void canvasApi.getChunks(canvasId, chunkRequest).then(({ data }) => {
+      updateCells((prev) => {
+        const next = [...prev];
+
+        for (const incoming of data.cells) {
+          const index = next.findIndex(
+            (cell) => cell.x === incoming.x && cell.y === incoming.y,
+          );
+
+          if (index === -1) {
+            next.push(incoming);
+            continue;
+          }
+
+          next[index] = incoming;
+        }
+
+        return next;
+      });
+    });
+  }, [canvasId, chunkRequest, updateCells]);
 
   const handleRoundEndedCleanup = useCallback(() => {
     clearSelectedCell();


### PR DESCRIPTION
## 관련 이슈
- Close #218 

## 작업 배경

기존 구조는 `/canvas/current` bootstrap 응답에서 전체 셀 데이터를 함께 내려주고 있었다.

이 방식은 이후 큰 보드에서 viewport/chunk 단위 조회 구조로 전환하기 어렵고,
초기 로딩 비용도 커질 수 있어
bootstrap 메타데이터와 실제 셀 조회를 분리할 필요가 있었다.

이번 작업에서는 캔버스 메타데이터는 `/canvas/current`에서 유지하고,
실제 셀 데이터는 별도의 chunk 조회 API로 가져오도록 분리했다.

## 변경 사항

- `GET /canvas/:canvasId/chunks` API 추가
- chunk 범위와 chunk size를 기준으로 painted 셀만 조회하도록 구현
- `/canvas/current` 응답에서 초기 `cells`는 빈 배열로 반환
- frontend에 chunk query/response 타입 추가
- frontend `canvasApi.getChunks()` 추가
- `useCanvasPage`에서 viewport 기준 chunk 요청 연결
- bootstrap 이후 셀 데이터는 chunk API를 통해 병합되도록 변경

## 주요 포인트

- chunk 기본 크기는 `64`
- 현재 단계에서는 viewport 기준 chunk 요청만 연결
- debounce, abort/cancel, cache, prefetch는 이번 범위에서 제외
- bootstrap은 메타데이터 중심으로 단순화하고, 셀 로딩 책임은 chunk API로 이동

## 확인 항목

- `/canvas/current` 응답에서 `cells`가 빈 배열인지 확인
- `/canvas/:canvasId/chunks` 호출 시 범위 내 painted 셀이 반환되는지 확인
- 프론트 진입 후 chunk API가 호출되어 셀이 채워지는지 확인
- 기존 보드 진입, 투표, 결과 모달 흐름에 회귀가 없는지 확인