### PR TITLE
feat: 미니맵과 최근 라운드 결과 표시를 스냅샷 기반으로 전환

### DIFF
--- a/backend/src/modules/canvas/template/outline-template.service.ts
+++ b/backend/src/modules/canvas/template/outline-template.service.ts
@@ -20,6 +20,16 @@ export function pickRandomOutlineTemplate(
   return candidates[randomIndex(candidates.length)] ?? null;
 }
 
+export function findOutlineTemplateByAssetKey(
+  assetKey: string | null,
+): OutlineTemplate | null {
+  if (!assetKey) {
+    return null;
+  }
+
+  return OUTLINE_TEMPLATES.find((template) => template.id === assetKey) ?? null;
+}
+
 export function buildOutlineCellSet(
   template: OutlineTemplate | null,
 ): Set<string> {

--- a/backend/src/modules/history/round-snapshot-render.service.ts
+++ b/backend/src/modules/history/round-snapshot-render.service.ts
@@ -10,6 +10,7 @@ interface RenderRoundSnapshotParams {
   width: number;
   height: number;
   cells: SnapshotCell[];
+  outlineCells?: Array<{ x: number; y: number }>;
 }
 
 interface RgbColor {
@@ -38,6 +39,7 @@ function parseHexColor(hex: string): RgbColor {
 
 const CHECKER_LIGHT = "#6f6f6f";
 const CHECKER_DARK = "#5f5f5f";
+const OUTLINE_COLOR = "#000000";
 
 function setPixelColor(png: PNG, x: number, y: number, color: RgbColor): void {
   const index = (png.width * y + x) << 2;
@@ -50,19 +52,43 @@ function setPixelColor(png: PNG, x: number, y: number, color: RgbColor): void {
 function getEmptyCellColor(x: number, y: number): RgbColor {
   return parseHexColor((x + y) % 2 === 0 ? CHECKER_LIGHT : CHECKER_DARK);
 }
+
+function createBasePng(
+  width: number,
+  height: number,
+  outlineCells: Array<{ x: number; y: number }> = [],
+): PNG {
+  const png = new PNG({ width, height });
+
+  for (let y = 0; y < height; y += 1) {
+    for (let x = 0; x < width; x += 1) {
+      setPixelColor(png, x, y, getEmptyCellColor(x, y));
+    }
+  }
+
+  for (const cell of outlineCells) {
+    if (cell.x < 0 || cell.y < 0 || cell.x >= width || cell.y >= height) {
+      continue;
+    }
+
+    setPixelColor(png, cell.x, cell.y, parseHexColor(OUTLINE_COLOR));
+  }
+
+  return png;
+}
+
 export const roundSnapshotRenderService = {
-  renderPngBuffer({ width, height, cells }: RenderRoundSnapshotParams): Buffer {
+  renderPngBuffer({
+    width,
+    height,
+    cells,
+    outlineCells = [],
+  }: RenderRoundSnapshotParams): Buffer {
     if (width <= 0 || height <= 0) {
       throw new Error("스냅샷 크기가 올바르지 않습니다.");
     }
 
-    const png = new PNG({ width, height });
-
-    for (let y = 0; y < height; y += 1) {
-      for (let x = 0; x < width; x += 1) {
-        setPixelColor(png, x, y, getEmptyCellColor(x, y));
-      }
-    }
+    const png = createBasePng(width, height, outlineCells);
 
     for (const cell of cells) {
       if (!cell.color) {

--- a/backend/src/modules/history/round-snapshot.service.ts
+++ b/backend/src/modules/history/round-snapshot.service.ts
@@ -10,6 +10,7 @@ import {
   resolveGameHistoryAbsolutePath,
 } from "./history-storage.service";
 import { roundSnapshotRenderService } from "./round-snapshot-render.service";
+import { findOutlineTemplateByAssetKey } from "../canvas/template/outline-template.service";
 
 const canvasRepository = AppDataSource.getRepository(Canvas);
 const cellRepository = AppDataSource.getRepository(Cell);
@@ -86,6 +87,10 @@ export const roundSnapshotService = {
       .andWhere("cell.color IS NOT NULL")
       .getMany();
 
+    const outlineTemplate = findOutlineTemplateByAssetKey(
+      canvas.backgroundAssetKey,
+    );
+
     const pngBuffer = roundSnapshotRenderService.renderPngBuffer({
       width: canvas.gridX,
       height: canvas.gridY,
@@ -94,6 +99,7 @@ export const roundSnapshotService = {
         y: cell.y,
         color: cell.color,
       })),
+      outlineCells: outlineTemplate?.cells ?? [],
     });
 
     await ensureRoundSnapshotDirectory({

--- a/frontend/src/features/gameplay/canvas/components/MiniMap.tsx
+++ b/frontend/src/features/gameplay/canvas/components/MiniMap.tsx
@@ -2,13 +2,14 @@ import { useEffect, useMemo, useRef } from "react";
 import { Cell, Viewport } from "../model/canvas.types";
 
 const MINIMAP_BOX_SIZE = 220;
-const EMPTY_CELL_COLOR = "#d1d5db";
 const VIEWPORT_STROKE = "#ef4444";
 const VIEWPORT_FILL = "rgba(239, 68, 68, 0.12)";
 const SELECTED_CELL_STROKE = "#f97316";
+const MINIMAP_STROKE_WIDTH = 2;
 
 interface Props {
-  cells: Cell[];
+  snapshotUrl: string | null;
+  backgroundImageUrl: string | null;
   gridX: number;
   gridY: number;
   viewport: Viewport | null;
@@ -16,8 +17,76 @@ interface Props {
   onNavigate: (x: number, y: number, behavior?: ScrollBehavior) => void;
 }
 
+function getInsetStrokeRect(
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+  lineWidth: number,
+  maxWidth: number,
+  maxHeight: number,
+) {
+  const inset = lineWidth / 2;
+
+  const safeX = Math.max(inset, x + inset);
+  const safeY = Math.max(inset, y + inset);
+  const safeRight = Math.min(maxWidth - inset, x + width - inset);
+  const safeBottom = Math.min(maxHeight - inset, y + height - inset);
+
+  return {
+    x: safeX,
+    y: safeY,
+    width: Math.max(0, safeRight - safeX),
+    height: Math.max(0, safeBottom - safeY),
+  };
+}
+
+function getClampedViewportRect(
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+  maxWidth: number,
+  maxHeight: number,
+) {
+  const safeX = Math.max(0, Math.min(x, maxWidth));
+  const safeY = Math.max(0, Math.min(y, maxHeight));
+  const safeRight = Math.max(0, Math.min(x + width, maxWidth));
+  const safeBottom = Math.max(0, Math.min(y + height, maxHeight));
+
+  return {
+    x: safeX,
+    y: safeY,
+    width: Math.max(0, safeRight - safeX),
+    height: Math.max(0, safeBottom - safeY),
+  };
+}
+
+function getClampedMarkerRect(
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+  maxWidth: number,
+  maxHeight: number,
+) {
+  const markerSize = Math.max(
+    2,
+    Math.floor(Math.min(Math.max(width, 2), Math.max(height, 2), 4)),
+  );
+  const safeX = Math.min(Math.max(x, 0), Math.max(0, maxWidth - markerSize));
+  const safeY = Math.min(Math.max(y, 0), Math.max(0, maxHeight - markerSize));
+
+  return {
+    x: safeX,
+    y: safeY,
+    size: markerSize,
+  };
+}
+
 export default function MiniMap({
-  cells,
+  snapshotUrl,
+  backgroundImageUrl,
   gridX,
   gridY,
   viewport,
@@ -53,49 +122,91 @@ export default function MiniMap({
     const cellWidth = canvas.width / Math.max(gridX, 1);
     const cellHeight = canvas.height / Math.max(gridY, 1);
 
-    for (const cell of cells) {
-      ctx.fillStyle = cell.color ?? EMPTY_CELL_COLOR;
-      ctx.fillRect(
-        cell.x * cellWidth,
-        cell.y * cellHeight,
-        Math.ceil(cellWidth),
-        Math.ceil(cellHeight),
-      );
-    }
-
-    if (selectedCell) {
-      ctx.save();
-      ctx.strokeStyle = SELECTED_CELL_STROKE;
-      ctx.lineWidth = 2;
-      ctx.strokeRect(
-        selectedCell.x * cellWidth,
-        selectedCell.y * cellHeight,
-        Math.max(cellWidth, 1),
-        Math.max(cellHeight, 1),
-      );
-      ctx.restore();
-    }
-
     if (viewport) {
+      const viewportRect = getClampedViewportRect(
+        viewport.left,
+        viewport.top,
+        viewport.width,
+        viewport.height,
+        canvas.width,
+        canvas.height,
+      );
+
       ctx.save();
       ctx.fillStyle = VIEWPORT_FILL;
       ctx.strokeStyle = VIEWPORT_STROKE;
-      ctx.lineWidth = 2;
+      ctx.lineWidth = MINIMAP_STROKE_WIDTH;
       ctx.fillRect(
-        viewport.left,
-        viewport.top,
-        viewport.width,
-        viewport.height,
+        viewportRect.x,
+        viewportRect.y,
+        viewportRect.width,
+        viewportRect.height,
       );
       ctx.strokeRect(
-        viewport.left,
-        viewport.top,
-        viewport.width,
-        viewport.height,
+        viewportRect.x + MINIMAP_STROKE_WIDTH / 2,
+        viewportRect.y + MINIMAP_STROKE_WIDTH / 2,
+        Math.max(0, viewportRect.width - MINIMAP_STROKE_WIDTH),
+        Math.max(0, viewportRect.height - MINIMAP_STROKE_WIDTH),
       );
       ctx.restore();
     }
-  }, [cells, gridX, gridY, minimapDimensions, selectedCell, viewport]);
+
+    if (selectedCell) {
+      const rawX = selectedCell.x * cellWidth;
+      const rawY = selectedCell.y * cellHeight;
+      const rawWidth = Math.max(cellWidth, 1);
+      const rawHeight = Math.max(cellHeight, 1);
+
+      ctx.save();
+      ctx.strokeStyle = SELECTED_CELL_STROKE;
+      ctx.fillStyle = SELECTED_CELL_STROKE;
+      ctx.lineWidth = MINIMAP_STROKE_WIDTH;
+
+      if (rawWidth <= 4 || rawHeight <= 4) {
+        const markerRect = getClampedMarkerRect(
+          rawX,
+          rawY,
+          rawWidth,
+          rawHeight,
+          canvas.width,
+          canvas.height,
+        );
+
+        ctx.fillRect(
+          markerRect.x,
+          markerRect.y,
+          markerRect.size,
+          markerRect.size,
+        );
+      } else {
+        const selectedRect = getInsetStrokeRect(
+          rawX,
+          rawY,
+          rawWidth,
+          rawHeight,
+          MINIMAP_STROKE_WIDTH,
+          canvas.width,
+          canvas.height,
+        );
+
+        ctx.strokeRect(
+          selectedRect.x,
+          selectedRect.y,
+          selectedRect.width,
+          selectedRect.height,
+        );
+      }
+
+      ctx.restore();
+    }
+  }, [
+    gridX,
+    gridY,
+    minimapDimensions.width,
+    minimapDimensions.height,
+    selectedCell,
+    viewport,
+  ]);
 
   const navigateFromPointer = (
     clientX: number,
@@ -142,7 +253,21 @@ export default function MiniMap({
 
   return (
     <div className="flex justify-center">
-      <div className="flex h-[220px] w-full items-center justify-center rounded-lg p-2">
+      <div className="relative flex h-[220px] w-full items-center justify-center overflow-hidden">
+        {(snapshotUrl || backgroundImageUrl) && (
+          <img
+            src={snapshotUrl ?? backgroundImageUrl ?? undefined}
+            alt="미니맵 스냅샷"
+            className="pointer-events-none absolute block h-full w-full select-none"
+            style={{
+              width: `${minimapDimensions.width}px`,
+              height: `${minimapDimensions.height}px`,
+              imageRendering: "pixelated",
+            }}
+            draggable={false}
+          />
+        )}
+
         <canvas
           ref={canvasRef}
           onMouseDown={(event) => {
@@ -150,7 +275,7 @@ export default function MiniMap({
             navigateFromPointer(event.clientX, event.clientY, "auto");
           }}
           onDragStart={(event) => event.preventDefault()}
-          className="block cursor-crosshair rounded border border-gray-50 bg-transparent"
+          className="relative z-[1] block cursor-crosshair bg-transparent"
           style={{
             width: `${minimapDimensions.width}px`,
             height: `${minimapDimensions.height}px`,

--- a/frontend/src/features/gameplay/vote/components/VotePanel.tsx
+++ b/frontend/src/features/gameplay/vote/components/VotePanel.tsx
@@ -23,7 +23,8 @@ interface Props {
   votes: Record<string, number>;
   remaining: number | null;
   cells: Cell[];
-  minimapCells: Cell[];
+  latestRoundSnapshot: string | null;
+  backgroundImageUrl: string | null;
   participants: ParticipantItem[];
   participantLoading: boolean;
   participantError: string | null;
@@ -50,7 +51,8 @@ export default function VotePanel({
   votes,
   remaining,
   cells,
-  minimapCells,
+  latestRoundSnapshot,
+  backgroundImageUrl,
   participants,
   participantLoading,
   participantError,
@@ -110,14 +112,14 @@ export default function VotePanel({
       </div>
 
       <MiniMap
-        cells={minimapCells}
+        snapshotUrl={latestRoundSnapshot}
+        backgroundImageUrl={backgroundImageUrl}
         gridX={gridX}
         gridY={gridY}
         viewport={viewport}
         selectedCell={selectedCell}
         onNavigate={onNavigateToCoordinate}
       />
-
       <CoordinateNavigator
         gridX={gridX}
         gridY={gridY}

--- a/frontend/src/pages/canvas/CanvasPage.tsx
+++ b/frontend/src/pages/canvas/CanvasPage.tsx
@@ -112,7 +112,6 @@ export default function CanvasPage() {
     selectedCell,
     votes,
     cells,
-    minimapCells,
     handleVoteSuccess,
     handleColorChange,
     handlePopupClose,
@@ -241,7 +240,8 @@ export default function CanvasPage() {
             votes={votes}
             remaining={remaining}
             cells={cells}
-            minimapCells={minimapCells}
+            latestRoundSnapshot={latestRoundSnapshot}
+            backgroundImageUrl={backgroundImageUrl}
             participants={participants}
             participantLoading={participantLoading}
             participantError={participantError}


### PR DESCRIPTION
## 관련 이슈
- Close #221 

# 작업 개요
작업으로 미니맵과 최근 라운드 결과 표시 구조를
기존 셀 데이터 기반 렌더링에서 스냅샷 재사용 방식으로 정리했습니다.

메인 보드는 viewport/chunk 기반 셀 렌더링을 유지하고,
미니맵과 히스토리/최근 라운드 결과는 snapshot 이미지를 기준으로 표시하도록 역할을 분리했습니다.

## 변경 사항
- 미니맵을 셀 직접 렌더링 대신 snapshot/background 이미지 기반으로 전환
- 미니맵 overlay는 viewport 박스와 선택 셀 표시만 담당하도록 정리
- VotePanel에서 미니맵에 snapshot URL과 background image URL을 전달하도록 수정
- CanvasPage/useCanvasPage에서 snapshot 기반 미니맵 표시 흐름 정리
- 라운드 스냅샷 생성 시 outline template를 함께 반영해 초기 아웃라인이 유지되도록 수정
- 미니맵 내부 패널/여백 구조를 정리해 실제 표시 영역이 패널을 최대한 활용하도록 조정

## 기대 효과
- 메인 보드 렌더링 책임과 미니맵/히스토리 표시 책임이 분리됨
- offscreen 확정 셀도 snapshot 기준으로 미니맵에서 즉시 확인 가능
- 최근 라운드 결과와 미니맵이 같은 시각 기준을 사용해 일관성이 높아짐
- 스냅샷에서도 초기 outline이 유지되어 실제 보드 모습과 차이가 줄어듦

## 확인한 항목
- snapshot이 있을 때 미니맵이 snapshot 이미지를 기준으로 표시되는지
- snapshot이 없을 때 background 이미지로 fallback 되는지
- 라운드 종료 후 미니맵이 전체 확정 결과를 즉시 보여주는지
- 스냅샷에 초기 outline이 유지되는지
- 미니맵 클릭/드래그 이동과 viewport overlay가 정상 동작하는지