### PR TITLE
feat: 히스토리 패널을 타임라인 기반으로 개선

### DIFF
--- a/backend/src/modules/canvas/canvas.router.ts
+++ b/backend/src/modules/canvas/canvas.router.ts
@@ -1,4 +1,5 @@
 import { Router } from "express";
+import { historyController } from "../history/history.controller";
 import { canvasController } from "./canvas.controller";
 import { authMiddleware } from "../../middlewares/auth.middleware";
 
@@ -6,7 +7,8 @@ const router = Router();
 
 // TO-BE
 router.get("/current", authMiddleware, canvasController.getCurrent);
-router.get("/:canvasId/chunks", authMiddleware, canvasController.getChunks);
+router.get("/:canvasId/history", historyController.getCanvasHistory);
+router.get("/:canvasId/chunks", canvasController.getChunks);
 router.get(
   "/current/participants/count",
   authMiddleware,

--- a/backend/src/modules/history/history.controller.ts
+++ b/backend/src/modules/history/history.controller.ts
@@ -1,0 +1,40 @@
+import type { Request, Response } from "express";
+import { historyService } from "./history.service";
+
+function parseCanvasId(value: unknown): number | null {
+  const rawValue = Array.isArray(value) ? value[0] : value;
+
+  if (typeof rawValue !== "string") {
+    return null;
+  }
+
+  const canvasId = Number(rawValue);
+
+  if (!Number.isInteger(canvasId) || canvasId <= 0) {
+    return null;
+  }
+
+  return canvasId;
+}
+
+export const historyController = {
+  async getCanvasHistory(req: Request, res: Response) {
+    const canvasId = parseCanvasId(req.params.canvasId);
+
+    if (!canvasId) {
+      return res.status(400).json({
+        message: "canvasId가 올바르지 않습니다.",
+      });
+    }
+
+    const history = await historyService.getCanvasHistory(canvasId);
+
+    if (!history) {
+      return res.status(404).json({
+        message: "캔버스를 찾을 수 없습니다.",
+      });
+    }
+
+    return res.json(history);
+  },
+};

--- a/backend/src/modules/history/history.service.ts
+++ b/backend/src/modules/history/history.service.ts
@@ -1,0 +1,237 @@
+import { AppDataSource } from "../../database/data-source";
+import { Canvas } from "../../entities/canvas.entity";
+import { RoundSnapshot } from "../../entities/round-snapshot.entity";
+import { VoteRound } from "../../entities/vote-round.entity";
+
+const canvasRepository = AppDataSource.getRepository(Canvas);
+const voteRoundRepository = AppDataSource.getRepository(VoteRound);
+const roundSnapshotRepository = AppDataSource.getRepository(RoundSnapshot);
+
+function toRecord(value: unknown): Record<string, unknown> {
+  if (value && typeof value === "object") {
+    return value as Record<string, unknown>;
+  }
+
+  return {};
+}
+
+function getNumberField(value: unknown, key: string): number | null {
+  const fieldValue = toRecord(value)[key];
+
+  return typeof fieldValue === "number" ? fieldValue : null;
+}
+
+function getStringField(value: unknown, key: string): string | null {
+  const fieldValue = toRecord(value)[key];
+
+  return typeof fieldValue === "string" ? fieldValue : null;
+}
+
+function getDateStringField(value: unknown, key: string): string | null {
+  const fieldValue = toRecord(value)[key];
+
+  if (fieldValue instanceof Date) {
+    return fieldValue.toISOString();
+  }
+
+  return typeof fieldValue === "string" ? fieldValue : null;
+}
+
+function getEntityId(value: unknown): number | null {
+  return getNumberField(value, "id");
+}
+
+function getRelatedEntityId(value: unknown, key: string): number | null {
+  return getEntityId(toRecord(value)[key]);
+}
+
+function getRoundSnapshotKey(snapshot: RoundSnapshot): string | null {
+  const roundId =
+    getNumberField(snapshot, "roundId") ??
+    getRelatedEntityId(snapshot, "round");
+
+  if (roundId) {
+    return `round:${roundId}`;
+  }
+
+  const roundNumber = getNumberField(snapshot, "roundNumber");
+
+  if (roundNumber) {
+    return `number:${roundNumber}`;
+  }
+
+  return null;
+}
+
+function getRoundKey(round: VoteRound): string {
+  const roundId = getEntityId(round);
+
+  if (roundId) {
+    return `round:${roundId}`;
+  }
+
+  return `number:${getNumberField(round, "roundNumber") ?? 0}`;
+}
+
+function getRoundFallbackKey(round: VoteRound): string {
+  return `number:${getNumberField(round, "roundNumber") ?? 0}`;
+}
+
+function serializeSnapshot(snapshot: RoundSnapshot | null) {
+  if (!snapshot) {
+    return null;
+  }
+
+  const imageUrl =
+    getStringField(snapshot, "imageUrl") ??
+    getStringField(snapshot, "snapshotUrl") ??
+    getStringField(snapshot, "publicUrl") ??
+    getStringField(snapshot, "url") ??
+    getStringField(snapshot, "relativePath");
+
+  return {
+    id: getEntityId(snapshot),
+    roundId:
+      getNumberField(snapshot, "roundId") ??
+      getRelatedEntityId(snapshot, "round"),
+    roundNumber: getNumberField(snapshot, "roundNumber"),
+    imageUrl,
+    snapshotUrl: imageUrl,
+    createdAt:
+      getDateStringField(snapshot, "createdAt") ??
+      getDateStringField(snapshot, "capturedAt") ??
+      new Date().toISOString(),
+  };
+}
+
+function serializeRoundSummary(
+  round: VoteRound,
+  snapshot: RoundSnapshot | null,
+) {
+  const roundId = getEntityId(round) ?? 0;
+  const roundNumber = getNumberField(round, "roundNumber") ?? 0;
+  const startedAt = getDateStringField(round, "startedAt");
+  const endedAt = getDateStringField(round, "endedAt");
+
+  return {
+    roundId,
+    roundNumber,
+    startedAt,
+    endedAt,
+    phaseStartedAt: startedAt,
+    phaseEndedAt: endedAt,
+    snapshot: serializeSnapshot(snapshot),
+    totalVotes: getNumberField(round, "totalVotes") ?? 0,
+    winnerColor: getStringField(round, "winnerColor"),
+    colorStats: toRecord(round).colorStats ?? [],
+  };
+}
+function serializeRoundSummaryFromSnapshot(snapshot: RoundSnapshot) {
+  const roundId =
+    getNumberField(snapshot, "roundId") ??
+    getRelatedEntityId(snapshot, "round") ??
+    getEntityId(snapshot) ??
+    0;
+  const roundNumber = getNumberField(snapshot, "roundNumber") ?? 0;
+  const createdAt =
+    getDateStringField(snapshot, "createdAt") ??
+    getDateStringField(snapshot, "capturedAt") ??
+    new Date().toISOString();
+
+  return {
+    roundId,
+    roundNumber,
+    startedAt: null,
+    endedAt: createdAt,
+    phaseStartedAt: null,
+    phaseEndedAt: createdAt,
+    snapshot: serializeSnapshot(snapshot),
+    totalVotes: 0,
+    winnerColor: null,
+    colorStats: [],
+  };
+}
+
+function serializeGameSummary(canvas: Canvas, rounds: VoteRound[]) {
+  const endedAt = getDateStringField(canvas, "endedAt");
+
+  return {
+    canvasId: getEntityId(canvas) ?? 0,
+    startedAt: getDateStringField(canvas, "startedAt"),
+    endedAt,
+    totalRounds:
+      getNumberField(canvas, "totalRounds") ??
+      getNumberField(canvas, "currentRoundNumber") ??
+      rounds.length,
+    roundCount: rounds.length,
+  };
+}
+
+export const historyService = {
+  async getCanvasHistory(canvasId: number) {
+    const canvas = await canvasRepository.findOne({
+      where: { id: canvasId },
+    });
+
+    if (!canvas) {
+      return null;
+    }
+
+    const rounds = await voteRoundRepository.find({
+      where: {
+        canvas: { id: canvasId },
+      },
+      order: {
+        roundNumber: "DESC",
+      },
+    });
+
+    const snapshots = await roundSnapshotRepository.find({
+      where: {
+        canvas: { id: canvasId },
+      },
+      order: {
+        roundNumber: "DESC",
+      },
+    });
+
+    const snapshotMap = new Map<string, RoundSnapshot>();
+
+    for (const snapshot of snapshots) {
+      const key = getRoundSnapshotKey(snapshot);
+
+      if (key) {
+        snapshotMap.set(key, snapshot);
+      }
+    }
+
+    const roundMap = new Map<string, VoteRound>();
+
+    for (const round of rounds) {
+      roundMap.set(getRoundKey(round), round);
+      roundMap.set(getRoundFallbackKey(round), round);
+    }
+
+    const historyRounds = snapshots.map((snapshot) => {
+      const snapshotKey = getRoundSnapshotKey(snapshot);
+      const fallbackKey = `number:${getNumberField(snapshot, "roundNumber") ?? 0}`;
+      const round =
+        (snapshotKey ? roundMap.get(snapshotKey) : null) ??
+        roundMap.get(fallbackKey) ??
+        null;
+
+      if (!round) {
+        return serializeRoundSummaryFromSnapshot(snapshot);
+      }
+
+      return serializeRoundSummary(round, snapshot);
+    });
+
+    return {
+      rounds: historyRounds,
+      gameSummary: getDateStringField(canvas, "endedAt")
+        ? serializeGameSummary(canvas, rounds)
+        : null,
+    };
+  },
+};

--- a/frontend/src/features/gameplay/canvas/components/CanvasStage.tsx
+++ b/frontend/src/features/gameplay/canvas/components/CanvasStage.tsx
@@ -32,7 +32,17 @@ export default function CanvasStage({
       onMouseMove={onMouseMove}
       onMouseUp={onMouseUp}
       onMouseLeave={onMouseLeave}
-      onWheel={onWheel}
+      onWheel={(event) => {
+        console.log("[canvas-stage:wheel]", {
+          deltaY: event.deltaY,
+          clientX: event.clientX,
+          clientY: event.clientY,
+          target: event.target,
+          currentTarget: event.currentTarget,
+        });
+
+        onWheel(event);
+      }}
     >
       {overlay && <div className="absolute left-4 top-4 z-10">{overlay}</div>}
 

--- a/frontend/src/features/gameplay/canvas/components/CanvasSurface.tsx
+++ b/frontend/src/features/gameplay/canvas/components/CanvasSurface.tsx
@@ -1,9 +1,10 @@
-import type { RefObject } from "react";
+import type { Ref } from "react";
+
 import { getGameConfig } from "@/shared/config/game-config";
 
 interface CanvasSurfaceProps {
-  paintCanvasRef: RefObject<HTMLCanvasElement | null>;
-  canvasRef: RefObject<HTMLCanvasElement | null>;
+  paintCanvasRef: Ref<HTMLCanvasElement>;
+  canvasRef: Ref<HTMLCanvasElement>;
   backgroundImageUrl: string | null;
   gridX: number;
   gridY: number;

--- a/frontend/src/features/gameplay/canvas/hooks/useCanvasRenderer.ts
+++ b/frontend/src/features/gameplay/canvas/hooks/useCanvasRenderer.ts
@@ -2,8 +2,6 @@ import { useEffect, type RefObject } from "react";
 import { renderOverlayLayer, renderPaintLayer } from "../model/canvas.render";
 import type { Cell, VisibleCellBounds } from "../model/canvas.types";
 
-const DEBUG_CANVAS_RENDERER = true;
-
 interface UseCanvasRendererParams {
   paintCanvasRef: RefObject<HTMLCanvasElement | null>;
   canvasRef: RefObject<HTMLCanvasElement | null>;

--- a/frontend/src/features/gameplay/canvas/hooks/useCanvasRenderer.ts
+++ b/frontend/src/features/gameplay/canvas/hooks/useCanvasRenderer.ts
@@ -2,6 +2,8 @@ import { useEffect, type RefObject } from "react";
 import { renderOverlayLayer, renderPaintLayer } from "../model/canvas.render";
 import type { Cell, VisibleCellBounds } from "../model/canvas.types";
 
+const DEBUG_CANVAS_RENDERER = true;
+
 interface UseCanvasRendererParams {
   paintCanvasRef: RefObject<HTMLCanvasElement | null>;
   canvasRef: RefObject<HTMLCanvasElement | null>;
@@ -39,7 +41,7 @@ export function useCanvasRenderer({
     const paintCanvas = paintCanvasRef.current;
     const paintCtx = paintCanvas?.getContext("2d");
 
-    if (!paintCtx) {
+    if (!paintCanvas || !paintCtx) {
       return;
     }
 
@@ -69,7 +71,7 @@ export function useCanvasRenderer({
     const overlayCanvas = canvasRef.current;
     const overlayCtx = overlayCanvas?.getContext("2d");
 
-    if (!overlayCtx) {
+    if (!overlayCanvas || !overlayCtx) {
       return;
     }
 

--- a/frontend/src/features/gameplay/history/api/history.api.ts
+++ b/frontend/src/features/gameplay/history/api/history.api.ts
@@ -1,0 +1,9 @@
+import api from "@/shared/api/client";
+import type { CanvasHistoryResponse } from "../model/history.types";
+
+export const historyApi = {
+  getCanvasHistory: (canvasId: number, signal?: AbortSignal) =>
+    api.get<CanvasHistoryResponse>(`/canvas/${canvasId}/history`, {
+      signal,
+    }),
+};

--- a/frontend/src/features/gameplay/history/components/GameHistoryPanel.tsx
+++ b/frontend/src/features/gameplay/history/components/GameHistoryPanel.tsx
@@ -1,56 +1,137 @@
-import IntroPanelButton from "@/features/gameplay/intro/components/IntroPanelButton";
-import { RoundPanelList } from "@/features/gameplay/round";
-import type { RoundSummaryData } from "@/features/gameplay/session/api/session.api";
+import type {
+  GameSummaryData,
+  RoundSummaryData,
+} from "@/features/gameplay/session/api/session.api";
+import type { GameHistoryItem } from "../model/history.types";
 
-interface GameHistoryPanelProps {
+interface Props {
+  historyItems: GameHistoryItem[];
+  historyLoading: boolean;
+  historyError: string | null;
   onOpenIntroGuide: () => void;
-  onOpenLatestRoundSummary: () => void;
-  latestRoundSummary: RoundSummaryData | null;
-  isLatestRoundSummaryEnabled: boolean;
+  onOpenRoundSummary: (summary: RoundSummaryData) => void;
+  onOpenGameSummary: (summary: GameSummaryData) => void;
+}
+function GameIntroCard({ onOpenIntroGuide }: { onOpenIntroGuide: () => void }) {
+  return (
+    <section className="rounded-2xl border border-blue-100 bg-gradient-to-br from-blue-50 to-white p-3 shadow-sm">
+      <div className="w-full text-center">
+        <p className="text-xs font-semibold uppercase tracking-[0.18em] text-blue-500">
+          Game Intro
+        </p>
+        <h2 className="mt-1 text-base font-bold text-gray-950">게임 인트로</h2>
+      </div>
+      <button
+        type="button"
+        onClick={onOpenIntroGuide}
+        className="mt-3 w-full rounded-xl bg-blue-600 px-3 py-2 text-sm font-semibold text-white transition hover:bg-blue-700"
+      >
+        인트로 다시 보기
+      </button>
+    </section>
+  );
+}
+
+function HistoryTimelineCard({
+  item,
+  onOpenRoundSummary,
+  onOpenGameSummary,
+}: {
+  item: GameHistoryItem;
+  onOpenRoundSummary: (summary: RoundSummaryData) => void;
+  onOpenGameSummary: (summary: GameSummaryData) => void;
+}) {
+  if (item.type === "game") {
+    return (
+      <button
+        type="button"
+        onClick={() => onOpenGameSummary(item.data)}
+        className="w-full rounded-xl border border-amber-200 bg-amber-50 p-3 text-center transition hover:border-amber-300 hover:bg-amber-100"
+      >
+        <div className="flex items-center justify-center gap-2">
+          <span className="rounded-full bg-amber-500 px-2 py-0.5 text-xs font-semibold text-white">
+            최종 결과
+          </span>
+        </div>
+
+        <p className="mt-2 text-sm font-semibold text-gray-950">
+          게임 결과 통계
+        </p>
+      </button>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={() => onOpenRoundSummary(item.data)}
+      className="w-full rounded-xl border border-gray-200 bg-white p-3 text-center transition hover:border-blue-300 hover:bg-blue-50"
+    >
+      <p className="mt-2 text-center text-sm font-semibold text-gray-950">
+        {item.roundNumber}라운드 결과
+      </p>
+    </button>
+  );
 }
 
 export default function GameHistoryPanel({
+  historyItems,
+  historyLoading,
+  historyError,
   onOpenIntroGuide,
-  onOpenLatestRoundSummary,
-  latestRoundSummary,
-  isLatestRoundSummaryEnabled,
-}: GameHistoryPanelProps) {
+  onOpenRoundSummary,
+  onOpenGameSummary,
+}: Props) {
   return (
-    <aside className="flex w-[256px] shrink-0 flex-col gap-3 border-r border-gray-200 bg-white px-4 py-5">
-      <div className="px-1">
-        <p className="text-xs font-semibold uppercase tracking-[0.08em] text-gray-400">
-          History
-        </p>
-        <p className="mt-1 text-lg font-bold text-gray-900">Game History</p>
-        <p className="mt-1 text-sm text-gray-500">
-          인트로와 최근 라운드 결과를 다시 확인할 수 있어요.
-        </p>
-      </div>
+    <aside className="flex h-full min-h-0 w-[260px] max-w-[260px] shrink-0 flex-col gap-3 overflow-hidden border-r border-gray-200 bg-white p-3">
+      <GameIntroCard onOpenIntroGuide={onOpenIntroGuide} />
 
-      <IntroPanelButton onClick={onOpenIntroGuide} />
+      <section className="min-h-0 flex-1 overflow-y-auto rounded-2xl border border-gray-200 bg-gray-50 p-3">
+        <div className="mb-3 flex items-start justify-between gap-3">
+          <div className="w-full text-center">
+            <h3 className="text-sm font-semibold text-gray-950">
+              결과 타임라인
+            </h3>
+          </div>
 
-      <RoundPanelList>
-        <button
-          type="button"
-          className="w-full rounded-2xl border border-gray-200 bg-white px-4 py-4 text-left shadow-sm transition hover:border-gray-300 hover:bg-gray-50 disabled:cursor-not-allowed disabled:border-gray-100 disabled:bg-gray-50 disabled:opacity-60"
-          onClick={onOpenLatestRoundSummary}
-          disabled={!isLatestRoundSummaryEnabled || !latestRoundSummary}
-        >
-          <p className="text-xs font-semibold uppercase tracking-[0.08em] text-gray-400">
-            Round
+          {historyItems.length > 0 && (
+            <span className="rounded-full bg-gray-900 px-2 py-0.5 text-xs font-semibold text-white">
+              {historyItems.length}
+            </span>
+          )}
+        </div>
+
+        {historyLoading && (
+          <p className="rounded-xl border border-dashed border-gray-300 bg-white p-3 text-sm text-gray-500">
+            히스토리를 불러오는 중입니다.
           </p>
-          <p className="mt-1 text-base font-bold text-gray-900">
-            {latestRoundSummary
-              ? `${latestRoundSummary.roundNumber} 라운드 결과`
-              : "최근 라운드 결과"}
+        )}
+
+        {!historyLoading && historyError && (
+          <p className="rounded-xl border border-red-200 bg-red-50 p-3 text-sm text-red-600">
+            {historyError}
           </p>
-          <p className="mt-1 text-sm text-gray-500">
-            {isLatestRoundSummaryEnabled && latestRoundSummary
-              ? "클릭하면 최근 라운드 결과 모달을 다시 확인할 수 있어요."
-              : "ROUND_RESULT 또는 ROUND_START_WAIT 상태에서만 열 수 있어요."}
+        )}
+
+        {!historyLoading && !historyError && historyItems.length === 0 && (
+          <p className="rounded-xl border border-dashed border-gray-300 bg-white p-3 text-sm text-gray-500">
+            아직 표시할 라운드 결과가 없습니다.
           </p>
-        </button>
-      </RoundPanelList>
+        )}
+
+        {!historyLoading && !historyError && historyItems.length > 0 && (
+          <div className="space-y-2">
+            {historyItems.map((item) => (
+              <HistoryTimelineCard
+                key={item.id}
+                item={item}
+                onOpenRoundSummary={onOpenRoundSummary}
+                onOpenGameSummary={onOpenGameSummary}
+              />
+            ))}
+          </div>
+        )}
+      </section>
     </aside>
   );
 }

--- a/frontend/src/features/gameplay/history/components/GameHistoryPanel.tsx
+++ b/frontend/src/features/gameplay/history/components/GameHistoryPanel.tsx
@@ -12,27 +12,8 @@ interface Props {
   onOpenRoundSummary: (summary: RoundSummaryData) => void;
   onOpenGameSummary: (summary: GameSummaryData) => void;
 }
-function GameIntroCard({ onOpenIntroGuide }: { onOpenIntroGuide: () => void }) {
-  return (
-    <section className="rounded-2xl border border-blue-100 bg-gradient-to-br from-blue-50 to-white p-3 shadow-sm">
-      <div className="w-full text-center">
-        <p className="text-xs font-semibold uppercase tracking-[0.18em] text-blue-500">
-          Game Intro
-        </p>
-        <h2 className="mt-1 text-base font-bold text-gray-950">게임 인트로</h2>
-      </div>
-      <button
-        type="button"
-        onClick={onOpenIntroGuide}
-        className="mt-3 w-full rounded-xl bg-blue-600 px-3 py-2 text-sm font-semibold text-white transition hover:bg-blue-700"
-      >
-        인트로 다시 보기
-      </button>
-    </section>
-  );
-}
 
-function HistoryTimelineCard({
+function HistoryTimelineButton({
   item,
   onOpenRoundSummary,
   onOpenGameSummary,
@@ -46,17 +27,9 @@ function HistoryTimelineCard({
       <button
         type="button"
         onClick={() => onOpenGameSummary(item.data)}
-        className="w-full rounded-xl border border-amber-200 bg-amber-50 p-3 text-center transition hover:border-amber-300 hover:bg-amber-100"
+        className="h-9 w-full rounded-lg border border-amber-200 bg-amber-50 text-xs font-bold text-amber-700 transition hover:border-amber-300 hover:bg-amber-100"
       >
-        <div className="flex items-center justify-center gap-2">
-          <span className="rounded-full bg-amber-500 px-2 py-0.5 text-xs font-semibold text-white">
-            최종 결과
-          </span>
-        </div>
-
-        <p className="mt-2 text-sm font-semibold text-gray-950">
-          게임 결과 통계
-        </p>
+        RESULT
       </button>
     );
   }
@@ -65,11 +38,9 @@ function HistoryTimelineCard({
     <button
       type="button"
       onClick={() => onOpenRoundSummary(item.data)}
-      className="w-full rounded-xl border border-gray-200 bg-white p-3 text-center transition hover:border-blue-300 hover:bg-blue-50"
+      className="h-9 w-full rounded-lg border border-gray-200 bg-white text-xs font-bold text-gray-800 transition hover:border-blue-300 hover:bg-blue-50 hover:text-blue-700"
     >
-      <p className="mt-2 text-center text-sm font-semibold text-gray-950">
-        {item.roundNumber}라운드 결과
-      </p>
+      {item.roundNumber}R
     </button>
   );
 }
@@ -83,46 +54,38 @@ export default function GameHistoryPanel({
   onOpenGameSummary,
 }: Props) {
   return (
-    <aside className="flex h-full min-h-0 w-[260px] max-w-[260px] shrink-0 flex-col gap-3 overflow-hidden border-r border-gray-200 bg-white p-3">
-      <GameIntroCard onOpenIntroGuide={onOpenIntroGuide} />
+    <aside className="flex h-full min-h-0 w-[88px] max-w-[88px] shrink-0 flex-col gap-2 overflow-hidden border-r border-gray-200 bg-white p-2">
+      <button
+        type="button"
+        onClick={onOpenIntroGuide}
+        className="h-9 w-full rounded-lg border border-blue-200 bg-blue-50 text-xs font-bold text-blue-700 transition hover:border-blue-300 hover:bg-blue-100"
+      >
+        INTRO
+      </button>
 
-      <section className="min-h-0 flex-1 overflow-y-auto rounded-2xl border border-gray-200 bg-gray-50 p-3">
-        <div className="mb-3 flex items-start justify-between gap-3">
-          <div className="w-full text-center">
-            <h3 className="text-sm font-semibold text-gray-950">
-              결과 타임라인
-            </h3>
-          </div>
-
-          {historyItems.length > 0 && (
-            <span className="rounded-full bg-gray-900 px-2 py-0.5 text-xs font-semibold text-white">
-              {historyItems.length}
-            </span>
-          )}
-        </div>
-
+      <div className="min-h-0 flex-1 overflow-y-auto">
         {historyLoading && (
-          <p className="rounded-xl border border-dashed border-gray-300 bg-white p-3 text-sm text-gray-500">
-            히스토리를 불러오는 중입니다.
-          </p>
+          <div className="rounded-lg border border-dashed border-gray-200 bg-gray-50 px-1 py-2 text-center text-[10px] font-medium text-gray-400">
+            LOAD
+          </div>
         )}
 
         {!historyLoading && historyError && (
-          <p className="rounded-xl border border-red-200 bg-red-50 p-3 text-sm text-red-600">
-            {historyError}
-          </p>
+          <div className="rounded-lg border border-red-200 bg-red-50 px-1 py-2 text-center text-[10px] font-medium text-red-500">
+            ERR
+          </div>
         )}
 
         {!historyLoading && !historyError && historyItems.length === 0 && (
-          <p className="rounded-xl border border-dashed border-gray-300 bg-white p-3 text-sm text-gray-500">
-            아직 표시할 라운드 결과가 없습니다.
-          </p>
+          <div className="rounded-lg border border-dashed border-gray-200 bg-gray-50 px-1 py-2 text-center text-[10px] font-medium text-gray-400">
+            EMPTY
+          </div>
         )}
 
         {!historyLoading && !historyError && historyItems.length > 0 && (
-          <div className="space-y-2">
+          <div className="flex flex-col gap-1.5">
             {historyItems.map((item) => (
-              <HistoryTimelineCard
+              <HistoryTimelineButton
                 key={item.id}
                 item={item}
                 onOpenRoundSummary={onOpenRoundSummary}
@@ -131,7 +94,7 @@ export default function GameHistoryPanel({
             ))}
           </div>
         )}
-      </section>
+      </div>
     </aside>
   );
 }

--- a/frontend/src/features/gameplay/history/components/GameHistoryPanel.tsx
+++ b/frontend/src/features/gameplay/history/components/GameHistoryPanel.tsx
@@ -27,7 +27,7 @@ function HistoryTimelineButton({
       <button
         type="button"
         onClick={() => onOpenGameSummary(item.data)}
-        className="h-9 w-full rounded-lg border border-amber-200 bg-amber-50 text-xs font-bold text-amber-700 transition hover:border-amber-300 hover:bg-amber-100"
+        className="h-9 w-full shrink-0 rounded-lg border border-amber-200 bg-amber-50 text-xs font-bold text-amber-700 transition hover:border-amber-300 hover:bg-amber-100"
       >
         RESULT
       </button>
@@ -38,7 +38,7 @@ function HistoryTimelineButton({
     <button
       type="button"
       onClick={() => onOpenRoundSummary(item.data)}
-      className="h-9 w-full rounded-lg border border-gray-200 bg-white text-xs font-bold text-gray-800 transition hover:border-blue-300 hover:bg-blue-50 hover:text-blue-700"
+      className="h-9 w-full shrink-0 rounded-lg border border-gray-200 bg-white text-xs font-bold text-gray-800 transition hover:border-blue-300 hover:bg-blue-50 hover:text-blue-700"
     >
       {item.roundNumber}R
     </button>
@@ -58,12 +58,12 @@ export default function GameHistoryPanel({
       <button
         type="button"
         onClick={onOpenIntroGuide}
-        className="h-9 w-full rounded-lg border border-blue-200 bg-blue-50 text-xs font-bold text-blue-700 transition hover:border-blue-300 hover:bg-blue-100"
+        className="h-9 w-full shrink-0 rounded-lg border border-blue-200 bg-blue-50 text-xs font-bold text-blue-700 transition hover:border-blue-300 hover:bg-blue-100"
       >
         INTRO
       </button>
 
-      <div className="min-h-0 flex-1 overflow-y-auto">
+      <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain pr-1">
         {historyLoading && (
           <div className="rounded-lg border border-dashed border-gray-200 bg-gray-50 px-1 py-2 text-center text-[10px] font-medium text-gray-400">
             LOAD
@@ -83,7 +83,7 @@ export default function GameHistoryPanel({
         )}
 
         {!historyLoading && !historyError && historyItems.length > 0 && (
-          <div className="flex flex-col gap-1.5">
+          <div className="flex min-h-0 flex-col gap-1.5 pb-1">
             {historyItems.map((item) => (
               <HistoryTimelineButton
                 key={item.id}

--- a/frontend/src/features/gameplay/history/hooks/useCanvasHistory.ts
+++ b/frontend/src/features/gameplay/history/hooks/useCanvasHistory.ts
@@ -1,0 +1,199 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import type {
+  GameSummaryData,
+  RoundSummaryData,
+} from "@/features/gameplay/session/api/session.api";
+import { historyApi } from "../api/history.api";
+import {
+  getGameHistoryItemId,
+  getRoundHistoryItemId,
+  type GameHistoryItem,
+} from "../model/history.types";
+
+function toRecord(value: unknown): Record<string, unknown> {
+  if (value && typeof value === "object") {
+    return value as Record<string, unknown>;
+  }
+
+  return {};
+}
+
+function getStringField(value: unknown, key: string): string | null {
+  const fieldValue = toRecord(value)[key];
+
+  return typeof fieldValue === "string" ? fieldValue : null;
+}
+
+function getObjectField(value: unknown, key: string): Record<string, unknown> {
+  return toRecord(toRecord(value)[key]);
+}
+
+function getRoundCreatedAt(summary: RoundSummaryData) {
+  const snapshot = getObjectField(summary, "snapshot");
+
+  return (
+    getStringField(snapshot, "createdAt") ??
+    getStringField(summary, "phaseEndedAt") ??
+    getStringField(summary, "endedAt") ??
+    new Date().toISOString()
+  );
+}
+
+function getGameCreatedAt(summary: GameSummaryData) {
+  return (
+    getStringField(summary, "endedAt") ??
+    getStringField(summary, "createdAt") ??
+    new Date().toISOString()
+  );
+}
+
+function sortHistoryItems(items: GameHistoryItem[]) {
+  return [...items].sort((a, b) => {
+    const createdAtDiff =
+      new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
+
+    if (createdAtDiff !== 0) {
+      return createdAtDiff;
+    }
+
+    if (a.type === "round" && b.type === "round") {
+      return b.roundNumber - a.roundNumber;
+    }
+
+    if (a.type === "game" && b.type !== "game") {
+      return -1;
+    }
+
+    if (a.type !== "game" && b.type === "game") {
+      return 1;
+    }
+
+    return b.id.localeCompare(a.id);
+  });
+}
+
+function toRoundHistoryItem(summary: RoundSummaryData): GameHistoryItem {
+  return {
+    type: "round",
+    id: getRoundHistoryItemId(summary.roundId),
+    createdAt: getRoundCreatedAt(summary),
+    roundNumber: summary.roundNumber,
+    data: summary,
+  };
+}
+
+function toGameHistoryItem(
+  canvasId: number,
+  summary: GameSummaryData,
+): GameHistoryItem {
+  const createdAt = getGameCreatedAt(summary);
+
+  return {
+    type: "game",
+    id: getGameHistoryItemId(canvasId, createdAt),
+    createdAt,
+    data: summary,
+  };
+}
+
+function upsertHistoryItem(
+  items: GameHistoryItem[],
+  nextItem: GameHistoryItem,
+) {
+  const filteredItems = items.filter((item) => item.id !== nextItem.id);
+  return sortHistoryItems([nextItem, ...filteredItems]);
+}
+
+export function useCanvasHistory(canvasId: number | null) {
+  const [historyItems, setHistoryItems] = useState<GameHistoryItem[]>([]);
+  const [historyLoading, setHistoryLoading] = useState(false);
+  const [historyError, setHistoryError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!canvasId) {
+      setHistoryItems([]);
+      setHistoryLoading(false);
+      setHistoryError(null);
+      return;
+    }
+
+    const abortController = new AbortController();
+
+    const loadHistory = async () => {
+      setHistoryLoading(true);
+      setHistoryError(null);
+
+      try {
+        const response = await historyApi.getCanvasHistory(
+          canvasId,
+          abortController.signal,
+        );
+
+        const items = [
+          ...response.data.rounds.map(toRoundHistoryItem),
+          ...(response.data.gameSummary
+            ? [toGameHistoryItem(canvasId, response.data.gameSummary)]
+            : []),
+        ];
+
+        setHistoryItems(sortHistoryItems(items));
+      } catch (error) {
+        if (abortController.signal.aborted) {
+          return;
+        }
+
+        setHistoryError(
+          error instanceof Error
+            ? error.message
+            : "히스토리를 불러오지 못했습니다.",
+        );
+      } finally {
+        if (!abortController.signal.aborted) {
+          setHistoryLoading(false);
+        }
+      }
+    };
+
+    void loadHistory();
+
+    return () => {
+      abortController.abort();
+    };
+  }, [canvasId]);
+
+  const addRoundHistoryItem = useCallback((summary: RoundSummaryData) => {
+    setHistoryItems((items) =>
+      upsertHistoryItem(items, toRoundHistoryItem(summary)),
+    );
+  }, []);
+
+  const addGameHistoryItem = useCallback(
+    (summary: GameSummaryData) => {
+      if (!canvasId) {
+        return;
+      }
+
+      setHistoryItems((items) =>
+        upsertHistoryItem(items, toGameHistoryItem(canvasId, summary)),
+      );
+    },
+    [canvasId],
+  );
+
+  return useMemo(
+    () => ({
+      historyItems,
+      historyLoading,
+      historyError,
+      addRoundHistoryItem,
+      addGameHistoryItem,
+    }),
+    [
+      historyError,
+      historyItems,
+      historyLoading,
+      addGameHistoryItem,
+      addRoundHistoryItem,
+    ],
+  );
+}

--- a/frontend/src/features/gameplay/history/index.ts
+++ b/frontend/src/features/gameplay/history/index.ts
@@ -1,1 +1,7 @@
 export { default as GameHistoryPanel } from "./components/GameHistoryPanel";
+export { historyApi } from "./api/history.api";
+export { useCanvasHistory } from "./hooks/useCanvasHistory";
+export type {
+  CanvasHistoryResponse,
+  GameHistoryItem,
+} from "./model/history.types";

--- a/frontend/src/features/gameplay/history/model/history.types.ts
+++ b/frontend/src/features/gameplay/history/model/history.types.ts
@@ -1,0 +1,35 @@
+import type {
+  GameSummaryData,
+  RoundSummaryData,
+} from "@/features/gameplay/session/api/session.api";
+
+export type GameHistoryItem =
+  | {
+      type: "round";
+      id: `round:${number}`;
+      createdAt: string;
+      roundNumber: number;
+      data: RoundSummaryData;
+    }
+  | {
+      type: "game";
+      id: `game:${number}:${string}`;
+      createdAt: string;
+      data: GameSummaryData;
+    };
+
+export interface CanvasHistoryResponse {
+  rounds: RoundSummaryData[];
+  gameSummary: GameSummaryData | null;
+}
+
+export function getRoundHistoryItemId(roundId: number): `round:${number}` {
+  return `round:${roundId}`;
+}
+
+export function getGameHistoryItemId(
+  canvasId: number,
+  endedAt: string | null,
+): `game:${number}:${string}` {
+  return `game:${canvasId}:${endedAt ?? "ended"}`;
+}

--- a/frontend/src/features/gameplay/round/components/RoundSummaryModal.tsx
+++ b/frontend/src/features/gameplay/round/components/RoundSummaryModal.tsx
@@ -10,6 +10,13 @@ interface RoundSummaryModalProps {
   onDragStart: (event: MouseEvent<HTMLDivElement>) => void;
 }
 
+function hasMostVotedCell(summary: RoundSummaryData) {
+  return (
+    typeof summary.mostVotedCellX === "number" &&
+    typeof summary.mostVotedCellY === "number"
+  );
+}
+
 function renderParticipantCopy(count: number) {
   if (count > 0) {
     return (
@@ -130,16 +137,14 @@ export default function RoundSummaryModal({
             </section>
 
             <section className="space-y-3 rounded-2xl border border-gray-100 bg-gray-50 px-5 py-4 text-sm leading-6 text-gray-700">
-              <p>
-                가장 인기 있었던 칸은{" "}
-                <span className="font-bold text-gray-900">
-                  {renderMostVotedCell(summary)}
-                </span>
-                {summary.mostVotedCellX !== null &&
-                summary.mostVotedCellY !== null
-                  ? " 이었어요."
-                  : ""}
-              </p>
+              {hasMostVotedCell(summary) ? (
+                <p>
+                  가장 인기 있었던 칸은 ({summary.mostVotedCellX},{" "}
+                  {summary.mostVotedCellY}) 이었어요.
+                </p>
+              ) : (
+                <p>가장 인기 있었던 칸은 없습니다.</p>
+              )}
               <p>
                 동점 추첨으로 결정된 칸은{" "}
                 <span className="font-bold text-gray-900">

--- a/frontend/src/pages/canvas/CanvasPage.tsx
+++ b/frontend/src/pages/canvas/CanvasPage.tsx
@@ -150,10 +150,7 @@ export default function CanvasPage() {
     roundSummaryOpen,
     roundSummaryPosition,
     handleRoundSummaryDragStart,
-    handleOpenLatestRoundSummary,
-    latestRoundSummary,
     latestRoundSnapshot,
-    isLatestRoundSummaryEnabled,
     historyItems,
     historyLoading,
     historyError,
@@ -187,7 +184,7 @@ export default function CanvasPage() {
   }
 
   return (
-    <div className="flex h-screen w-full bg-gray-50">
+    <div className="flex h-screen w-full overflow-hidden bg-gray-50">
       <GameHistoryPanel
         onOpenIntroGuide={handleOpenIntroGuide}
         historyItems={historyItems}

--- a/frontend/src/pages/canvas/CanvasPage.tsx
+++ b/frontend/src/pages/canvas/CanvasPage.tsx
@@ -5,9 +5,10 @@ import {
   CanvasSurface,
   PANEL_WIDTH,
 } from "@/features/gameplay/canvas";
-import { IntroGuideModal } from "@/features/gameplay/intro";
 import { GameHistoryPanel } from "@/features/gameplay/history";
+import { IntroGuideModal } from "@/features/gameplay/intro";
 import RoundSummaryModal from "@/features/gameplay/round/components/RoundSummaryModal";
+import type { GameSummaryData } from "@/features/gameplay/session/api/session.api";
 import {
   ErrorScreen,
   GameEndedScreen,
@@ -16,7 +17,6 @@ import {
 import { GAME_PHASE } from "@/features/gameplay/session/model/game-phase.types";
 import { VotePanel, VotePopup } from "@/features/gameplay/vote";
 import useCanvasPage from "./model/useCanvasPage";
-import type { GameSummaryData } from "@/features/gameplay/session/api/session.api";
 
 interface SummaryModalProps {
   title: string;
@@ -77,7 +77,7 @@ function GameSummaryModal({
 
 export default function CanvasPage() {
   const navigate = useNavigate();
-  const [introModalDismissed, setIntroModalDismissed] = useState(false); // 추가: INTRO 중 사용자가 닫은 상태 보관
+  const [introModalDismissed, setIntroModalDismissed] = useState(false);
 
   const handleSessionEnded = useCallback(() => {
     window.alert("세션이 종료되었습니다. 다시 로그인해 주세요.");
@@ -91,6 +91,7 @@ export default function CanvasPage() {
     },
     [navigate],
   );
+
   const {
     paintCanvasRef,
     canvasRef,
@@ -132,6 +133,8 @@ export default function CanvasPage() {
     gameSummaryModal,
     handleCloseRoundSummaryModal,
     handleCloseGameSummaryModal,
+    handleOpenRoundSummaryModal,
+    handleOpenGameSummaryModal,
     gridX,
     gridY,
     backgroundImageUrl,
@@ -151,6 +154,9 @@ export default function CanvasPage() {
     latestRoundSummary,
     latestRoundSnapshot,
     isLatestRoundSummaryEnabled,
+    historyItems,
+    historyLoading,
+    historyError,
   } = useCanvasPage({
     onSessionEnded: handleSessionEnded,
     onUnauthorized: handleUnauthorized,
@@ -184,9 +190,11 @@ export default function CanvasPage() {
     <div className="flex h-screen w-full bg-gray-50">
       <GameHistoryPanel
         onOpenIntroGuide={handleOpenIntroGuide}
-        onOpenLatestRoundSummary={handleOpenLatestRoundSummary}
-        latestRoundSummary={latestRoundSummary}
-        isLatestRoundSummaryEnabled={isLatestRoundSummaryEnabled}
+        historyItems={historyItems}
+        historyLoading={historyLoading}
+        historyError={historyError}
+        onOpenRoundSummary={handleOpenRoundSummaryModal}
+        onOpenGameSummary={handleOpenGameSummaryModal}
       />
 
       <CanvasStage
@@ -262,7 +270,7 @@ export default function CanvasPage() {
           backgroundImageUrl={backgroundImageUrl}
           gridX={gridX}
           gridY={gridY}
-          gameConfig={gameConfig!}
+          gameConfig={gameConfig}
           formattedGameEndTime={formattedGameEndTime}
           onClose={() => {
             setIntroModalDismissed(true);

--- a/frontend/src/pages/canvas/model/useCanvasPage.ts
+++ b/frontend/src/pages/canvas/model/useCanvasPage.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useChunkLoader } from "@/features/gameplay/canvas/hooks/useChunkLoader";
+import { useCanvasHistory } from "@/features/gameplay/history/hooks/useCanvasHistory";
 import { useVotePopup, useVoteState } from "@/features/gameplay/vote";
 import type {
   GameSummaryData,
@@ -140,6 +141,14 @@ export default function useCanvasPage({
     clearSelectedCell();
   }, [clearSelectedCell]);
 
+  const {
+    historyItems,
+    historyLoading,
+    historyError,
+    addRoundHistoryItem,
+    addGameHistoryItem,
+  } = useCanvasHistory(canvasId);
+
   const handleOpenRoundSummaryModal = useCallback(
     (summary: RoundSummaryData) => {
       setRoundSummaryModal(summary);
@@ -161,6 +170,22 @@ export default function useCanvasPage({
     setRoundSummaryOpen(false);
     setRoundSummaryPosition(getDefaultRoundSummaryModalPosition());
   }, []);
+
+  const handleReceiveRoundSummary = useCallback(
+    (summary: RoundSummaryData) => {
+      addRoundHistoryItem(summary);
+      handleOpenRoundSummaryModal(summary);
+    },
+    [addRoundHistoryItem, handleOpenRoundSummaryModal],
+  );
+
+  const handleReceiveGameSummary = useCallback(
+    (summary: GameSummaryData) => {
+      addGameHistoryItem(summary);
+      handleOpenGameSummaryModal(summary);
+    },
+    [addGameHistoryItem, handleOpenGameSummaryModal],
+  );
 
   const handleCloseGameSummaryModal = useCallback(() => {
     setGameSummaryModal(null);
@@ -204,8 +229,8 @@ export default function useCanvasPage({
     onBootstrapScene: applyBootstrapScene,
     onCanvasUpdated: handleCanvasUpdated,
     onCanvasBatchUpdated: handleCanvasBatchUpdatedForRoundResult,
-    onOpenRoundSummaryModal: handleOpenRoundSummaryModal,
-    onOpenGameSummaryModal: handleOpenGameSummaryModal,
+    onOpenRoundSummaryModal: handleReceiveRoundSummary,
+    onOpenGameSummaryModal: handleReceiveGameSummary,
     onRoundEndedCleanup: handleRoundEndedCleanup,
     onGameEndedCleanup: handleGameEndedCleanup,
     onSessionEnded,
@@ -287,6 +312,8 @@ export default function useCanvasPage({
     gameSummaryModal,
     handleCloseRoundSummaryModal,
     handleCloseGameSummaryModal,
+    handleOpenRoundSummaryModal,
+    handleOpenGameSummaryModal,
     gridX,
     gridY,
     backgroundImageUrl,
@@ -306,5 +333,8 @@ export default function useCanvasPage({
     latestRoundSummary: gameplay.roundSummary,
     latestRoundSnapshot: gameplay.latestRoundSnapshot,
     isLatestRoundSummaryEnabled: gameplay.canOpenLatestRoundSummary,
+    historyItems,
+    historyLoading,
+    historyError,
   };
 }

--- a/frontend/src/pages/canvas/model/useCanvasScene.ts
+++ b/frontend/src/pages/canvas/model/useCanvasScene.ts
@@ -47,6 +47,7 @@ function getWorldSize(gridX: number, gridY: number) {
 
 const ZOOM_SCALE = 1.1;
 const MAX_ZOOM = 4;
+const MAX_ZOOM_MULTIPLIER = 4;
 
 function getZoomBounds(
   container: HTMLDivElement,
@@ -68,7 +69,7 @@ function getZoomBounds(
 
   return {
     minZoom,
-    maxZoom: Math.max(MAX_ZOOM, minZoom),
+    maxZoom: Math.max(MAX_ZOOM, minZoom * MAX_ZOOM_MULTIPLIER),
   };
 }
 
@@ -161,9 +162,29 @@ export default function useCanvasScene({
   resetPreviewColor,
   openPopup,
 }: UseCanvasSceneParams) {
-  const paintCanvasRef = useRef<HTMLCanvasElement>(null);
-  const canvasRef = useRef<HTMLCanvasElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
+
+  const paintCanvasElementRef = useRef<HTMLCanvasElement | null>(null);
+  const canvasElementRef = useRef<HTMLCanvasElement | null>(null);
+  const [canvasNodeVersion, setCanvasNodeVersion] = useState(0);
+
+  const paintCanvasRef = useCallback((node: HTMLCanvasElement | null) => {
+    if (paintCanvasElementRef.current === node) {
+      return;
+    }
+
+    paintCanvasElementRef.current = node;
+    setCanvasNodeVersion((prev) => prev + 1);
+  }, []);
+
+  const canvasRef = useCallback((node: HTMLCanvasElement | null) => {
+    if (canvasElementRef.current === node) {
+      return;
+    }
+
+    canvasElementRef.current = node;
+    setCanvasNodeVersion((prev) => prev + 1);
+  }, []);
 
   const selectedCellRef = useRef<Cell | null>(null);
   const zoomRef = useRef(1);
@@ -217,6 +238,11 @@ export default function useCanvasScene({
         const nextWidth = container.clientWidth;
         const nextHeight = container.clientHeight;
 
+        if (nextWidth <= 0 || nextHeight <= 0) {
+          frameId = requestAnimationFrame(syncViewportSize);
+          return;
+        }
+
         setViewportSize((prev) => {
           if (prev.width === nextWidth && prev.height === nextHeight) {
             return prev;
@@ -230,6 +256,7 @@ export default function useCanvasScene({
       };
 
       syncViewportSize();
+      frameId = requestAnimationFrame(syncViewportSize);
 
       observer = new ResizeObserver(() => {
         syncViewportSize();
@@ -272,9 +299,8 @@ export default function useCanvasScene({
 
   useLayoutEffect(() => {
     const container = containerRef.current;
-    const paintCanvas = paintCanvasRef.current;
-    const canvas = canvasRef.current;
-
+    const paintCanvas = paintCanvasElementRef.current;
+    const canvas = canvasElementRef.current;
     if (
       !container ||
       !paintCanvas ||
@@ -286,6 +312,18 @@ export default function useCanvasScene({
       if (canvasReady) {
         setCanvasReady(false);
       }
+
+      if (!canvasId || gridX === 0 || gridY === 0) {
+        sceneKeyRef.current = null;
+        pendingZoomAdjustmentRef.current = null;
+        initialZoomRef.current = 1;
+        zoomRef.current = 1;
+        cameraXRef.current = 0;
+        cameraYRef.current = 0;
+        selectedCellRef.current = null;
+        setSelectedCell(null);
+      }
+
       return;
     }
 
@@ -311,15 +349,23 @@ export default function useCanvasScene({
     }
 
     const sceneKey = `${canvasId}:${gridX}:${gridY}`;
+
     if (sceneKeyRef.current !== sceneKey) {
       const { worldWidth, worldHeight } = getWorldSize(gridX, gridY);
       const bounds = getZoomBounds(container, worldWidth, worldHeight);
 
       sceneKeyRef.current = sceneKey;
+      pendingZoomAdjustmentRef.current = null;
       initialZoomRef.current = bounds.minZoom;
+      zoomRef.current = bounds.minZoom;
+      cameraXRef.current = 0;
+      cameraYRef.current = 0;
+      selectedCellRef.current = null;
+
       setZoom(bounds.minZoom);
       setCameraX(0);
       setCameraY(0);
+      setSelectedCell(null);
     }
 
     if (!canvasReady) {
@@ -330,6 +376,7 @@ export default function useCanvasScene({
     gridX,
     gridY,
     canvasReady,
+    canvasNodeVersion,
     viewportSize.width,
     viewportSize.height,
   ]);
@@ -378,8 +425,8 @@ export default function useCanvasScene({
   });
 
   useCanvasRenderer({
-    paintCanvasRef,
-    canvasRef,
+    paintCanvasRef: paintCanvasElementRef,
+    canvasRef: canvasElementRef,
     canvasReady,
     cells,
     selectedCell,
@@ -423,7 +470,7 @@ export default function useCanvasScene({
 
   const { handleMouseDown, handleMouseMove, handleMouseUp, handleMouseLeave } =
     useCanvasInteraction({
-      canvasRef,
+      canvasRef: canvasElementRef,
       cells,
       gridX,
       gridY,
@@ -500,10 +547,11 @@ export default function useCanvasScene({
         };
 
         zoomRef.current = nextZoom;
+
         return nextZoom;
       });
     },
-    [canvasReady, gridX, gridY],
+    [canvasId, canvasReady, gridX, gridY, zoom],
   );
 
   const handleCanvasUpdated = useCallback(


### PR DESCRIPTION
## 관련 이슈
- Close #234 

## 개요

- 히스토리 패널을 좁은 타임라인형 UI로 개선했습니다.
- 게임 인트로, 라운드 결과, 최종 결과 진입 버튼을 간결한 타임라인 버튼 형태로 정리했습니다.
- 캔버스 초기 렌더링 시 canvas ref가 붙기 전에 renderer가 먼저 동작하던 문제를 안정화했습니다.
- `canvasReady`와 실제 canvas DOM attach 타이밍이 어긋나면서 새로고침마다 미니맵 viewport/zoom 동작이 달라지던 문제를 개선했습니다.


## 수정

- `GameHistoryPanel` 레이아웃을 88px 폭의 타임라인 패널로 변경
- 라운드/게임 결과 항목을 버튼 기반 타임라인 UI로 단순화
- canvas ref를 callback ref 기반으로 전환하여 DOM attach/detach 시점을 상태로 감지
- canvas node 변경 시 layout effect가 다시 실행되도록 `canvasNodeVersion` 추가
- renderer와 interaction hook에는 실제 canvas element ref를 전달하도록 정리