### PR TITLE
fix: 새로고침 시 히스토리 결과 중복 및 스냅샷 표시 오류 수정

### DIFF
--- a/backend/src/modules/history/history.controller.ts
+++ b/backend/src/modules/history/history.controller.ts
@@ -17,6 +17,20 @@ function parseCanvasId(value: unknown): number | null {
   return canvasId;
 }
 
+function toAbsoluteUrl(req: Request, url: string | null) {
+  if (!url) {
+    return null;
+  }
+
+  if (/^https?:\/\//i.test(url)) {
+    return url;
+  }
+
+  const host = req.get("host");
+
+  return host ? `${req.protocol}://${host}${url}` : url;
+}
+
 export const historyController = {
   async getCanvasHistory(req: Request, res: Response) {
     const canvasId = parseCanvasId(req.params.canvasId);
@@ -35,6 +49,25 @@ export const historyController = {
       });
     }
 
-    return res.json(history);
+    return res.json({
+      ...history,
+      rounds: history.rounds.map((round) => ({
+        ...round,
+        snapshotUrl: toAbsoluteUrl(req, round.snapshotUrl),
+        snapshot: round.snapshot
+          ? {
+              ...round.snapshot,
+              imageUrl: toAbsoluteUrl(req, round.snapshot.imageUrl),
+              snapshotUrl: toAbsoluteUrl(req, round.snapshot.snapshotUrl),
+            }
+          : null,
+      })),
+      gameSummary: history.gameSummary
+        ? {
+            ...history.gameSummary,
+            snapshotUrl: toAbsoluteUrl(req, history.gameSummary.snapshotUrl),
+          }
+        : null,
+    });
   },
 };

--- a/frontend/src/features/gameplay/history/hooks/useCanvasHistory.ts
+++ b/frontend/src/features/gameplay/history/hooks/useCanvasHistory.ts
@@ -90,7 +90,7 @@ function toGameHistoryItem(
 
   return {
     type: "game",
-    id: getGameHistoryItemId(canvasId, createdAt),
+    id: getGameHistoryItemId(canvasId),
     createdAt,
     data: summary,
   };

--- a/frontend/src/features/gameplay/history/model/history.types.ts
+++ b/frontend/src/features/gameplay/history/model/history.types.ts
@@ -13,7 +13,7 @@ export type GameHistoryItem =
     }
   | {
       type: "game";
-      id: `game:${number}:${string}`;
+      id: `game:${number}`;
       createdAt: string;
       data: GameSummaryData;
     };
@@ -29,7 +29,6 @@ export function getRoundHistoryItemId(roundId: number): `round:${number}` {
 
 export function getGameHistoryItemId(
   canvasId: number,
-  endedAt: string | null,
-): `game:${number}:${string}` {
-  return `game:${canvasId}:${endedAt ?? "ended"}`;
+): `game:${number}` {
+  return `game:${canvasId}`;
 }

--- a/frontend/src/features/gameplay/round/components/RoundSummaryModal.tsx
+++ b/frontend/src/features/gameplay/round/components/RoundSummaryModal.tsx
@@ -70,6 +70,7 @@ export default function RoundSummaryModal({
           100
         ).toFixed(1)
       : "0.0";
+  const roundSnapshot = summary.snapshotUrl ?? snapshot;
 
   return (
     <div
@@ -103,10 +104,10 @@ export default function RoundSummaryModal({
 
         <div className="min-h-0 flex-1 overflow-y-auto px-6 py-6">
           <div className="space-y-5">
-            {snapshot && (
+            {roundSnapshot && (
               <div className="mx-auto w-1/2 min-w-[180px] rounded-2xl border border-gray-200 bg-white p-3 shadow-sm">
                 <img
-                  src={snapshot}
+                  src={roundSnapshot}
                   alt={`${summary.roundNumber} 라운드 스냅샷`}
                   className="block w-full rounded border border-gray-100 bg-transparent"
                   style={{ imageRendering: "pixelated" }}


### PR DESCRIPTION
## 관련 이슈
- Close #254

## 작업 내용
- 새로고침 시 게임 결과 히스토리가 중복 표시되던 문제 수정
- 게임 결과 히스토리 id를 시간 기준이 아닌 canvas 기준 고정값으로 변경
- 새로고침 후 히스토리에서 라운드 결과를 열었을 때 스냅샷 이미지가 바로 보이지 않던 문제 수정
- 라운드 결과 모달이 `summary.snapshotUrl`을 우선 사용하도록 수정
- 히스토리 API 응답의 라운드/게임 스냅샷 URL을 절대 경로로 변환하도록 수정

## 변경 파일
- `frontend/src/features/gameplay/history/hooks/useCanvasHistory.ts`
- `frontend/src/features/gameplay/history/model/history.types.ts`
- `frontend/src/features/gameplay/round/components/RoundSummaryModal.tsx`
- `backend/src/modules/history/history.controller.ts`

## 확인 사항
- 게임 종료 후 히스토리 패널에 게임 결과가 1개만 표시되는지 확인
- 새로고침 후에도 게임 결과 히스토리가 중복 생성되지 않는지 확인
- 새로고침 후 히스토리에서 라운드 결과를 클릭하면 스냅샷 이미지가 즉시 표시되는지 확인
- 게임 결과 히스토리 클릭 시 기존처럼 게임 종료 통계 모달이 정상적으로 열리는지 확인
- 실시간으로 여는 라운드 결과 모달에도 기존처럼 이미지가 정상 표시되는지 확인