### PR TITLE
fix : 게임 모달 ESC 닫기 지원

### DIFF
--- a/frontend/src/features/gameplay/intro/components/IntroGuideModal.tsx
+++ b/frontend/src/features/gameplay/intro/components/IntroGuideModal.tsx
@@ -52,6 +52,27 @@ export default function IntroGuideModal({
       return;
     }
 
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== "Escape") {
+        return;
+      }
+
+      event.preventDefault();
+      onClose();
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [onClose, open]);
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+
     const handleMouseMove = (event: MouseEvent) => {
       if (!isDraggingRef.current) {
         return;

--- a/frontend/src/features/gameplay/round/components/RoundSummaryModal.tsx
+++ b/frontend/src/features/gameplay/round/components/RoundSummaryModal.tsx
@@ -1,4 +1,4 @@
-import type { MouseEvent } from "react";
+import { useEffect, type MouseEvent } from "react";
 import type { RoundSummaryData } from "@/features/gameplay/session/api/session.api";
 
 interface RoundSummaryModalProps {
@@ -46,6 +46,27 @@ export default function RoundSummaryModal({
   onClose,
   onDragStart,
 }: RoundSummaryModalProps) {
+  useEffect(() => {
+    if (!open || !summary) {
+      return;
+    }
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== "Escape") {
+        return;
+      }
+
+      event.preventDefault();
+      onClose();
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [onClose, open, summary]);
+
   if (!open || !summary) {
     return null;
   }

--- a/frontend/src/features/gameplay/vote/components/VotePopup.tsx
+++ b/frontend/src/features/gameplay/vote/components/VotePopup.tsx
@@ -331,6 +331,12 @@ export default function VotePopup({
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        onClose();
+        return;
+      }
+
       if (event.code !== "Space") {
         return;
       }
@@ -357,7 +363,7 @@ export default function VotePopup({
     return () => {
       window.removeEventListener("keydown", handleKeyDown);
     };
-  }, [handleSubmit, isVoteDisabled]);
+  }, [handleSubmit, isVoteDisabled, onClose]);
 
   return (
     <div

--- a/frontend/src/pages/canvas/CanvasPage.tsx
+++ b/frontend/src/pages/canvas/CanvasPage.tsx
@@ -25,6 +25,23 @@ interface SummaryModalProps {
 }
 
 function SummaryModal({ title, onClose, children }: SummaryModalProps) {
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== "Escape") {
+        return;
+      }
+
+      event.preventDefault();
+      onClose();
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [onClose]);
+
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/45 px-4">
       <div className="w-full max-w-[560px] rounded-3xl border border-gray-200 bg-white/95 p-6 shadow-2xl backdrop-blur">


### PR DESCRIPTION
## 관련 이슈
- Close #247 

## 작업 내용
- 인트로 가이드 모달을 ESC 키로 닫을 수 있도록 수정
- 라운드 결과 모달을 ESC 키로 닫을 수 있도록 수정
- 게임 결과 모달을 ESC 키로 닫을 수 있도록 수정
- 셀 클릭 시 표시되는 색상 팔레트 팝업을 ESC 키로 닫을 수 있도록 수정
- 색상 팔레트 팝업의 기존 스페이스바 투표 동작 유지

## 변경 파일
- `frontend/src/features/gameplay/intro/components/IntroGuideModal.tsx`
- `frontend/src/features/gameplay/round/components/RoundSummaryModal.tsx`
- `frontend/src/features/gameplay/vote/components/VotePopup.tsx`
- `frontend/src/pages/canvas/CanvasPage.tsx`

## 확인 사항
- ESC 입력 시 각 모달/팝업이 닫히는지 확인
- 색상 팔레트 팝업에서 스페이스바 투표가 기존처럼 동작하는지 확인
- 모달이 닫힌 상태에서 ESC 입력으로 불필요한 동작이 발생하지 않는지 확인