### PR TITLE
feat: 브랜드 로고 리소스 적용

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="icon" type="image/svg+xml" href="/brand/logo-symbol.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>VoteDots</title>
   </head>

--- a/frontend/public/brand/logo-full.svg
+++ b/frontend/public/brand/logo-full.svg
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg width="800" height="900" viewBox="0 0 800 900" xmlns="http://www.w3.org/2000/svg">
+
+  <rect width="100%" height="100%" fill="none"/>
+
+  <!-- Grid -->
+  <g stroke="#0B1B2B" stroke-width="16" fill="none" transform="translate(150,80)">
+    <rect x="0" y="0" width="500" height="500" rx="60"/>
+    <line x1="166" y1="0" x2="166" y2="500"/>
+    <line x1="333" y1="0" x2="333" y2="500"/>
+    <line x1="0" y1="166" x2="500" y2="166"/>
+    <line x1="0" y1="333" x2="500" y2="333"/>
+  </g>
+
+  <!-- Center dot -->
+  <circle cx="400" cy="330" r="40" fill="#8B5CF6"/>
+
+  <!-- Vote dots -->
+  <circle cx="400" cy="80" r="60" fill="#4ADE80"/>
+  <circle cx="160" cy="330" r="60" fill="#F87171"/>
+  <circle cx="640" cy="330" r="60" fill="#60A5FA"/>
+  <circle cx="400" cy="580" r="60" fill="#FBBF24"/>
+
+  <!-- Text -->
+  <g transform="translate(125,760)">
+    <text x="0" y="0"
+          font-family="Inter, Poppins, Arial, sans-serif"
+          font-size="140"
+          font-weight="700"
+          fill="#071A33">v</text>
+
+    <circle cx="112" cy="-40" r="38" fill="#8B5CF6"/>
+
+    <text x="150" y="0"
+          font-family="Inter, Poppins, Arial, sans-serif"
+          font-size="140"
+          font-weight="700"
+          fill="#071A33">tedots</text>
+  </g>
+
+</svg>

