### PR TITLE
fix : 줌 원복 버튼 클릭 시 셀 선택 방지

### DIFF
--- a/frontend/src/features/gameplay/canvas/hooks/useCanvasInteraction.ts
+++ b/frontend/src/features/gameplay/canvas/hooks/useCanvasInteraction.ts
@@ -87,15 +87,30 @@ export function useCanvasInteraction({
   const handleMouseUp = (event: React.MouseEvent) => {
     if (event.button !== 0) return;
 
+    const wasPanning = isPanning.current;
     isPanning.current = false;
 
-    if (hasPanned.current) return;
+    if (!wasPanning) {
+      hasPanned.current = false;
+      return;
+    }
+
+    if (hasPanned.current) {
+      hasPanned.current = false;
+      return;
+    }
 
     const canvas = canvasRef.current;
-    if (!canvas || gridX === 0 || gridY === 0 || zoom <= 0) return;
+    if (!canvas || gridX === 0 || gridY === 0 || zoom <= 0) {
+      hasPanned.current = false;
+      return;
+    }
 
     const rect = canvas.getBoundingClientRect();
-    if (!isInsideCanvas(event.clientX, event.clientY, rect)) return;
+    if (!isInsideCanvas(event.clientX, event.clientY, rect)) {
+      hasPanned.current = false;
+      return;
+    }
 
     const cellSize = getGameConfig().board.cellSize;
     const worldPoint = getWorldCoordinate(
@@ -113,6 +128,7 @@ export function useCanvasInteraction({
     const targetY = Math.floor(worldPoint.y / cellSize);
 
     if (targetX < 0 || targetX >= gridX || targetY < 0 || targetY >= gridY) {
+      hasPanned.current = false;
       return;
     }
 
@@ -125,6 +141,7 @@ export function useCanvasInteraction({
         status: "idle",
       } as Cell);
 
+    hasPanned.current = false;
     onResetPreviewColor();
     onSelectCell(targetCell);
     onOpenPopup({ x: event.clientX, y: event.clientY });

--- a/frontend/src/pages/canvas/CanvasPage.tsx
+++ b/frontend/src/pages/canvas/CanvasPage.tsx
@@ -147,6 +147,7 @@ export default function CanvasPage() {
             aria-label="초기 줌 비율로 복귀"
             title="초기 줌 비율로 복귀"
             onMouseDown={(event) => event.stopPropagation()}
+            onMouseUp={(event) => event.stopPropagation()}
             onClick={(event) => {
               event.stopPropagation();
               resetCanvasZoom();


### PR DESCRIPTION
## 관련 이슈
- Close #258 

## 작업 내용
- 줌 원복 버튼 클릭 시 캔버스 셀 선택으로 처리되던 문제 수정
- 캔버스 `mouseup`이 실제 `mousedown`으로 시작된 상호작용일 때만 셀 선택으로 이어지도록 수정
- 팬 이동 또는 예외 경로에서도 상호작용 상태가 남지 않도록 보강
- 줌 원복 버튼의 `mouseup` 이벤트가 캔버스 스테이지로 버블링되지 않도록 수정

## 변경 파일
- `frontend/src/features/gameplay/canvas/hooks/useCanvasInteraction.ts`
- `frontend/src/pages/canvas/CanvasPage.tsx`

## 확인 사항
- 캔버스를 확대/이동한 뒤 줌 원복 버튼 클릭 시 셀 선택 팝업이 열리지 않는지 확인
- 줌 원복 버튼 클릭 시 초기 줌/초기 위치로 정상 복귀하는지 확인
- 일반 캔버스 클릭 시에는 기존처럼 셀 선택이 정상 동작하는지 확인
- 드래그 팬 이동 동작이 기존처럼 정상 동작하는지 확인