### PR TITLE
fix : 게임 시작 전 예상 종료 시간 표시

### DIFF
--- a/frontend/src/features/gameplay/session/hooks/useGameplayBootstrap.ts
+++ b/frontend/src/features/gameplay/session/hooks/useGameplayBootstrap.ts
@@ -47,6 +47,163 @@ function getPhaseDurationSeconds(
   );
 }
 
+function addSeconds(date: Date, seconds: number): Date {
+  return new Date(date.getTime() + Math.max(0, seconds) * 1000);
+}
+
+function parseDate(value: string | null): Date | null {
+  if (!value) {
+    return null;
+  }
+
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+function getPhaseEndDate(
+  phaseStartedAt: string | null,
+  phaseEndsAt: string | null,
+  fallbackDurationSec: number,
+): Date | null {
+  const explicitPhaseEnd = parseDate(phaseEndsAt);
+
+  if (explicitPhaseEnd) {
+    return explicitPhaseEnd;
+  }
+
+  const phaseStart = parseDate(phaseStartedAt);
+
+  if (!phaseStart) {
+    return null;
+  }
+
+  return addSeconds(phaseStart, fallbackDurationSec);
+}
+
+function getEstimatedGameEndFromRoundStart(
+  roundStartedAt: Date,
+  currentRoundNumber: number,
+  totalRounds: number,
+  roundDurationSec: number,
+  roundResultDelaySec: number,
+): Date | null {
+  const remainingRoundsIncludingCurrent =
+    totalRounds - currentRoundNumber + 1;
+
+  if (remainingRoundsIncludingCurrent <= 0) {
+    return null;
+  }
+
+  const remainingSeconds =
+    remainingRoundsIncludingCurrent * roundDurationSec +
+    Math.max(0, remainingRoundsIncludingCurrent - 1) * roundResultDelaySec;
+
+  return addSeconds(roundStartedAt, remainingSeconds);
+}
+
+function getEstimatedGameEndAt({
+  phase,
+  phaseStartedAt,
+  phaseEndsAt,
+  currentRoundNumber,
+  totalRounds,
+  introPhaseSec,
+  roundStartWaitSec,
+  roundDurationSec,
+  roundResultDelaySec,
+}: {
+  phase: string;
+  phaseStartedAt: string | null;
+  phaseEndsAt: string | null;
+  currentRoundNumber: number | null;
+  totalRounds: number;
+  introPhaseSec: number;
+  roundStartWaitSec: number;
+  roundDurationSec: number;
+  roundResultDelaySec: number;
+}): Date | null {
+  const safeRoundNumber = Math.max(1, currentRoundNumber ?? 1);
+
+  switch (phase) {
+    case GAME_PHASE.INTRO: {
+      const introEndsAt = getPhaseEndDate(
+        phaseStartedAt,
+        phaseEndsAt,
+        introPhaseSec,
+      );
+
+      if (!introEndsAt) {
+        return null;
+      }
+
+      return getEstimatedGameEndFromRoundStart(
+        addSeconds(introEndsAt, roundStartWaitSec),
+        1,
+        totalRounds,
+        roundDurationSec,
+        roundResultDelaySec,
+      );
+    }
+
+    case GAME_PHASE.ROUND_START_WAIT: {
+      const roundStartedAt = getPhaseEndDate(
+        phaseStartedAt,
+        phaseEndsAt,
+        roundStartWaitSec,
+      );
+
+      if (!roundStartedAt) {
+        return null;
+      }
+
+      return getEstimatedGameEndFromRoundStart(
+        roundStartedAt,
+        safeRoundNumber,
+        totalRounds,
+        roundDurationSec,
+        roundResultDelaySec,
+      );
+    }
+
+    case GAME_PHASE.ROUND_ACTIVE: {
+      const roundStartedAt = parseDate(phaseStartedAt);
+
+      if (!roundStartedAt) {
+        return null;
+      }
+
+      return getEstimatedGameEndFromRoundStart(
+        roundStartedAt,
+        safeRoundNumber,
+        totalRounds,
+        roundDurationSec,
+        roundResultDelaySec,
+      );
+    }
+
+    case GAME_PHASE.ROUND_RESULT: {
+      const resultStartedAt = parseDate(phaseStartedAt);
+
+      if (!resultStartedAt) {
+        return null;
+      }
+
+      const remainingRounds = Math.max(0, totalRounds - safeRoundNumber);
+      const remainingSeconds =
+        remainingRounds * roundDurationSec +
+        remainingRounds * roundResultDelaySec;
+
+      return addSeconds(resultStartedAt, remainingSeconds);
+    }
+
+    case GAME_PHASE.GAME_END:
+      return parseDate(phaseStartedAt);
+
+    default:
+      return null;
+  }
+}
+
 function getFallbackPhaseDuration(
   phase: string,
   phaseDurationSeconds: number | null,
@@ -127,6 +284,18 @@ export function useGameplayBootstrap() {
         phases.gameEndWaitSec,
       );
 
+    const estimatedGameEndAt = getEstimatedGameEndAt({
+      phase: canvas.phase,
+      phaseStartedAt: canvas.phaseStartedAt,
+      phaseEndsAt: canvas.phaseEndsAt,
+      currentRoundNumber: canvas.currentRoundNumber,
+      totalRounds: rules.totalRounds,
+      introPhaseSec: phases.introPhaseSec,
+      roundStartWaitSec: phases.roundStartWaitSec,
+      roundDurationSec: phases.roundDurationSec,
+      roundResultDelaySec: phases.roundResultDelaySec,
+    });
+
     const round: RoundInfoState = {
       phase: canvas.phase,
       roundId: roundState?.round?.id ?? null,
@@ -136,7 +305,9 @@ export function useGameplayBootstrap() {
       totalRounds: roundState?.round?.totalRounds ?? rules.totalRounds,
       formattedGameEndTime: roundState?.round
         ? formatClockTime(new Date(roundState.round.gameEndAt))
-        : null,
+        : estimatedGameEndAt
+          ? formatClockTime(estimatedGameEndAt)
+          : null,
       remainingSeconds: resolvedRemainingSeconds,
       formattedRemainingTime:
         resolvedRemainingSeconds !== null


### PR DESCRIPTION
## 관련 이슈
- Close #245 

## 개요
게임 시작 전 라운드 인포 패널과 인트로 가이드 모달에서 게임 종료 시간이 `-`로 표시되던 문제를 수정했습니다.

기존에는 active round 정보가 있을 때만 서버의 `gameEndAt`을 사용해 종료 시간을 표시했기 때문에, `INTRO` 또는 `ROUND_START_WAIT` 단계에서는 종료 시간이 비어 있었습니다.

## 작업 내용
- active round가 있는 경우 기존처럼 서버의 `round.gameEndAt`을 우선 사용
- active round가 없는 경우 현재 canvas phase와 game config를 기반으로 예상 종료 시간 계산
- `INTRO`, `ROUND_START_WAIT`, `ROUND_ACTIVE`, `ROUND_RESULT`, `GAME_END` phase별 fallback 계산 추가
- 계산된 종료 시간을 기존과 동일한 `HH:mm` 포맷으로 표시

## 확인 사항
- 게임 시작 직후 라운드 인포 패널에 예상 종료 시간이 표시됨
- 인트로 가이드 모달에 예상 종료 시간이 표시됨
- active round가 있는 경우 기존 종료 시간 표시 유지
- phase별 fallback 계산이 정상 동작하는지 확인