--- a/frontend/public/brand/logo-symbol.svg
+++ b/frontend/public/brand/logo-symbol.svg
@@ -1,0 +1,90 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1024" height="1024" viewBox="0 0 1024 1024">
+  <defs>
+    <linearGradient id="purpleGrad" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#7C3AED"/>
+      <stop offset="100%" stop-color="#A855F7"/>
+    </linearGradient>
+    <style>
+      .grid { fill: none; stroke: #03162B; stroke-width: 22; stroke-linecap: round; stroke-linejoin: round; }
+      .check { fill: none; stroke: #F7F7F7; stroke-width: 18; stroke-linecap: round; stroke-linejoin: round; }
+    </style>
+  </defs>
+
+  <!-- Transparent background -->
+
+  <!-- Grid outer shape -->
+  <rect class="grid" x="265" y="260" width="494" height="494" rx="74" ry="74"/>
+
+  <!-- Inner grid lines -->
+  <line class="grid" x1="430" y1="260" x2="430" y2="754"/>
+  <line class="grid" x1="594" y1="260" x2="594" y2="754"/>
+  <line class="grid" x1="265" y1="425" x2="759" y2="425"/>
+  <line class="grid" x1="265" y1="589" x2="759" y2="589"/>
+
+  <!-- Center purple circle -->
+  <circle cx="512" cy="507" r="50" fill="url(#purpleGrad)"/>
+
+  <!-- Top green bubble -->
+  <path d="M468 116
+           H556
+           C589 116 616 143 616 176
+           V257
+           C616 290 589 317 556 317
+           H534
+           L512 363
+           L490 317
+           H468
+           C435 317 408 290 408 257
+           V176
+           C408 143 435 116 468 116Z"
+        fill="#3DD68C"/>
+  <path class="check" d="M474 210 L503 239 L554 188"/>
+
+  <!-- Left red bubble -->
+  <path d="M132 430
+           H222
+           C255 430 282 457 282 490
+           V505
+           L324 530
+           L282 555
+           V570
+           C282 603 255 630 222 630
+           H132
+           C99 630 72 603 72 570
+           V490
+           C72 457 99 430 132 430Z"
+        fill="#FF624E"/>
+  <path class="check" d="M152 529 L182 559 L236 505"/>
+
+  <!-- Right blue bubble -->
+  <path d="M802 430
+           H892
+           C925 430 952 457 952 490
+           V570
+           C952 603 925 630 892 630
+           H802
+           C769 630 742 603 742 570
+           V555
+           L700 530
+           L742 505
+           V490
+           C742 457 769 430 802 430Z"
+        fill="#469AE5"/>
+  <path class="check" d="M792 529 L822 559 L876 505"/>
+
+  <!-- Bottom yellow bubble -->
+  <path d="M468 738
+           H490
+           L512 694
+           L534 738
+           H556
+           C589 738 616 765 616 798
+           V888
+           C616 921 589 948 556 948
+           H468
+           C435 948 408 921 408 888
+           V798
+           C408 765 435 738 468 738Z"
+        fill="#F8B321"/>
+  <path class="check" d="M474 848 L503 877 L554 826"/>
+</svg>

--- a/frontend/public/brand/logo-wordmark.svg
+++ b/frontend/public/brand/logo-wordmark.svg
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg width="620" height="180" viewBox="0 0 620 180" xmlns="http://www.w3.org/2000/svg">
+  <title>votedots wordmark</title>
+  <desc>Transparent SVG wordmark for votedots, matching the wordmark used in logo-full.svg.</desc>
+
+  <rect width="100%" height="100%" fill="none"/>
+
+  <g transform="translate(30,125)">
+    <text x="0" y="0"
+          font-family="Inter, Poppins, Arial, sans-serif"
+          font-size="140"
+          font-weight="700"
+          fill="#071A33">v</text>
+
+    <circle cx="112" cy="-40" r="38" fill="#8B5CF6"/>
+
+    <text x="150" y="0"
+          font-family="Inter, Poppins, Arial, sans-serif"
+          font-size="140"
+          font-weight="700"
+          fill="#071A33">tedots</text>
+  </g>
+</svg>

--- a/frontend/src/features/gameplay/vote/components/VotePanel.tsx
+++ b/frontend/src/features/gameplay/vote/components/VotePanel.tsx
@@ -77,8 +77,12 @@ export default function VotePanel({
 
   return (
     <div className="flex h-full flex-col gap-5 overflow-y-auto px-4 py-5">
-      <div className="flex flex-col gap-2">
-        <h3 className="text-lg font">VoteDots</h3>
+      <div className="flex flex-col items-center gap-2">
+        <img
+          src="/brand/logo-wordmark.svg"
+          alt="VoteDots"
+          className="mx-auto h-auto w-40"
+        />
         <MyInfoCard participants={participants} />
       </div>
 

--- a/frontend/src/pages/login/LoginPage.tsx
+++ b/frontend/src/pages/login/LoginPage.tsx
@@ -30,7 +30,11 @@ export default function LoginPage() {
   return (
     <div className="flex min-h-screen items-center justify-center">
       <div className="flex w-full max-w-sm flex-col gap-6">
-        <h1 className="text-center text-2xl font-bold">VoteDots</h1>
+        <img
+          src="/brand/logo-full.svg"
+          alt="VoteDots"
+          className="mx-auto h-auto w-56"
+        />
 
         <form onSubmit={handleSubmit} className="flex flex-col gap-4">
           <div className="flex flex-col gap-1">


### PR DESCRIPTION
## 관련 이슈
- Close #267 

## 변경 요약
- 브랜드 리소스를 `logo-symbol`, `logo-wordmark`, `logo-full` 3종 SVG로 추가했습니다.
- 로그인 화면 상단의 `VoteDots` 텍스트를 `logo-full.svg`로 교체했습니다.
- 게임 화면 오른쪽 인포 패널 상단의 `VoteDots` 텍스트를 `logo-wordmark.svg`로 교체했습니다.
- 브라우저 favicon을 `logo-symbol.svg`로 교체했습니다.
- full/wordmark 로고의 보라색 `o`, 자간, 좌우 여백, 정렬을 조정했습니다.

## 확인 방법
- 로그인 화면 상단에 full 로고가 표시되는지 확인합니다.
- 게임 진입 후 오른쪽 인포 패널 상단에 wordmark 로고가 가운데 정렬로 표시되는지 확인합니다.
- 브라우저 탭 favicon이 symbol 로고로 표시되는지 확인합니다.