### PR TITLE
fix : 게임 종료 통계 수치 및 모달 구성 수정

### DIFF
--- a/backend/src/modules/canvas/canvas.controller.ts
+++ b/backend/src/modules/canvas/canvas.controller.ts
@@ -13,12 +13,6 @@ interface CreateCanvasRequestBody {
   profileKey?: string;
 }
 
-type RoundVoteExtreme = {
-  roundId: number;
-  roundNumber: number;
-  voteCount: number;
-} | null;
-
 function serializeCanvas(canvas: Canvas) {
   return {
     id: canvas.id,
@@ -63,7 +57,6 @@ function buildRoundSnapshotUrl(
 function serializeGameSummary(
   summary: GameSummary,
   snapshotUrl: string | null,
-  quietestRound: RoundVoteExtreme,
 ) {
   return {
     id: summary.id,
@@ -93,9 +86,6 @@ function serializeGameSummary(
     hottestRoundId: summary.hottestRoundId,
     hottestRoundNumber: summary.hottestRoundNumber,
     hottestRoundVoteCount: summary.hottestRoundVoteCount,
-    quietestRoundId: quietestRound?.roundId ?? null,
-    quietestRoundNumber: quietestRound?.roundNumber ?? null,
-    quietestRoundVoteCount: quietestRound?.voteCount ?? 0,
     topVoters: summary.topVotersJson,
     participants: summary.participantsJson,
     snapshotUrl,
@@ -183,10 +173,9 @@ export const canvasController = {
         return res.status(400).json({ message: "존재하지 않는 캔버스입니다." });
       }
 
-      const [summary, snapshot, quietestRound] = await Promise.all([
+      const [summary, snapshot] = await Promise.all([
         summaryService.getGameSummary(canvasId),
         roundSnapshotService.findLatestRoundSnapshot(canvasId),
-        summaryService.getQuietestRound(canvasId),
       ]);
 
       return res.json({
@@ -195,7 +184,6 @@ export const canvasController = {
           snapshot?.round?.id
             ? buildRoundSnapshotUrl(req, canvasId, snapshot.round.id)
             : null,
-          quietestRound,
         ),
       });
     } catch (err) {

--- a/backend/src/modules/history/history.service.ts
+++ b/backend/src/modules/history/history.service.ts
@@ -3,18 +3,11 @@ import { Canvas } from "../../entities/canvas.entity";
 import { GameSummary } from "../../entities/game-summary.entity";
 import { RoundSnapshot } from "../../entities/round-snapshot.entity";
 import { VoteRound } from "../../entities/vote-round.entity";
-import { summaryService } from "../summary/summary.service";
 
 const canvasRepository = AppDataSource.getRepository(Canvas);
 const gameSummaryRepository = AppDataSource.getRepository(GameSummary);
 const voteRoundRepository = AppDataSource.getRepository(VoteRound);
 const roundSnapshotRepository = AppDataSource.getRepository(RoundSnapshot);
-
-type RoundVoteExtreme = {
-  roundId: number;
-  roundNumber: number;
-  voteCount: number;
-} | null;
 
 function toRecord(value: unknown): Record<string, unknown> {
   if (value && typeof value === "object") {
@@ -209,7 +202,6 @@ function serializeGameSummary(
   rounds: VoteRound[],
   summary: GameSummary | null,
   snapshotUrl: string | null,
-  quietestRound: RoundVoteExtreme,
 ) {
   const endedAt = getDateStringField(canvas, "endedAt");
   const totalRounds =
@@ -248,9 +240,6 @@ function serializeGameSummary(
     hottestRoundId: summary?.hottestRoundId ?? null,
     hottestRoundNumber: summary?.hottestRoundNumber ?? null,
     hottestRoundVoteCount: summary?.hottestRoundVoteCount ?? 0,
-    quietestRoundId: quietestRound?.roundId ?? null,
-    quietestRoundNumber: quietestRound?.roundNumber ?? null,
-    quietestRoundVoteCount: quietestRound?.voteCount ?? 0,
     topVoters: summary?.topVotersJson ?? null,
     participants: summary?.participantsJson ?? null,
     snapshotUrl,
@@ -275,7 +264,7 @@ export const historyService = {
       return null;
     }
 
-    const [rounds, snapshots, gameSummary, quietestRound] = await Promise.all([
+    const [rounds, snapshots, gameSummary] = await Promise.all([
       voteRoundRepository.find({
         where: {
           canvas: { id: canvasId },
@@ -296,7 +285,6 @@ export const historyService = {
         where: { canvas: { id: canvasId } },
         relations: ["canvas"],
       }),
-      summaryService.getQuietestRound(canvasId),
     ]);
 
     const snapshotMap = new Map<string, RoundSnapshot>();
@@ -340,7 +328,6 @@ export const historyService = {
             rounds,
             gameSummary,
             latestSnapshotUrl,
-            quietestRound,
           )
         : null,
     };

--- a/backend/src/modules/summary/summary.service.ts
+++ b/backend/src/modules/summary/summary.service.ts
@@ -32,18 +32,6 @@ type TopVoterAggregate = {
   voteCount: number;
 };
 
-type RoundVoteExtreme = {
-  roundId: number;
-  roundNumber: number;
-  voteCount: number;
-} | null;
-
-type RoundVoteExtremeRow = {
-  roundId: number | string;
-  roundNumber: number | string;
-  voteCount: number | string;
-};
-
 function toPercent(numerator: number, denominator: number): string {
   if (denominator <= 0) {
     return "0.00";
@@ -159,31 +147,6 @@ export const summaryService = {
     }
 
     return summary;
-  },
-
-  async getQuietestRound(canvasId: number): Promise<RoundVoteExtreme> {
-    const row = await voteRoundRepository
-      .createQueryBuilder("round")
-      .leftJoin("round.votes", "vote")
-      .select("round.id", "roundId")
-      .addSelect("round.roundNumber", "roundNumber")
-      .addSelect("COUNT(vote.id)", "voteCount")
-      .where("round.canvas_id = :canvasId", { canvasId })
-      .groupBy("round.id")
-      .addGroupBy("round.roundNumber")
-      .orderBy("COUNT(vote.id)", "ASC")
-      .addOrderBy("round.roundNumber", "ASC")
-      .getRawOne<RoundVoteExtremeRow>();
-
-    if (!row) {
-      return null;
-    }
-
-    return {
-      roundId: Number(row.roundId),
-      roundNumber: Number(row.roundNumber),
-      voteCount: Number(row.voteCount),
-    };
   },
 
   async saveRoundSummary(
@@ -436,7 +399,7 @@ export const summaryService = {
       }
     }
 
-    const totalCellCount = cells.length;
+    const totalCellCount = canvas.gridX * canvas.gridY;
 
     const randomResolvedCellCount = countRandomResolvedCellsFromVotes(votes);
     const paintedCells = cells.filter(

--- a/frontend/src/features/gameplay/round/components/RoundSummaryModal.tsx
+++ b/frontend/src/features/gameplay/round/components/RoundSummaryModal.tsx
@@ -87,7 +87,7 @@ export default function RoundSummaryModal({
           className="relative flex cursor-move items-center justify-center border-b border-gray-100 px-5 py-4"
           onMouseDown={onDragStart}
         >
-          <p className="text-center text-base font-semibold text-gray-900">
+          <p className="text-center text-lg font-bold text-gray-900">
             {summary.roundNumber} 라운드 결과
           </p>
 
@@ -114,15 +114,6 @@ export default function RoundSummaryModal({
                 />
               </div>
             )}
-
-            <section className="space-y-1 text-center">
-              <p className="text-sm text-gray-500">
-                이번 라운드 결과를 정리했어요
-              </p>
-              <p className="text-2xl font-bold text-gray-900">
-                {summary.roundNumber} 라운드 결과
-              </p>
-            </section>
 
             <section className="space-y-3 text-left text-[15px] font-bold leading-7 text-gray-700">
               <p>{renderParticipantCopy(summary.participantCount)}</p>

--- a/frontend/src/features/gameplay/session/api/session.api.ts
+++ b/frontend/src/features/gameplay/session/api/session.api.ts
@@ -109,9 +109,6 @@ export interface GameSummaryData {
   hottestRoundId: number | null;
   hottestRoundNumber: number | null;
   hottestRoundVoteCount: number;
-  quietestRoundId: number | null;
-  quietestRoundNumber: number | null;
-  quietestRoundVoteCount: number;
   topVoters: GameSummaryTopVoter[] | null;
   participants: GameSummaryParticipant[] | null;
   snapshotUrl: string | null;

--- a/frontend/src/features/gameplay/session/components/GameSummaryModal.tsx
+++ b/frontend/src/features/gameplay/session/components/GameSummaryModal.tsx
@@ -39,11 +39,7 @@ function NumberText({ value }: { value: number | null | undefined }) {
   return <HighlightNumber>{formatNumber(value)}</HighlightNumber>;
 }
 
-function PercentText({
-  value,
-}: {
-  value: string | number | null | undefined;
-}) {
+function PercentText({ value }: { value: string | number | null | undefined }) {
   return <HighlightNumber>{formatPercentText(value)}</HighlightNumber>;
 }
 
@@ -124,13 +120,7 @@ function ColorStat({
   );
 }
 
-function StatLine({
-  label,
-  children,
-}: {
-  label: string;
-  children: ReactNode;
-}) {
+function StatLine({ label, children }: { label: string; children: ReactNode }) {
   return (
     <p>
       <span className="font-bold text-gray-900">{label}: </span>
@@ -175,8 +165,8 @@ export default function GameSummaryModal({
         onClick={(event) => event.stopPropagation()}
       >
         <div className="relative flex items-center justify-center border-b border-gray-100 px-5 py-4">
-          <p className="text-center text-base font-semibold text-gray-900">
-            게임 종료 통계
+          <p className="text-center text-lg font-bold text-gray-900">
+            게임 종료
           </p>
 
           <button
@@ -207,23 +197,15 @@ export default function GameSummaryModal({
               </div>
             )}
 
-            <section className="space-y-1 text-center">
-              <p className="text-sm text-gray-500">
-                모두가 함께 만든 결과를 정리했어요
-              </p>
-              <p className="text-2xl font-bold text-gray-900">
-                게임 종료 통계
-              </p>
-            </section>
-
             <section className="space-y-4 text-[15px] leading-7 text-gray-700">
               <div className="space-y-1 text-left">
                 <StatLine label="총 라운드 수">
-                  총 <NumberText value={summary.totalRounds} />라운드 진행
+                  총 <NumberText value={summary.totalRounds} />
+                  라운드 진행
                 </StatLine>
                 <StatLine label="투표 인원 수">
-                  총 <NumberText value={summary.participantCount} />명이
-                  참여했어요
+                  총 <NumberText value={summary.participantCount} />
+                  명이 참여했어요
                 </StatLine>
               </div>
 
@@ -236,7 +218,8 @@ export default function GameSummaryModal({
                   발급됐어요
                 </StatLine>
                 <StatLine label="총 투표 수">
-                  총 <NumberText value={summary.totalVotes} />표가 제출됐어요
+                  총 <NumberText value={summary.totalVotes} />
+                  표가 제출됐어요
                 </StatLine>
               </div>
 
@@ -251,33 +234,31 @@ export default function GameSummaryModal({
                   되었어요
                 </StatLine>
                 <StatLine label="남은 빈 칸 수">
-                  아직 <NumberText value={summary.emptyCellCount} />칸이 비어
-                  있어요
+                  아직 <NumberText value={summary.emptyCellCount} />
+                  칸이 비어 있어요
                 </StatLine>
               </div>
 
               <div className="space-y-1 text-left">
                 <StatLine label="가장 인기 있었던 칸">
                   <CellCoordinate summary={summary} />
-                  {summary.mostVotedCellVoteCount > 0
-                    ? (
-                        <>
-                          , <NumberText value={summary.mostVotedCellVoteCount} />
-                          표
-                        </>
-                      )
-                    : null}
+                  {summary.mostVotedCellVoteCount > 0 ? (
+                    <>
+                      , <NumberText value={summary.mostVotedCellVoteCount} />표
+                    </>
+                  ) : null}
                 </StatLine>
                 <StatLine label="랜덤 당선 칸 수">
                   동점 추첨으로 결정된 칸은{" "}
-                  <NumberText value={summary.randomResolvedCellCount} />개였어요
+                  <NumberText value={summary.randomResolvedCellCount} />
+                  개였어요
                 </StatLine>
               </div>
 
               <div className="space-y-1 text-left">
                 <StatLine label="사용 색상 수">
-                  총 <NumberText value={summary.usedColorCount} />가지 색이
-                  사용됐어요
+                  총 <NumberText value={summary.usedColorCount} />
+                  가지 색이 사용됐어요
                 </StatLine>
                 <StatLine label="가장 많이 선택된 색">
                   <ColorStat
@@ -297,26 +278,15 @@ export default function GameSummaryModal({
 
               <div className="space-y-1 text-left">
                 <StatLine label="가장 뜨거웠던 라운드">
-                  {summary.hottestRoundNumber
-                    ? (
-                        <>
-                          <NumberText value={summary.hottestRoundNumber} />
-                          라운드,{" "}
-                          <NumberText value={summary.hottestRoundVoteCount} />표
-                        </>
-                      )
-                    : "-"}
-                </StatLine>
-                <StatLine label="가장 구경했던 라운드">
-                  {summary.quietestRoundNumber
-                    ? (
-                        <>
-                          <NumberText value={summary.quietestRoundNumber} />
-                          라운드,{" "}
-                          <NumberText value={summary.quietestRoundVoteCount} />표
-                        </>
-                      )
-                    : "-"}
+                  {summary.hottestRoundNumber ? (
+                    <>
+                      <NumberText value={summary.hottestRoundNumber} />
+                      라운드,{" "}
+                      <NumberText value={summary.hottestRoundVoteCount} />표
+                    </>
+                  ) : (
+                    "-"
+                  )}
                 </StatLine>
               </div>
             </section>


### PR DESCRIPTION
## 관련 이슈
- Close #252 

## 작업 내용
- 게임 종료 통계에서 `가장 구경했던 라운드` 항목 제거
- 게임 종료 통계의 전체 셀 수 기준을 `canvas.gridX * canvas.gridY`로 수정
- `완성도`, `색칠된 칸 수`, `남은 빈 칸 수`가 전체 그리드 셀 기준으로 계산되도록 수정
- 게임 종료 summary API/히스토리 응답에서 `quietestRound` 관련 필드 제거
- 게임 종료 통계 모달의 이미지 아래 중복 타이틀/설명 섹션 제거
- 게임 종료 통계 모달 상단 타이틀 크기 확대
- 라운드 결과 모달의 이미지 아래 중복 `N 라운드 결과` 섹션 제거
- 라운드 결과 모달 상단 `N 라운드 결과` 타이틀 크기 확대

## 변경 파일
- `backend/src/modules/summary/summary.service.ts`
- `backend/src/modules/canvas/canvas.controller.ts`
- `backend/src/modules/history/history.service.ts`
- `frontend/src/features/gameplay/session/api/session.api.ts`
- `frontend/src/features/gameplay/session/components/GameSummaryModal.tsx`
- `frontend/src/features/gameplay/round/components/RoundSummaryModal.tsx`

## 확인 사항
- 게임 종료 통계에서 `가장 구경했던 라운드`가 노출되지 않는지 확인
- `색칠된 칸 수`가 전체 그리드 셀 수 기준으로 올바르게 표시되는지 확인
- `남은 빈 칸 수`가 전체 셀 수 - 색칠된 칸 수로 표시되는지 확인
- `완성도`가 전체 그리드 셀 수 기준으로 계산되는지 확인
- 게임 종료 직후 모달과 히스토리 재조회 모달이 동일한 수치를 표시하는지 확인
- 라운드 결과 모달과 게임 종료 통계 모달 모두 이미지 아래 중복 제목이 제거되었는지 확인
- 상단 타이틀 크기가 의도대로 커졌는지 확인