### PR TITLE
fix : 남은 투표권 숫자 표기 적용

### DIFF
--- a/frontend/src/features/gameplay/vote/components/VotePanel.tsx
+++ b/frontend/src/features/gameplay/vote/components/VotePanel.tsx
@@ -70,8 +70,6 @@ export default function VotePanel({
     MAX_VOTE_PANEL_ENTRIES,
   );
   const maxCount = voteEntries[0]?.totalCount ?? 1;
-  const usedCount =
-    remaining !== null ? Math.max(0, votesPerRound - remaining) : 0;
   const slots = Array.from({ length: MAX_VOTE_PANEL_ENTRIES }, (_, index) => {
     return voteEntries[index] ?? null;
   });
@@ -97,20 +95,13 @@ export default function VotePanel({
 
       <div className="flex min-h-2 items-center justify-between gap-3">
         <p className="text-sm font-medium">남은 투표권</p>
-        <div className="flex gap-1">
-          {isVotingPhase && remaining !== null ? (
-            Array.from({ length: votesPerRound }).map((_, index) => (
-              <span
-                key={index}
-                className={`text-lg ${index < usedCount ? "text-gray-300" : "text-blue-500"}`}
-              >
-                ●
-              </span>
-            ))
-          ) : (
-            <span className="text-sm text-gray-400">-</span>
-          )}
-        </div>
+        {isVotingPhase && remaining !== null ? (
+          <span className="text-sm font-bold text-blue-600">
+            {remaining}/{votesPerRound}
+          </span>
+        ) : (
+          <span className="text-sm text-gray-400">-</span>
+        )}
       </div>
       <MiniMap
         cells={minimapCells}


### PR DESCRIPTION
## 관련 이슈
- Close #243 

## 개요
게임 화면의 남은 투표권 표시 방식을 아이콘 나열 방식에서 숫자 표기 방식으로 변경했습니다.

기존에는 남은 투표권을 `●` 아이콘으로 표시해 정확한 수량을 한눈에 파악하기 어려웠습니다. 이제 `남은 수/전체 수` 형식으로 표시해 현재 사용 가능한 투표권 수를 더 명확하게 확인할 수 있습니다.

## 작업 내용
- 남은 투표권 `●` 아이콘 나열 UI 제거
- 남은 투표권을 `{remaining}/{votesPerRound}` 형식으로 표시
- 숫자 표기로 변경하면서 불필요해진 `usedCount` 계산 제거
- 투표 가능 상태가 아니거나 `remaining` 값이 없는 경우 기존처럼 `-` 표시 유지

## 확인 사항
- 투표 가능 상태에서 남은 투표권이 숫자로 표시됨
- 투표 후 남은 투표권 숫자가 갱신됨
- 투표 가능 상태가 아니면 `-`가 표시됨
- 기존 투표 패널 레이아웃이 깨지지 않음