### PR TITLE
refactor: full grid 전제 구조 제거 및 레거시 응답 정리

### DIFF
--- a/backend/src/modules/canvas/canvas.controller.ts
+++ b/backend/src/modules/canvas/canvas.controller.ts
@@ -106,7 +106,6 @@ export const canvasController = {
 
       return res.json({
         canvas: serializeCanvas(canvas),
-        cells: [],
         gameConfig: getCanvasGameConfigSnapshot(canvas),
       });
     } catch (err) {

--- a/backend/src/modules/canvas/canvas.service.ts
+++ b/backend/src/modules/canvas/canvas.service.ts
@@ -121,16 +121,6 @@ export const canvasService = {
     });
   },
 
-  async getCells(canvasId: number): Promise<Cell[]> {
-    return cellRepository.find({
-      where: {
-        canvas: { id: canvasId },
-        status: CellStatus.PAINTED,
-      },
-      order: { y: "ASC", x: "ASC" },
-    });
-  },
-
   async getCurrentParticipantCount(): Promise<{
     canvasId: number;
     count: number;

--- a/frontend/src/features/gameplay/canvas/api/canvas.api.ts
+++ b/frontend/src/features/gameplay/canvas/api/canvas.api.ts
@@ -1,13 +1,10 @@
-// TO-BE
 import api from "@/shared/api/client";
 import type {
   CanvasChunkQuery,
   CanvasChunkResponse,
-  CanvasCurrentResponse,
 } from "../model/canvas.types";
 
 export const canvasApi = {
-  getCurrent: () => api.get<CanvasCurrentResponse>("/canvas/current"),
   getChunks: (
     canvasId: number,
     params: CanvasChunkQuery,
@@ -19,4 +16,4 @@ export const canvasApi = {
     }),
 };
 
-export type { CanvasChunkQuery, CanvasChunkResponse, CanvasCurrentResponse };
+export type { CanvasChunkQuery, CanvasChunkResponse };

--- a/frontend/src/features/gameplay/canvas/model/canvas.types.ts
+++ b/frontend/src/features/gameplay/canvas/model/canvas.types.ts
@@ -1,5 +1,4 @@
 import type { GamePhase } from "@/features/gameplay/session/model/game-phase.types";
-import type { GameConfig } from "@/shared/config/game-config";
 
 export type CanvasStatus = "playing" | "finished";
 
@@ -27,12 +26,6 @@ export interface Cell {
   status: CellStatus;
 }
 
-export interface CanvasCurrentResponse {
-  canvas: Canvas;
-  cells: Cell[];
-  gameConfig: GameConfig;
-}
-
 export interface Viewport {
   left: number;
   top: number;
@@ -46,6 +39,7 @@ export interface VisibleCellBounds {
   startCellY: number;
   endCellY: number;
 }
+
 export interface CanvasChunkQuery {
   startChunkX: number;
   endChunkX: number;

--- a/frontend/src/features/gameplay/session/api/session.api.ts
+++ b/frontend/src/features/gameplay/session/api/session.api.ts
@@ -1,7 +1,13 @@
 import api from "@/shared/api/client";
-import type { CanvasCurrentResponse } from "@/features/gameplay/canvas";
+import type { Canvas } from "@/features/gameplay/canvas";
 import { voteApi } from "@/features/gameplay/vote/api/vote.api";
+import type { GameConfig } from "@/shared/config/game-config";
 import type { GamePhase } from "../model/game-phase.types";
+
+export interface CanvasCurrentResponse {
+  canvas: Canvas;
+  gameConfig: GameConfig;
+}
 
 export interface RoundStateResponse {
   status: "active" | "waiting";
@@ -147,5 +153,3 @@ export const sessionApi = {
 
   createCanvas: (payload?: CreateCanvasRequest) => api.post("/canvas", payload),
 };
-
-export type { CanvasCurrentResponse };

--- a/frontend/src/features/gameplay/session/hooks/useGameplayBootstrap.ts
+++ b/frontend/src/features/gameplay/session/hooks/useGameplayBootstrap.ts
@@ -156,7 +156,6 @@ export function useGameplayBootstrap() {
       gridX: canvas.gridX,
       gridY: canvas.gridY,
       backgroundImageUrl: getBackgroundImageUrl(canvas.backgroundAssetKey),
-      cells: [],
       round,
       votes,
       remaining,

--- a/frontend/src/features/gameplay/session/model/session.types.ts
+++ b/frontend/src/features/gameplay/session/model/session.types.ts
@@ -1,4 +1,3 @@
-import type { Cell } from "@/features/gameplay/canvas";
 import type { GamePhase } from "@/features/gameplay/session/model/game-phase.types";
 import type { GameConfig } from "@/shared/config/game-config";
 
@@ -15,6 +14,7 @@ export interface RoundInfoState {
   phaseStartedAt: string | null;
   phaseEndsAt: string | null;
 }
+
 export interface PhaseTimingState {
   introPhaseSec: number;
   roundStartWaitSec: number;
@@ -29,15 +29,6 @@ export interface VoteSessionState {
   topColorMap: Map<string, string>;
 }
 
-export interface CanvasSessionState {
-  canvasId: number | null;
-  gridX: number;
-  gridY: number;
-  cells: Cell[];
-  selectedCell: Cell | null;
-  previewColor: string | null;
-}
-
 export interface SessionStatusState {
   loading: boolean;
   error: string | null;
@@ -50,7 +41,6 @@ export interface SessionBootstrapResult {
   gridX: number;
   gridY: number;
   backgroundImageUrl: string | null;
-  cells: Cell[];
   round: RoundInfoState;
   votes: Record<string, number>;
   remaining: number | null;

--- a/frontend/src/pages/canvas/model/useCanvasPage.ts
+++ b/frontend/src/pages/canvas/model/useCanvasPage.ts
@@ -84,7 +84,6 @@ export default function useCanvasPage({
     setGridX,
     setGridY,
     updateCells,
-    updateMinimapCells,
     handleMouseDown,
     handleMouseMove,
     handleMouseUp,
@@ -111,10 +110,8 @@ export default function useCanvasPage({
       setGridX(result.gridX);
       setGridY(result.gridY);
       setBackgroundImageUrl(result.backgroundImageUrl);
-      updateCells(result.cells);
-      updateMinimapCells(result.cells);
     },
-    [setCanvasId, setGridX, setGridY, updateCells, updateMinimapCells],
+    [setCanvasId, setGridX, setGridY],
   );
 
   const { invalidateChunksByCells } = useChunkLoader({

--- a/frontend/src/pages/canvas/model/useCanvasScene.ts
+++ b/frontend/src/pages/canvas/model/useCanvasScene.ts
@@ -165,8 +165,6 @@ export default function useCanvasScene({
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
 
-  const cellsRef = useRef<Cell[]>([]);
-  const minimapCellsRef = useRef<Cell[]>([]);
   const selectedCellRef = useRef<Cell | null>(null);
   const zoomRef = useRef(1);
   const cameraXRef = useRef(0);
@@ -251,15 +249,11 @@ export default function useCanvasScene({
   const updateCells = useCallback(
     (updater: Cell[] | ((prev: Cell[]) => Cell[])) => {
       if (typeof updater === "function") {
-        setCells((prev) => {
-          const next = updater(prev);
-          cellsRef.current = next;
-          return next;
-        });
-      } else {
-        cellsRef.current = updater;
-        setCells(updater);
+        setCells((prev) => updater(prev));
+        return;
       }
+
+      setCells(updater);
     },
     [],
   );
@@ -267,15 +261,11 @@ export default function useCanvasScene({
   const updateMinimapCells = useCallback(
     (updater: Cell[] | ((prev: Cell[]) => Cell[])) => {
       if (typeof updater === "function") {
-        setMinimapCells((prev) => {
-          const next = updater(prev);
-          minimapCellsRef.current = next;
-          return next;
-        });
-      } else {
-        minimapCellsRef.current = updater;
-        setMinimapCells(updater);
+        setMinimapCells((prev) => updater(prev));
+        return;
       }
+
+      setMinimapCells(updater);
     },
     [],
   );


### PR DESCRIPTION
## 관련 이슈
- Close #222 

## 개요
viewport/chunk 기반 구조로 전환된 이후에도 남아 있던
전체 셀 응답 전제, bootstrap 시 빈 cells 초기화, 사용되지 않는 API/타입 등을 제거해
현재 구조에 맞는 코드 경로만 남기도록 정리했습니다.

## 변경 사항
- backend canvas service의 전체 셀 조회 레거시 메서드 제거
- `/canvas/current` 응답에서 더 이상 사용하지 않는 `cells` 필드 제거
- frontend `CanvasCurrentResponse`를 현재 응답 구조에 맞게 단순화
- bootstrap 결과에서 `cells` 필드 제거
- `useCanvasPage`의 bootstrap 시 빈 `cells` 초기화 제거
- 사용되지 않는 `canvasApi.getCurrent` 제거
- session/canvas 관련 레거시 타입 정리
- `useCanvasScene` 내부 상태 업데이트 helper를 현재 구조에 맞게 단순화

## 기대 효과
- full grid 전제를 가정하는 잔여 코드 제거
- 현재 sparse/chunk 기반 구조와 타입/응답 정의 일치
- bootstrap 및 current canvas 응답 흐름 단순화
- 불필요한 레거시 경로 제거로 유지보수성 향상

## 확인 사항
- `/canvas/current` 응답이 `canvas`, `gameConfig` 기준으로 정상 동작하는지
- bootstrap 이후 chunk 로딩으로 메인 canvas가 정상 표시되는지
- 라운드 진행 중 chunk 조회, 선택, 투표, 라운드 종료 반영이 기존과 동일하게 동작하는지
- 타입 변경 이후 session/gameplay 관련 코드에서 회귀가 없는지
