### PR TITLE
feat : 게임 종료 통계 모달 구성

### DIFF
--- a/backend/src/modules/canvas/canvas.controller.ts
+++ b/backend/src/modules/canvas/canvas.controller.ts
@@ -6,11 +6,18 @@ import { Cell } from "../../entities/cell.entity";
 import { canvasService } from "./canvas.service";
 import { GameSummary } from "../../entities/game-summary.entity";
 import { summaryService } from "../summary/summary.service";
+import { roundSnapshotService } from "../history/round-snapshot.service";
 import type { GetCanvasChunksQuery } from "./dto/get-canvas-chunks.dto";
 
 interface CreateCanvasRequestBody {
   profileKey?: string;
 }
+
+type RoundVoteExtreme = {
+  roundId: number;
+  roundNumber: number;
+  voteCount: number;
+} | null;
 
 function serializeCanvas(canvas: Canvas) {
   return {
@@ -38,8 +45,26 @@ function serializeCell(cell: Cell) {
   };
 }
 
+function buildRoundSnapshotUrl(
+  req: Request,
+  canvasId: number,
+  roundId: number,
+): string {
+  const relativePath = roundSnapshotService.buildRoundSnapshotApiPath(
+    canvasId,
+    roundId,
+  );
+  const host = req.get("host");
+
+  return host ? `${req.protocol}://${host}${relativePath}` : relativePath;
+}
+
 // 게임 summary 응답 구조를 명시적으로 고정
-function serializeGameSummary(summary: GameSummary) {
+function serializeGameSummary(
+  summary: GameSummary,
+  snapshotUrl: string | null,
+  quietestRound: RoundVoteExtreme,
+) {
   return {
     id: summary.id,
     canvasId: summary.canvas.id,
@@ -68,8 +93,12 @@ function serializeGameSummary(summary: GameSummary) {
     hottestRoundId: summary.hottestRoundId,
     hottestRoundNumber: summary.hottestRoundNumber,
     hottestRoundVoteCount: summary.hottestRoundVoteCount,
+    quietestRoundId: quietestRound?.roundId ?? null,
+    quietestRoundNumber: quietestRound?.roundNumber ?? null,
+    quietestRoundVoteCount: quietestRound?.voteCount ?? 0,
     topVoters: summary.topVotersJson,
     participants: summary.participantsJson,
+    snapshotUrl,
     createdAt: summary.createdAt,
     updatedAt: summary.updatedAt,
   };
@@ -154,10 +183,20 @@ export const canvasController = {
         return res.status(400).json({ message: "존재하지 않는 캔버스입니다." });
       }
 
-      const summary = await summaryService.getGameSummary(canvasId);
+      const [summary, snapshot, quietestRound] = await Promise.all([
+        summaryService.getGameSummary(canvasId),
+        roundSnapshotService.findLatestRoundSnapshot(canvasId),
+        summaryService.getQuietestRound(canvasId),
+      ]);
 
       return res.json({
-        data: serializeGameSummary(summary),
+        data: serializeGameSummary(
+          summary,
+          snapshot?.round?.id
+            ? buildRoundSnapshotUrl(req, canvasId, snapshot.round.id)
+            : null,
+          quietestRound,
+        ),
       });
     } catch (err) {
       return res.status(400).json({ message: String(err) });

--- a/backend/src/modules/history/history.service.ts
+++ b/backend/src/modules/history/history.service.ts
@@ -1,11 +1,20 @@
 import { AppDataSource } from "../../database/data-source";
 import { Canvas } from "../../entities/canvas.entity";
+import { GameSummary } from "../../entities/game-summary.entity";
 import { RoundSnapshot } from "../../entities/round-snapshot.entity";
 import { VoteRound } from "../../entities/vote-round.entity";
+import { summaryService } from "../summary/summary.service";
 
 const canvasRepository = AppDataSource.getRepository(Canvas);
+const gameSummaryRepository = AppDataSource.getRepository(GameSummary);
 const voteRoundRepository = AppDataSource.getRepository(VoteRound);
 const roundSnapshotRepository = AppDataSource.getRepository(RoundSnapshot);
+
+type RoundVoteExtreme = {
+  roundId: number;
+  roundNumber: number;
+  voteCount: number;
+} | null;
 
 function toRecord(value: unknown): Record<string, unknown> {
   if (value && typeof value === "object") {
@@ -77,7 +86,43 @@ function getRoundFallbackKey(round: VoteRound): string {
   return `number:${getNumberField(round, "roundNumber") ?? 0}`;
 }
 
-function serializeSnapshot(snapshot: RoundSnapshot | null) {
+function getRoundForSnapshot(
+  snapshot: RoundSnapshot,
+  roundMap: Map<string, VoteRound>,
+): VoteRound | null {
+  const snapshotKey = getRoundSnapshotKey(snapshot);
+  const fallbackKey = `number:${getNumberField(snapshot, "roundNumber") ?? 0}`;
+
+  return (
+    (snapshotKey ? roundMap.get(snapshotKey) : null) ??
+    roundMap.get(fallbackKey) ??
+    null
+  );
+}
+
+function buildRoundSnapshotApiPath(canvasId: number, roundId: number): string {
+  return `/canvas/${canvasId}/rounds/${roundId}/snapshot`;
+}
+
+function getRoundSnapshotUrl(
+  canvasId: number,
+  snapshot: RoundSnapshot | null,
+  roundMap: Map<string, VoteRound>,
+): string | null {
+  if (!snapshot) {
+    return null;
+  }
+
+  const round = getRoundForSnapshot(snapshot, roundMap);
+  const roundId = round ? getEntityId(round) : null;
+
+  return roundId ? buildRoundSnapshotApiPath(canvasId, roundId) : null;
+}
+
+function serializeSnapshot(
+  snapshot: RoundSnapshot | null,
+  snapshotUrl: string | null,
+) {
   if (!snapshot) {
     return null;
   }
@@ -87,7 +132,8 @@ function serializeSnapshot(snapshot: RoundSnapshot | null) {
     getStringField(snapshot, "snapshotUrl") ??
     getStringField(snapshot, "publicUrl") ??
     getStringField(snapshot, "url") ??
-    getStringField(snapshot, "relativePath");
+    getStringField(snapshot, "relativePath") ??
+    snapshotUrl;
 
   return {
     id: getEntityId(snapshot),
@@ -107,6 +153,7 @@ function serializeSnapshot(snapshot: RoundSnapshot | null) {
 function serializeRoundSummary(
   round: VoteRound,
   snapshot: RoundSnapshot | null,
+  snapshotUrl: string | null,
 ) {
   const roundId = getEntityId(round) ?? 0;
   const roundNumber = getNumberField(round, "roundNumber") ?? 0;
@@ -120,13 +167,17 @@ function serializeRoundSummary(
     endedAt,
     phaseStartedAt: startedAt,
     phaseEndedAt: endedAt,
-    snapshot: serializeSnapshot(snapshot),
+    snapshot: serializeSnapshot(snapshot, snapshotUrl),
+    snapshotUrl,
     totalVotes: getNumberField(round, "totalVotes") ?? 0,
     winnerColor: getStringField(round, "winnerColor"),
     colorStats: toRecord(round).colorStats ?? [],
   };
 }
-function serializeRoundSummaryFromSnapshot(snapshot: RoundSnapshot) {
+function serializeRoundSummaryFromSnapshot(
+  snapshot: RoundSnapshot,
+  snapshotUrl: string | null,
+) {
   const roundId =
     getNumberField(snapshot, "roundId") ??
     getRelatedEntityId(snapshot, "round") ??
@@ -145,25 +196,72 @@ function serializeRoundSummaryFromSnapshot(snapshot: RoundSnapshot) {
     endedAt: createdAt,
     phaseStartedAt: null,
     phaseEndedAt: createdAt,
-    snapshot: serializeSnapshot(snapshot),
+    snapshot: serializeSnapshot(snapshot, snapshotUrl),
+    snapshotUrl,
     totalVotes: 0,
     winnerColor: null,
     colorStats: [],
   };
 }
 
-function serializeGameSummary(canvas: Canvas, rounds: VoteRound[]) {
+function serializeGameSummary(
+  canvas: Canvas,
+  rounds: VoteRound[],
+  summary: GameSummary | null,
+  snapshotUrl: string | null,
+  quietestRound: RoundVoteExtreme,
+) {
   const endedAt = getDateStringField(canvas, "endedAt");
+  const totalRounds =
+    summary?.totalRounds ??
+    getNumberField(canvas, "totalRounds") ??
+    getNumberField(canvas, "currentRoundNumber") ??
+    rounds.length;
 
   return {
     canvasId: getEntityId(canvas) ?? 0,
     startedAt: getDateStringField(canvas, "startedAt"),
     endedAt,
-    totalRounds:
-      getNumberField(canvas, "totalRounds") ??
-      getNumberField(canvas, "currentRoundNumber") ??
-      rounds.length,
+    totalRounds,
     roundCount: rounds.length,
+    participantCount: summary?.participantCount ?? 0,
+    issuedTicketCount: summary?.issuedTicketCount ?? 0,
+    totalVotes: summary?.totalVotes ?? 0,
+    ticketUsageRate: summary?.ticketUsageRate ?? "0.00",
+    totalCellCount: summary?.totalCellCount ?? 0,
+    paintedCellCount: summary?.paintedCellCount ?? 0,
+    emptyCellCount: summary?.emptyCellCount ?? 0,
+    canvasCompletionPercent: summary?.canvasCompletionPercent ?? "0.00",
+    mostVotedCellId: summary?.mostVotedCellId ?? null,
+    mostVotedCellX: summary?.mostVotedCellX ?? null,
+    mostVotedCellY: summary?.mostVotedCellY ?? null,
+    mostVotedCellVoteCount: summary?.mostVotedCellVoteCount ?? 0,
+    randomResolvedCellCount: summary?.randomResolvedCellCount ?? 0,
+    usedColorCount: summary?.usedColorCount ?? 0,
+    mostSelectedColor: summary?.mostSelectedColor ?? null,
+    mostSelectedColorVoteCount: summary?.mostSelectedColorVoteCount ?? 0,
+    mostPaintedColor: summary?.mostPaintedColor ?? null,
+    mostPaintedColorCellCount: summary?.mostPaintedColorCellCount ?? 0,
+    topVoterId: summary?.topVoterId ?? null,
+    topVoterName: summary?.topVoterName ?? null,
+    topVoterVoteCount: summary?.topVoterVoteCount ?? 0,
+    hottestRoundId: summary?.hottestRoundId ?? null,
+    hottestRoundNumber: summary?.hottestRoundNumber ?? null,
+    hottestRoundVoteCount: summary?.hottestRoundVoteCount ?? 0,
+    quietestRoundId: quietestRound?.roundId ?? null,
+    quietestRoundNumber: quietestRound?.roundNumber ?? null,
+    quietestRoundVoteCount: quietestRound?.voteCount ?? 0,
+    topVoters: summary?.topVotersJson ?? null,
+    participants: summary?.participantsJson ?? null,
+    snapshotUrl,
+    createdAt:
+      getDateStringField(summary, "createdAt") ??
+      endedAt ??
+      new Date().toISOString(),
+    updatedAt:
+      getDateStringField(summary, "updatedAt") ??
+      endedAt ??
+      new Date().toISOString(),
   };
 }
 
@@ -177,23 +275,29 @@ export const historyService = {
       return null;
     }
 
-    const rounds = await voteRoundRepository.find({
-      where: {
-        canvas: { id: canvasId },
-      },
-      order: {
-        roundNumber: "DESC",
-      },
-    });
-
-    const snapshots = await roundSnapshotRepository.find({
-      where: {
-        canvas: { id: canvasId },
-      },
-      order: {
-        roundNumber: "DESC",
-      },
-    });
+    const [rounds, snapshots, gameSummary, quietestRound] = await Promise.all([
+      voteRoundRepository.find({
+        where: {
+          canvas: { id: canvasId },
+        },
+        order: {
+          roundNumber: "DESC",
+        },
+      }),
+      roundSnapshotRepository.find({
+        where: {
+          canvas: { id: canvasId },
+        },
+        order: {
+          roundNumber: "DESC",
+        },
+      }),
+      gameSummaryRepository.findOne({
+        where: { canvas: { id: canvasId } },
+        relations: ["canvas"],
+      }),
+      summaryService.getQuietestRound(canvasId),
+    ]);
 
     const snapshotMap = new Map<string, RoundSnapshot>();
 
@@ -213,24 +317,31 @@ export const historyService = {
     }
 
     const historyRounds = snapshots.map((snapshot) => {
-      const snapshotKey = getRoundSnapshotKey(snapshot);
-      const fallbackKey = `number:${getNumberField(snapshot, "roundNumber") ?? 0}`;
-      const round =
-        (snapshotKey ? roundMap.get(snapshotKey) : null) ??
-        roundMap.get(fallbackKey) ??
-        null;
+      const round = getRoundForSnapshot(snapshot, roundMap);
+      const snapshotUrl = getRoundSnapshotUrl(canvasId, snapshot, roundMap);
 
       if (!round) {
-        return serializeRoundSummaryFromSnapshot(snapshot);
+        return serializeRoundSummaryFromSnapshot(snapshot, snapshotUrl);
       }
 
-      return serializeRoundSummary(round, snapshot);
+      return serializeRoundSummary(round, snapshot, snapshotUrl);
     });
+    const latestSnapshotUrl = getRoundSnapshotUrl(
+      canvasId,
+      snapshots[0] ?? null,
+      roundMap,
+    );
 
     return {
       rounds: historyRounds,
       gameSummary: getDateStringField(canvas, "endedAt")
-        ? serializeGameSummary(canvas, rounds)
+        ? serializeGameSummary(
+            canvas,
+            rounds,
+            gameSummary,
+            latestSnapshotUrl,
+            quietestRound,
+          )
         : null,
     };
   },

--- a/backend/src/modules/history/round-snapshot.service.ts
+++ b/backend/src/modules/history/round-snapshot.service.ts
@@ -45,6 +45,18 @@ export const roundSnapshotService = {
     });
   },
 
+  async findLatestRoundSnapshot(canvasId: number): Promise<RoundSnapshot | null> {
+    return roundSnapshotRepository.findOne({
+      where: {
+        canvas: { id: canvasId },
+      },
+      relations: ["round"],
+      order: {
+        roundNumber: "DESC",
+      },
+    });
+  },
+
   async getRoundSnapshot(
     canvasId: number,
     roundId: number,

--- a/backend/src/modules/summary/summary.service.ts
+++ b/backend/src/modules/summary/summary.service.ts
@@ -32,6 +32,18 @@ type TopVoterAggregate = {
   voteCount: number;
 };
 
+type RoundVoteExtreme = {
+  roundId: number;
+  roundNumber: number;
+  voteCount: number;
+} | null;
+
+type RoundVoteExtremeRow = {
+  roundId: number | string;
+  roundNumber: number | string;
+  voteCount: number | string;
+};
+
 function toPercent(numerator: number, denominator: number): string {
   if (denominator <= 0) {
     return "0.00";
@@ -147,6 +159,31 @@ export const summaryService = {
     }
 
     return summary;
+  },
+
+  async getQuietestRound(canvasId: number): Promise<RoundVoteExtreme> {
+    const row = await voteRoundRepository
+      .createQueryBuilder("round")
+      .leftJoin("round.votes", "vote")
+      .select("round.id", "roundId")
+      .addSelect("round.roundNumber", "roundNumber")
+      .addSelect("COUNT(vote.id)", "voteCount")
+      .where("round.canvas_id = :canvasId", { canvasId })
+      .groupBy("round.id")
+      .addGroupBy("round.roundNumber")
+      .orderBy("COUNT(vote.id)", "ASC")
+      .addOrderBy("round.roundNumber", "ASC")
+      .getRawOne<RoundVoteExtremeRow>();
+
+    if (!row) {
+      return null;
+    }
+
+    return {
+      roundId: Number(row.roundId),
+      roundNumber: Number(row.roundNumber),
+      voteCount: Number(row.voteCount),
+    };
   },
 
   async saveRoundSummary(

--- a/frontend/src/features/gameplay/canvas/components/MiniMap.tsx
+++ b/frontend/src/features/gameplay/canvas/components/MiniMap.tsx
@@ -124,6 +124,22 @@ export default function MiniMap({
     const cellWidth = canvas.width / Math.max(gridX, 1);
     const cellHeight = canvas.height / Math.max(gridY, 1);
 
+    if (!snapshotUrl && !backgroundImageUrl) {
+      for (const cell of cells) {
+        if (!cell.color) {
+          continue;
+        }
+
+        ctx.fillStyle = cell.color;
+        ctx.fillRect(
+          cell.x * cellWidth,
+          cell.y * cellHeight,
+          Math.max(cellWidth, 1),
+          Math.max(cellHeight, 1),
+        );
+      }
+    }
+
     if (viewport) {
       const viewportRect = getClampedViewportRect(
         viewport.left,
@@ -202,11 +218,14 @@ export default function MiniMap({
       ctx.restore();
     }
   }, [
+    backgroundImageUrl,
+    cells,
     gridX,
     gridY,
     minimapDimensions.width,
     minimapDimensions.height,
     selectedCell,
+    snapshotUrl,
     viewport,
   ]);
 

--- a/frontend/src/features/gameplay/round/components/RoundSummaryModal.tsx
+++ b/frontend/src/features/gameplay/round/components/RoundSummaryModal.tsx
@@ -30,14 +30,6 @@ function renderParticipantCopy(count: number) {
   return "참여자가 없어요.";
 }
 
-function renderMostVotedCell(summary: RoundSummaryData) {
-  if (summary.mostVotedCellX === null || summary.mostVotedCellY === null) {
-    return "없었어요";
-  }
-
-  return `(${summary.mostVotedCellX}, ${summary.mostVotedCellY})`;
-}
-
 export default function RoundSummaryModal({
   open,
   summary,

--- a/frontend/src/features/gameplay/session/api/session.api.ts
+++ b/frontend/src/features/gameplay/session/api/session.api.ts
@@ -109,8 +109,12 @@ export interface GameSummaryData {
   hottestRoundId: number | null;
   hottestRoundNumber: number | null;
   hottestRoundVoteCount: number;
+  quietestRoundId: number | null;
+  quietestRoundNumber: number | null;
+  quietestRoundVoteCount: number;
   topVoters: GameSummaryTopVoter[] | null;
   participants: GameSummaryParticipant[] | null;
+  snapshotUrl: string | null;
   createdAt: string;
   updatedAt: string;
 }

--- a/frontend/src/features/gameplay/session/components/GameSummaryModal.tsx
+++ b/frontend/src/features/gameplay/session/components/GameSummaryModal.tsx
@@ -1,0 +1,343 @@
+import { useEffect, type ReactNode } from "react";
+import type {
+  GameSummaryData,
+  GameSummaryParticipant,
+  GameSummaryTopVoter,
+} from "@/features/gameplay/session/api/session.api";
+
+interface GameSummaryModalProps {
+  summary: GameSummaryData;
+  snapshotUrl?: string | null;
+  onClose: () => void;
+}
+
+function formatNumber(value: number | null | undefined) {
+  return (value ?? 0).toLocaleString("ko-KR");
+}
+
+function formatPercentText(value: string | number | null | undefined) {
+  if (value === null || value === undefined || value === "") {
+    return "0%";
+  }
+
+  const numericValue = Number(value);
+
+  if (!Number.isFinite(numericValue)) {
+    return `${value}%`;
+  }
+
+  return `${numericValue.toLocaleString("ko-KR", {
+    maximumFractionDigits: 2,
+  })}%`;
+}
+
+function HighlightNumber({ children }: { children: ReactNode }) {
+  return <span className="text-[19px] font-bold text-red-500">{children}</span>;
+}
+
+function NumberText({ value }: { value: number | null | undefined }) {
+  return <HighlightNumber>{formatNumber(value)}</HighlightNumber>;
+}
+
+function PercentText({
+  value,
+}: {
+  value: string | number | null | undefined;
+}) {
+  return <HighlightNumber>{formatPercentText(value)}</HighlightNumber>;
+}
+
+function CellCoordinate({ summary }: { summary: GameSummaryData }) {
+  if (
+    typeof summary.mostVotedCellX !== "number" ||
+    typeof summary.mostVotedCellY !== "number"
+  ) {
+    return <span>-</span>;
+  }
+
+  return (
+    <>
+      (<NumberText value={summary.mostVotedCellX} />,{" "}
+      <NumberText value={summary.mostVotedCellY} />)
+    </>
+  );
+}
+
+function VoterName({
+  voter,
+}: {
+  voter: GameSummaryTopVoter | GameSummaryParticipant;
+}) {
+  return `${voter.name} #${formatNumber(voter.voterId)}`;
+}
+
+function VoterList({
+  voters,
+  limit = 6,
+}: {
+  voters: Array<GameSummaryTopVoter | GameSummaryParticipant> | null;
+  limit?: number;
+}) {
+  if (!voters || voters.length === 0) {
+    return <span>-</span>;
+  }
+
+  const visibleVoters = voters.slice(0, limit);
+
+  return (
+    <>
+      {visibleVoters.map((voter, index) => (
+        <span key={voter.voterId}>
+          {index > 0 ? ", " : ""}
+          <VoterName voter={voter} />
+        </span>
+      ))}
+      {voters.length > limit ? ", ..." : ""}
+    </>
+  );
+}
+
+function ColorStat({
+  color,
+  count,
+  suffix,
+}: {
+  color: string | null;
+  count: number;
+  suffix: string;
+}) {
+  if (!color) {
+    return <span>-</span>;
+  }
+
+  return (
+    <span className="inline-flex items-center gap-1.5 align-middle">
+      <span
+        className="h-3 w-3 rounded-full border border-gray-300"
+        style={{ backgroundColor: color }}
+      />
+      <span>
+        {color} <NumberText value={count} />
+        {suffix}
+      </span>
+    </span>
+  );
+}
+
+function StatLine({
+  label,
+  children,
+}: {
+  label: string;
+  children: ReactNode;
+}) {
+  return (
+    <p>
+      <span className="font-bold text-gray-900">{label}: </span>
+      {children}
+    </p>
+  );
+}
+
+export default function GameSummaryModal({
+  summary,
+  snapshotUrl,
+  onClose,
+}: GameSummaryModalProps) {
+  const finalSnapshotUrl = summary.snapshotUrl ?? snapshotUrl ?? null;
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== "Escape") {
+        return;
+      }
+
+      event.preventDefault();
+      onClose();
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [onClose]);
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/45 px-3 py-6"
+      onMouseDown={(event) => event.stopPropagation()}
+      onClick={(event) => event.stopPropagation()}
+    >
+      <div
+        className="pointer-events-auto flex max-h-[min(calc(100vh-80px),680px)] w-[720px] max-w-[calc(100vw-24px)] flex-col overflow-hidden rounded-3xl border border-gray-200 bg-white/95 shadow-2xl backdrop-blur"
+        onMouseDown={(event) => event.stopPropagation()}
+        onClick={(event) => event.stopPropagation()}
+      >
+        <div className="relative flex items-center justify-center border-b border-gray-100 px-5 py-4">
+          <p className="text-center text-base font-semibold text-gray-900">
+            게임 종료 통계
+          </p>
+
+          <button
+            type="button"
+            onClick={onClose}
+            className="absolute right-5 top-1/2 flex h-8 w-8 -translate-y-1/2 items-center justify-center rounded-full text-gray-400 hover:bg-gray-100 hover:text-gray-700"
+            aria-label="게임 종료 통계 닫기"
+          >
+            ×
+          </button>
+        </div>
+
+        <div className="min-h-0 flex-1 overflow-y-auto px-7 py-6">
+          <div className="space-y-5">
+            {finalSnapshotUrl ? (
+              <div className="mx-auto w-1/2 min-w-[180px] rounded-2xl border border-gray-200 bg-white p-3 shadow-sm">
+                <img
+                  src={finalSnapshotUrl}
+                  alt="최종 캔버스 스냅샷"
+                  className="block w-full rounded border border-gray-100 bg-transparent"
+                  style={{ imageRendering: "pixelated" }}
+                  draggable={false}
+                />
+              </div>
+            ) : (
+              <div className="mx-auto flex aspect-square w-1/2 min-w-[180px] items-center justify-center rounded-2xl border border-dashed border-gray-200 bg-gray-50 px-4 text-center text-sm font-medium text-gray-400">
+                최종 스냅샷이 없어요
+              </div>
+            )}
+
+            <section className="space-y-1 text-center">
+              <p className="text-sm text-gray-500">
+                모두가 함께 만든 결과를 정리했어요
+              </p>
+              <p className="text-2xl font-bold text-gray-900">
+                게임 종료 통계
+              </p>
+            </section>
+
+            <section className="space-y-4 text-[15px] leading-7 text-gray-700">
+              <div className="space-y-1 text-left">
+                <StatLine label="총 라운드 수">
+                  총 <NumberText value={summary.totalRounds} />라운드 진행
+                </StatLine>
+                <StatLine label="투표 인원 수">
+                  총 <NumberText value={summary.participantCount} />명이
+                  참여했어요
+                </StatLine>
+              </div>
+
+              <div className="space-y-1 text-left">
+                <StatLine label="투표권 사용률">
+                  <PercentText value={summary.ticketUsageRate} />
+                </StatLine>
+                <StatLine label="총 지급 투표권 수">
+                  총 <NumberText value={summary.issuedTicketCount} />개 투표권이
+                  발급됐어요
+                </StatLine>
+                <StatLine label="총 투표 수">
+                  총 <NumberText value={summary.totalVotes} />표가 제출됐어요
+                </StatLine>
+              </div>
+
+              <div className="space-y-1 text-left">
+                <StatLine label="완성도">
+                  캔버스 완성도{" "}
+                  <PercentText value={summary.canvasCompletionPercent} />
+                </StatLine>
+                <StatLine label="색칠된 칸 수">
+                  총 <NumberText value={summary.totalCellCount} />칸 중{" "}
+                  <NumberText value={summary.paintedCellCount} />칸 색칠
+                  되었어요
+                </StatLine>
+                <StatLine label="남은 빈 칸 수">
+                  아직 <NumberText value={summary.emptyCellCount} />칸이 비어
+                  있어요
+                </StatLine>
+              </div>
+
+              <div className="space-y-1 text-left">
+                <StatLine label="가장 인기 있었던 칸">
+                  <CellCoordinate summary={summary} />
+                  {summary.mostVotedCellVoteCount > 0
+                    ? (
+                        <>
+                          , <NumberText value={summary.mostVotedCellVoteCount} />
+                          표
+                        </>
+                      )
+                    : null}
+                </StatLine>
+                <StatLine label="랜덤 당선 칸 수">
+                  동점 추첨으로 결정된 칸은{" "}
+                  <NumberText value={summary.randomResolvedCellCount} />개였어요
+                </StatLine>
+              </div>
+
+              <div className="space-y-1 text-left">
+                <StatLine label="사용 색상 수">
+                  총 <NumberText value={summary.usedColorCount} />가지 색이
+                  사용됐어요
+                </StatLine>
+                <StatLine label="가장 많이 선택된 색">
+                  <ColorStat
+                    color={summary.mostSelectedColor}
+                    count={summary.mostSelectedColorVoteCount}
+                    suffix="표"
+                  />
+                </StatLine>
+                <StatLine label="캔버스에서 가장 많이 쓰인 색">
+                  <ColorStat
+                    color={summary.mostPaintedColor}
+                    count={summary.mostPaintedColorCellCount}
+                    suffix="칸"
+                  />
+                </StatLine>
+              </div>
+
+              <div className="space-y-1 text-left">
+                <StatLine label="가장 뜨거웠던 라운드">
+                  {summary.hottestRoundNumber
+                    ? (
+                        <>
+                          <NumberText value={summary.hottestRoundNumber} />
+                          라운드,{" "}
+                          <NumberText value={summary.hottestRoundVoteCount} />표
+                        </>
+                      )
+                    : "-"}
+                </StatLine>
+                <StatLine label="가장 구경했던 라운드">
+                  {summary.quietestRoundNumber
+                    ? (
+                        <>
+                          <NumberText value={summary.quietestRoundNumber} />
+                          라운드,{" "}
+                          <NumberText value={summary.quietestRoundVoteCount} />표
+                        </>
+                      )
+                    : "-"}
+                </StatLine>
+              </div>
+            </section>
+
+            <section className="space-y-3 rounded-2xl border border-gray-100 bg-gray-50 px-5 py-4 text-sm leading-6 text-gray-700">
+              <div>
+                <p className="mb-1 font-bold text-gray-900">최다 투표자</p>
+                <p>
+                  <VoterList voters={summary.topVoters} />
+                </p>
+              </div>
+              <div>
+                <p className="mb-1 font-bold text-gray-900">함께한 투표자</p>
+                <p>
+                  <VoterList voters={summary.participants} limit={8} />
+                </p>
+              </div>
+            </section>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/canvas/CanvasPage.tsx
+++ b/frontend/src/pages/canvas/CanvasPage.tsx
@@ -8,7 +8,7 @@ import {
 import { GameHistoryPanel } from "@/features/gameplay/history";
 import { IntroGuideModal } from "@/features/gameplay/intro";
 import RoundSummaryModal from "@/features/gameplay/round/components/RoundSummaryModal";
-import type { GameSummaryData } from "@/features/gameplay/session/api/session.api";
+import GameSummaryModal from "@/features/gameplay/session/components/GameSummaryModal";
 import {
   ErrorScreen,
   GameEndedScreen,
@@ -17,80 +17,6 @@ import {
 import { GAME_PHASE } from "@/features/gameplay/session/model/game-phase.types";
 import { VotePanel, VotePopup } from "@/features/gameplay/vote";
 import useCanvasPage from "./model/useCanvasPage";
-
-interface SummaryModalProps {
-  title: string;
-  onClose: () => void;
-  children: React.ReactNode;
-}
-
-function SummaryModal({ title, onClose, children }: SummaryModalProps) {
-  useEffect(() => {
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key !== "Escape") {
-        return;
-      }
-
-      event.preventDefault();
-      onClose();
-    };
-
-    window.addEventListener("keydown", handleKeyDown);
-
-    return () => {
-      window.removeEventListener("keydown", handleKeyDown);
-    };
-  }, [onClose]);
-
-  return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/45 px-4">
-      <div className="w-full max-w-[560px] rounded-3xl border border-gray-200 bg-white/95 p-6 shadow-2xl backdrop-blur">
-        <div className="mb-5 flex items-center justify-between gap-3 border-b border-gray-100 pb-4">
-          <h2 className="text-xl font-bold text-gray-900">{title}</h2>
-          <button
-            type="button"
-            className="rounded-full px-3 py-1.5 text-sm font-medium text-gray-400 hover:bg-gray-100 hover:text-gray-700"
-            onClick={onClose}
-          >
-            닫기
-          </button>
-        </div>
-        <div>{children}</div>
-      </div>
-    </div>
-  );
-}
-
-function GameSummaryModal({
-  summary,
-  onClose,
-}: {
-  summary: GameSummaryData;
-  onClose: () => void;
-}) {
-  return (
-    <SummaryModal title="게임 종료 결과" onClose={onClose}>
-      <div className="flex flex-col gap-2 text-sm text-gray-700">
-        <div className="flex items-center justify-between gap-3">
-          <span>총 라운드 수</span>
-          <span>{summary.totalRounds}</span>
-        </div>
-        <div className="flex items-center justify-between gap-3">
-          <span>참여자 수</span>
-          <span>{summary.participantCount}명</span>
-        </div>
-        <div className="flex items-center justify-between gap-3">
-          <span>총 투표 수</span>
-          <span>{summary.totalVotes}</span>
-        </div>
-        <div className="flex items-center justify-between gap-3">
-          <span>완성도</span>
-          <span>{summary.canvasCompletionPercent}%</span>
-        </div>
-      </div>
-    </SummaryModal>
-  );
-}
 
 export default function CanvasPage() {
   const navigate = useNavigate();
@@ -323,6 +249,7 @@ export default function CanvasPage() {
       {gameSummaryModal && (
         <GameSummaryModal
           summary={gameSummaryModal}
+          snapshotUrl={latestRoundSnapshot}
           onClose={handleCloseGameSummaryModal}
         />
       )}


### PR DESCRIPTION
## 관련 이슈
- Close #249

## 작업 내용
- 게임 종료 결과 모달을 게임 종료 통계 모달로 확장
- 인트로 모달과 동일한 폭 기준으로 게임 종료 통계 모달 레이아웃 구성
- 최종 캔버스 스냅샷 표시 추가
- 게임 전체 통계 표시 추가
  - 총 라운드 수
  - 투표 인원 수
  - 투표권 사용률
  - 총 지급 투표권 수
  - 총 투표 수
  - 캔버스 완성도
  - 색칠된 칸 수
  - 남은 빈 칸 수
  - 가장 인기 있었던 칸
  - 랜덤 당선 칸 수
  - 사용 색상 수
  - 가장 많이 선택된 색
  - 캔버스에서 가장 많이 쓰인 색
  - 가장 뜨거웠던 라운드
  - 가장 구경했던 라운드
- 최다 투표자/함께한 투표자 목록 표시 추가
- 게임 종료 summary 응답에 최종 스냅샷 URL과 가장 구경했던 라운드 정보 추가
- 히스토리에서 게임 종료 결과를 다시 열 때도 동일한 상세 통계 데이터를 사용할 수 있도록 보강
- 스냅샷/배경 이미지가 없는 경우 미니맵이 `cells` 기반으로 fallback 렌더링되도록 수정
- 기존 미사용 helper 정리

## 변경 파일
- `backend/src/modules/canvas/canvas.controller.ts`
- `backend/src/modules/history/history.service.ts`
- `backend/src/modules/history/round-snapshot.service.ts`
- `backend/src/modules/summary/summary.service.ts`
- `frontend/src/features/gameplay/canvas/components/MiniMap.tsx`
- `frontend/src/features/gameplay/round/components/RoundSummaryModal.tsx`
- `frontend/src/features/gameplay/session/api/session.api.ts`
- `frontend/src/features/gameplay/session/components/GameSummaryModal.tsx`
- `frontend/src/pages/canvas/CanvasPage.tsx`

## 확인 사항
- 게임 종료 시 게임 종료 통계 모달이 표시되는지 확인
- 모달 폭이 인트로 모달과 동일한 기준으로 표시되는지 확인
- 최종 캔버스 스냅샷이 표시되는지 확인
- 통계 숫자가 볼드/빨강으로 강조되는지 확인
- 왼쪽 bullet 없이 문장형으로 표시되는지 확인
- 히스토리 패널에서 게임 종료 결과를 다시 열어도 동일한 통계 모달이 표시되는지 확인
- ESC 또는 닫기 버튼으로 모달이 닫히는지 확인