### PR TITLE
chore: Zone.Identifier 메타파일 정리

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ dist/
 # OS
 .DS_Store
 Thumbs.db
+*:Zone.Identifier
 
 # Docker
 .docker/

--- a/frontend/public/brand/logo-full.svg:Zone.Identifier
+++ b/frontend/public/brand/logo-full.svg:Zone.Identifier
@@ -1,2 +1,0 @@
-[ZoneTransfer]
-ZoneId=3

--- a/frontend/public/brand/logo-symbol.svg:Zone.Identifier
+++ b/frontend/public/brand/logo-symbol.svg:Zone.Identifier
@@ -1,2 +1,0 @@
-[ZoneTransfer]
-ZoneId=3


### PR DESCRIPTION
## 관련 이슈
- Close #276

## 변경 목적
Windows 환경에서 생성된 `Zone.Identifier` 메타파일을 정리하고, 이후 동일한 메타파일이 작업 트리에 노출되지 않도록 ignore 규칙을 추가합니다.

## 변경 내용
- 브랜드 SVG 리소스에 생성된 `Zone.Identifier` 메타파일을 제거했습니다.
- `Zone.Identifier` 계열 파일이 Git 추적 대상에 포함되지 않도록 `.gitignore`를 업데이트했습니다.

## 확인 방법
- `git status`에서 `Zone.Identifier` 파일이 노출되지 않는지 확인합니다.
- 브랜드 SVG 리소스가 기존과 동일하게 정상 표시되는지 확인합니다.
- 이후 동일한 메타파일이 생성돼도 Git 변경사항에 포함되지 않는지 확인합니다.

## 비고
- `Zone.Identifier`는 실제 서비스 리소스가 아닌 Windows 메타데이터 파일입니다.
