### PR TITLE
fix : 캔버스 및 게임 이미지 드래그 고스트 방지

### DIFF
--- a/frontend/src/features/gameplay/canvas/components/CanvasStage.tsx
+++ b/frontend/src/features/gameplay/canvas/components/CanvasStage.tsx
@@ -32,6 +32,9 @@ export default function CanvasStage({
       onMouseMove={onMouseMove}
       onMouseUp={onMouseUp}
       onMouseLeave={onMouseLeave}
+      onDragStart={(event) => {
+        event.preventDefault();
+      }}
       onWheel={(event) => {
         console.log("[canvas-stage:wheel]", {
           deltaY: event.deltaY,

--- a/frontend/src/features/gameplay/canvas/components/CanvasSurface.tsx
+++ b/frontend/src/features/gameplay/canvas/components/CanvasSurface.tsx
@@ -49,6 +49,9 @@ export default function CanvasSurface({
             imageRendering: "pixelated",
           }}
           draggable={false}
+          onDragStart={(event) => {
+            event.preventDefault();
+          }}
         />
       )}
       <canvas

--- a/frontend/src/features/gameplay/canvas/components/MiniMap.tsx
+++ b/frontend/src/features/gameplay/canvas/components/MiniMap.tsx
@@ -286,6 +286,9 @@ export default function MiniMap({
               imageRendering: "pixelated",
             }}
             draggable={false}
+            onDragStart={(event) => {
+              event.preventDefault();
+            }}
           />
         )}
 

--- a/frontend/src/features/gameplay/intro/components/IntroCanvasPreview.tsx
+++ b/frontend/src/features/gameplay/intro/components/IntroCanvasPreview.tsx
@@ -39,6 +39,9 @@ export default function IntroCanvasPreview({
               imageRendering: "pixelated",
             }}
             draggable={false}
+            onDragStart={(event) => {
+              event.preventDefault();
+            }}
           />
         ) : (
           <div

--- a/frontend/src/features/gameplay/round/components/RoundSummaryModal.tsx
+++ b/frontend/src/features/gameplay/round/components/RoundSummaryModal.tsx
@@ -112,6 +112,9 @@ export default function RoundSummaryModal({
                   className="block w-full rounded border border-gray-100 bg-transparent"
                   style={{ imageRendering: "pixelated" }}
                   draggable={false}
+                  onDragStart={(event) => {
+                    event.preventDefault();
+                  }}
                 />
               </div>
             )}

--- a/frontend/src/features/gameplay/session/components/GameSummaryModal.tsx
+++ b/frontend/src/features/gameplay/session/components/GameSummaryModal.tsx
@@ -189,6 +189,9 @@ export default function GameSummaryModal({
                   className="block w-full rounded border border-gray-100 bg-transparent"
                   style={{ imageRendering: "pixelated" }}
                   draggable={false}
+                  onDragStart={(event) => {
+                    event.preventDefault();
+                  }}
                 />
               </div>
             ) : (


### PR DESCRIPTION
## 관련 이슈
- Close #256 

## 작업 내용
- 메인 캔버스 배경 이미지 드래그 시 브라우저 기본 고스트 이미지가 생성되지 않도록 수정
- 캔버스 스테이지 루트에서 native dragstart를 차단하도록 수정
- 배경 이미지 요소에서 dragstart 기본 동작을 차단하도록 수정
- 라운드 결과 모달 스냅샷 이미지의 드래그 고스트를 방지하도록 수정
- 게임 종료 통계 모달 스냅샷 이미지의 드래그 고스트를 방지하도록 수정
- 인트로 가이드 이미지의 드래그 고스트를 방지하도록 수정
- 미니맵 이미지의 드래그 고스트를 방지하도록 수정

## 변경 파일
- `frontend/src/features/gameplay/canvas/components/CanvasStage.tsx`
- `frontend/src/features/gameplay/canvas/components/CanvasSurface.tsx`
- `frontend/src/features/gameplay/round/components/RoundSummaryModal.tsx`
- `frontend/src/features/gameplay/session/components/GameSummaryModal.tsx`
- `frontend/src/features/gameplay/intro/components/IntroCanvasPreview.tsx`
- `frontend/src/features/gameplay/canvas/components/MiniMap.tsx`

## 확인 사항
- 메인 캔버스에서 배경 이미지를 드래그해도 고스트 이미지가 생성되지 않는지 확인
- 드래그 시 기존처럼 캔버스 팬 이동이 정상 동작하는지 확인
- 라운드 결과 모달 스냅샷을 드래그해도 고스트 이미지가 생성되지 않는지 확인
- 게임 종료 통계 모달 스냅샷을 드래그해도 고스트 이미지가 생성되지 않는지 확인
- 인트로 가이드 이미지를 드래그해도 고스트 이미지가 생성되지 않는지 확인
- 미니맵 이미지를 드래그해도 고스트 이미지가 생성되지 않는지 확인
- 줌, 셀 선택, 팝업, 미니맵 이동 동작에 영향이 없는지 확인
