### PR TITLE
feat: 라운드 종료 후 확정 셀 반영을 sparse/chunk 구조에 맞게 정리

### DIFF
--- a/frontend/src/features/gameplay/canvas/hooks/useChunkLoader.ts
+++ b/frontend/src/features/gameplay/canvas/hooks/useChunkLoader.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef } from "react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
 import { canvasApi } from "../api/canvas.api";
 import { MINIMAP_SIZE } from "../model/canvas.constants";
 import type { Cell, Viewport } from "../model/canvas.types";
@@ -15,6 +15,11 @@ interface ChunkRange {
   chunkSize: number;
 }
 
+interface ChunkCellCoordinate {
+  x: number;
+  y: number;
+}
+
 interface UseChunkLoaderParams {
   canvasId: number | null;
   gridX: number;
@@ -29,6 +34,10 @@ function clamp(value: number, min: number, max: number): number {
 
 function getChunkKey(chunkX: number, chunkY: number): string {
   return `${chunkX}:${chunkY}`;
+}
+
+function getChunkKeyFromCell(x: number, y: number, chunkSize: number): string {
+  return getChunkKey(Math.floor(x / chunkSize), Math.floor(y / chunkSize));
 }
 
 function buildChunkKeys(range: ChunkRange): string[] {
@@ -139,6 +148,33 @@ export function useChunkLoader({
     return buildChunkRange(viewport, gridX, gridY, DEFAULT_CHUNK_SIZE);
   }, [canvasId, gridX, gridY, viewport]);
 
+  const invalidateChunksByCells = useCallback(
+    (cells: ChunkCellCoordinate[], chunkSize = DEFAULT_CHUNK_SIZE) => {
+      if (cells.length === 0) {
+        return;
+      }
+
+      const nextLoadedChunkKeys = new Set(loadedChunkKeysRef.current);
+
+      for (const cell of cells) {
+        if (!Number.isFinite(cell.x) || !Number.isFinite(cell.y)) {
+          continue;
+        }
+
+        if (cell.x < 0 || cell.y < 0) {
+          continue;
+        }
+
+        nextLoadedChunkKeys.delete(
+          getChunkKeyFromCell(cell.x, cell.y, chunkSize),
+        );
+      }
+
+      loadedChunkKeysRef.current = nextLoadedChunkKeys;
+    },
+    [],
+  );
+
   useEffect(() => {
     loadedChunkKeysRef.current = new Set();
 
@@ -228,4 +264,8 @@ export function useChunkLoader({
       }
     };
   }, [canvasId, chunkRange, updateCells]);
+
+  return {
+    invalidateChunksByCells,
+  };
 }

--- a/frontend/src/features/gameplay/vote/components/VotePanel.tsx
+++ b/frontend/src/features/gameplay/vote/components/VotePanel.tsx
@@ -23,6 +23,7 @@ interface Props {
   votes: Record<string, number>;
   remaining: number | null;
   cells: Cell[];
+  minimapCells: Cell[];
   participants: ParticipantItem[];
   participantLoading: boolean;
   participantError: string | null;
@@ -49,6 +50,7 @@ export default function VotePanel({
   votes,
   remaining,
   cells,
+  minimapCells,
   participants,
   participantLoading,
   participantError,
@@ -108,7 +110,7 @@ export default function VotePanel({
       </div>
 
       <MiniMap
-        cells={cells}
+        cells={minimapCells}
         gridX={gridX}
         gridY={gridY}
         viewport={viewport}

--- a/frontend/src/pages/canvas/CanvasPage.tsx
+++ b/frontend/src/pages/canvas/CanvasPage.tsx
@@ -91,7 +91,6 @@ export default function CanvasPage() {
     },
     [navigate],
   );
-
   const {
     paintCanvasRef,
     canvasRef,
@@ -113,6 +112,7 @@ export default function CanvasPage() {
     selectedCell,
     votes,
     cells,
+    minimapCells,
     handleVoteSuccess,
     handleColorChange,
     handlePopupClose,
@@ -241,6 +241,7 @@ export default function CanvasPage() {
             votes={votes}
             remaining={remaining}
             cells={cells}
+            minimapCells={minimapCells}
             participants={participants}
             participantLoading={participantLoading}
             participantError={participantError}

--- a/frontend/src/pages/canvas/model/useCanvasPage.ts
+++ b/frontend/src/pages/canvas/model/useCanvasPage.ts
@@ -1,4 +1,3 @@
-// TO-BE
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useChunkLoader } from "@/features/gameplay/canvas/hooks/useChunkLoader";
 import { useVotePopup, useVoteState } from "@/features/gameplay/vote";
@@ -11,6 +10,7 @@ import {
   GAME_PHASE,
   type GamePhase,
 } from "@/features/gameplay/session/model/game-phase.types";
+import type { CanvasBatchUpdatedPayload } from "@/features/gameplay/session/model/socket.types";
 import useCanvasGameplay from "./useCanvasGameplay";
 import useCanvasScene from "./useCanvasScene";
 
@@ -69,6 +69,7 @@ export default function useCanvasPage({
     canvasRef,
     containerRef,
     cells,
+    minimapCells,
     canvasId,
     gridX,
     gridY,
@@ -83,6 +84,7 @@ export default function useCanvasPage({
     setGridX,
     setGridY,
     updateCells,
+    updateMinimapCells,
     handleMouseDown,
     handleMouseMove,
     handleMouseUp,
@@ -110,17 +112,26 @@ export default function useCanvasPage({
       setGridY(result.gridY);
       setBackgroundImageUrl(result.backgroundImageUrl);
       updateCells(result.cells);
+      updateMinimapCells(result.cells);
     },
-    [setCanvasId, setGridX, setGridY, updateCells],
+    [setCanvasId, setGridX, setGridY, updateCells, updateMinimapCells],
   );
 
-  useChunkLoader({
+  const { invalidateChunksByCells } = useChunkLoader({
     canvasId,
     gridX,
     gridY,
     viewport,
     updateCells,
   });
+
+  const handleCanvasBatchUpdatedForRoundResult = useCallback(
+    (payload: CanvasBatchUpdatedPayload) => {
+      invalidateChunksByCells(payload.updates);
+      handleCanvasBatchUpdated(payload);
+    },
+    [handleCanvasBatchUpdated, invalidateChunksByCells],
+  );
 
   const handleRoundEndedCleanup = useCallback(() => {
     clearSelectedCell();
@@ -195,7 +206,7 @@ export default function useCanvasPage({
     canvasId,
     onBootstrapScene: applyBootstrapScene,
     onCanvasUpdated: handleCanvasUpdated,
-    onCanvasBatchUpdated: handleCanvasBatchUpdated,
+    onCanvasBatchUpdated: handleCanvasBatchUpdatedForRoundResult,
     onOpenRoundSummaryModal: handleOpenRoundSummaryModal,
     onOpenGameSummaryModal: handleOpenGameSummaryModal,
     onRoundEndedCleanup: handleRoundEndedCleanup,
@@ -258,6 +269,7 @@ export default function useCanvasPage({
     selectedCell,
     votes,
     cells,
+    minimapCells,
     handleVoteSuccess,
     handleColorChange,
     handlePopupClose,

--- a/frontend/src/pages/canvas/model/useCanvasScene.ts
+++ b/frontend/src/pages/canvas/model/useCanvasScene.ts
@@ -12,7 +12,7 @@ import {
   useCanvasRenderer,
   useCanvasViewport,
 } from "@/features/gameplay/canvas";
-import type { CanvasBatchUpdatedPayload } from "@/features/gameplay/session/model/socket.types"; // 추가: batch canvas update payload
+import type { CanvasBatchUpdatedPayload } from "@/features/gameplay/session/model/socket.types";
 import { getGameConfig } from "@/shared/config/game-config";
 
 interface UseCanvasSceneParams {
@@ -76,12 +76,10 @@ function clampZoom(nextZoom: number, bounds: ZoomBounds) {
   return Math.min(bounds.maxZoom, Math.max(bounds.minZoom, nextZoom));
 }
 
-function getNextZoom(
-  currentZoom: number,
-  zoomIn: boolean,
-  bounds: ZoomBounds,
-) {
-  const scaledZoom = zoomIn ? currentZoom * ZOOM_SCALE : currentZoom / ZOOM_SCALE;
+function getNextZoom(currentZoom: number, zoomIn: boolean, bounds: ZoomBounds) {
+  const scaledZoom = zoomIn
+    ? currentZoom * ZOOM_SCALE
+    : currentZoom / ZOOM_SCALE;
   return clampZoom(scaledZoom, bounds);
 }
 
@@ -103,6 +101,59 @@ function clampCamera(
   };
 }
 
+function isCellInsideVisibleBounds(
+  x: number,
+  y: number,
+  bounds: {
+    startCellX: number;
+    endCellX: number;
+    startCellY: number;
+    endCellY: number;
+  } | null,
+) {
+  if (!bounds) {
+    return false;
+  }
+
+  return (
+    x >= bounds.startCellX &&
+    x <= bounds.endCellX &&
+    y >= bounds.startCellY &&
+    y <= bounds.endCellY
+  );
+}
+
+function upsertCells(
+  prev: Cell[],
+  updates: Array<{ x: number; y: number; color: string }>,
+) {
+  const next = [...prev];
+
+  for (const update of updates) {
+    const index = next.findIndex(
+      (cell) => cell.x === update.x && cell.y === update.y,
+    );
+
+    if (index === -1) {
+      next.push({
+        x: update.x,
+        y: update.y,
+        color: update.color,
+        status: "painted",
+      } as Cell);
+      continue;
+    }
+
+    next[index] = {
+      ...next[index],
+      color: update.color,
+      status: "painted",
+    };
+  }
+
+  return next;
+}
+
 export default function useCanvasScene({
   previewColor,
   votingCellIds,
@@ -115,6 +166,7 @@ export default function useCanvasScene({
   const containerRef = useRef<HTMLDivElement>(null);
 
   const cellsRef = useRef<Cell[]>([]);
+  const minimapCellsRef = useRef<Cell[]>([]);
   const selectedCellRef = useRef<Cell | null>(null);
   const zoomRef = useRef(1);
   const cameraXRef = useRef(0);
@@ -124,6 +176,7 @@ export default function useCanvasScene({
   const pendingZoomAdjustmentRef = useRef<PendingZoomAdjustment | null>(null);
 
   const [cells, setCells] = useState<Cell[]>([]);
+  const [minimapCells, setMinimapCells] = useState<Cell[]>([]);
   const [canvasId, setCanvasId] = useState<number | null>(null);
   const [gridX, setGridX] = useState(0);
   const [gridY, setGridY] = useState(0);
@@ -210,6 +263,23 @@ export default function useCanvasScene({
     },
     [],
   );
+
+  const updateMinimapCells = useCallback(
+    (updater: Cell[] | ((prev: Cell[]) => Cell[])) => {
+      if (typeof updater === "function") {
+        setMinimapCells((prev) => {
+          const next = updater(prev);
+          minimapCellsRef.current = next;
+          return next;
+        });
+      } else {
+        minimapCellsRef.current = updater;
+        setMinimapCells(updater);
+      }
+    },
+    [],
+  );
+
   useLayoutEffect(() => {
     const container = containerRef.current;
     const paintCanvas = paintCanvasRef.current;
@@ -448,27 +518,25 @@ export default function useCanvasScene({
 
   const handleCanvasUpdated = useCallback(
     ({ x, y, color }: { x: number; y: number; color: string }) => {
-      updateCells((prev) => {
-        const index = prev.findIndex((cell) => cell.x === x && cell.y === y);
+      updateCells((prev) =>
+        upsertCells(prev, [
+          {
+            x,
+            y,
+            color,
+          },
+        ]),
+      );
 
-        if (index === -1) {
-          return [
-            ...prev,
-            {
-              x,
-              y,
-              color,
-              status: "painted",
-            } as Cell,
-          ];
-        }
-
-        return prev.map((cell) =>
-          cell.x === x && cell.y === y
-            ? { ...cell, color, status: "painted" }
-            : cell,
-        );
-      });
+      updateMinimapCells((prev) =>
+        upsertCells(prev, [
+          {
+            x,
+            y,
+            color,
+          },
+        ]),
+      );
 
       if (
         selectedCellRef.current &&
@@ -485,50 +553,33 @@ export default function useCanvasScene({
         selectedCellRef.current = nextSelectedCell;
       }
     },
-    [updateCells],
+    [updateCells, updateMinimapCells],
   );
 
   const handleCanvasBatchUpdated = useCallback(
     ({ updates }: CanvasBatchUpdatedPayload) => {
-      const colorByCoordinate = new Map(
-        updates.map((update) => [`${update.x}:${update.y}`, update.color]),
+      updateMinimapCells((prev) => upsertCells(prev, updates));
+
+      updateCells((prev) =>
+        upsertCells(
+          prev,
+          updates.filter((update) =>
+            isCellInsideVisibleBounds(update.x, update.y, visibleCellBounds),
+          ),
+        ),
       );
 
-      updateCells((prev) => {
-        const next = [...prev];
-
-        for (const update of updates) {
-          const index = next.findIndex(
-            (cell) => cell.x === update.x && cell.y === update.y,
-          );
-
-          if (index === -1) {
-            next.push({
-              x: update.x,
-              y: update.y,
-              color: update.color,
-              status: "painted",
-            } as Cell);
-            continue;
-          }
-
-          next[index] = {
-            ...next[index],
-            color: update.color,
-            status: "painted",
-          };
-        }
-
-        return next;
-      });
-
       if (selectedCellRef.current) {
-        const selectedKey = `${selectedCellRef.current.x}:${selectedCellRef.current.y}`;
+        const updatedSelectedCell = updates.find(
+          (update) =>
+            update.x === selectedCellRef.current?.x &&
+            update.y === selectedCellRef.current?.y,
+        );
 
-        if (colorByCoordinate.has(selectedKey)) {
+        if (updatedSelectedCell) {
           const nextSelectedCell: Cell = {
             ...selectedCellRef.current,
-            color: colorByCoordinate.get(selectedKey)!,
+            color: updatedSelectedCell.color,
             status: "painted",
           };
 
@@ -537,7 +588,7 @@ export default function useCanvasScene({
         }
       }
     },
-    [updateCells],
+    [updateCells, updateMinimapCells, visibleCellBounds],
   );
 
   const clearSelectedCell = useCallback(() => {
@@ -550,6 +601,7 @@ export default function useCanvasScene({
     canvasRef,
     containerRef,
     cells,
+    minimapCells,
     canvasId,
     gridX,
     gridY,
@@ -564,13 +616,14 @@ export default function useCanvasScene({
     setGridX,
     setGridY,
     updateCells,
+    updateMinimapCells,
     handleMouseDown,
     handleMouseMove,
     handleMouseUp,
     handleMouseLeave,
-    handleWheel, // 추가: CanvasPage에서 사용하는 wheel zoom 핸들러 반환
+    handleWheel,
     handleCanvasUpdated,
-    handleCanvasBatchUpdated, // 유지: 여러 셀을 한 번에 반영하는 batch handler 노출
+    handleCanvasBatchUpdated,
     clearSelectedCell,
   };
 }


### PR DESCRIPTION
## 관련 이슈
- Close #219 

기존에는 batch 업데이트가 들어오면 화면에 보이지 않는 셀까지 바로 반영되면서
viewport 기반 렌더링 의도와 어긋나는 부분이 있었습니다.

이번 변경에서는 현재 보고 있는 영역은 즉시 갱신하고,
보지 않는 영역은 다음 chunk 조회 시 반영되도록 정리했습니다.
또한 미니맵은 offscreen 확정 셀도 바로 볼 수 있도록 분리했습니다.

## 변경 사항
- 라운드 종료 batch 업데이트 시 변경된 chunk cache invalidation 추가
- 현재 viewport 안의 확정 셀만 즉시 메인 canvas에 반영하도록 수정
- viewport 밖의 확정 셀은 다음 chunk 조회 시 반영되도록 정리
- 미니맵용 셀 상태를 메인 렌더용 셀 상태와 분리
- offscreen 확정 셀도 미니맵에는 즉시 반영되도록 수정
- bootstrap 시 메인 canvas용 셀과 미니맵용 셀을 함께 초기화하도록 정리

## 기대 효과
- viewport 기반 렌더링 구조와 라운드 종료 반영 정책이 일치
- 불필요한 offscreen 즉시 반영을 줄이면서도 데이터 정합성 유지
- 사용자는 현재 화면만 즉시 업데이트하고, 전체 확정 상태는 미니맵에서 바로 확인 가능
- 이후 해당 영역으로 이동하면 최신 chunk 기준으로 자연스럽게 반영

## 확인한 항목
- viewport 안 확정 셀은 즉시 메인 canvas와 미니맵에 반영되는지
- viewport 밖 확정 셀은 메인 canvas에는 바로 보이지 않고 미니맵에는 즉시 보이는지
- offscreen 확정 셀 위치로 이동 시 최신 chunk 조회 후 메인 canvas에 정상 반영되는지
- chunk 경계 좌표에서도 invalidation과 재조회가 정상 동작하는지
- 연속 라운드에서도 stale cache 없이 최신 확정 상태가 유지되는지