### PR TITLE
feat: 인트로 모달 자동 표시 기준을 게임 첫 입장으로 변경

### DIFF
--- a/frontend/src/pages/canvas/CanvasPage.tsx
+++ b/frontend/src/pages/canvas/CanvasPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import {
   CanvasStage,
@@ -14,16 +14,20 @@ import {
   GameEndedScreen,
   LoadingScreen,
 } from "@/features/gameplay/session";
-import { GAME_PHASE } from "@/features/gameplay/session/model/game-phase.types";
 import { VotePanel, VotePopup } from "@/features/gameplay/vote";
 import { useI18n } from "@/shared/i18n";
 import useCanvasPage from "./model/useCanvasPage";
 import { PLAY_THEME_STYLE } from "./model/play-theme";
 
+const INTRO_GUIDE_SEEN_STORAGE_KEY = "votedots:intro-guide-seen";
+
+function buildIntroGuideSeenStorageKey(canvasId: number): string {
+  return `${INTRO_GUIDE_SEEN_STORAGE_KEY}:${canvasId}`;
+}
+
 export default function CanvasPage() {
   const navigate = useNavigate();
   const { t } = useI18n();
-  const [introModalDismissed, setIntroModalDismissed] = useState(false);
 
   const handleSessionEnded = useCallback(() => {
     window.alert(t("canvas.sessionEnded"));
@@ -110,16 +114,19 @@ export default function CanvasPage() {
   const canvasPageThemeStyle = PLAY_THEME_STYLE;
 
   useEffect(() => {
-    if (phase === GAME_PHASE.INTRO && !introModalDismissed) {
-      handleOpenIntroGuide();
+    if (!canvasId || loading || error || gameEnded) {
       return;
     }
 
-    if (phase !== GAME_PHASE.INTRO) {
-      handleCloseIntroGuide();
-      setIntroModalDismissed(false);
+    const storageKey = buildIntroGuideSeenStorageKey(canvasId);
+
+    if (window.sessionStorage.getItem(storageKey) === "true") {
+      return;
     }
-  }, [handleCloseIntroGuide, handleOpenIntroGuide, introModalDismissed, phase]);
+
+    window.sessionStorage.setItem(storageKey, "true");
+    handleOpenIntroGuide();
+  }, [canvasId, error, gameEnded, handleOpenIntroGuide, loading]);
 
   if (loading) {
     return (
@@ -248,10 +255,7 @@ export default function CanvasPage() {
           gridY={gridY}
           gameConfig={gameConfig}
           formattedGameEndTime={formattedGameEndTime}
-          onClose={() => {
-            setIntroModalDismissed(true);
-            handleCloseIntroGuide();
-          }}
+          onClose={handleCloseIntroGuide}
         />
       )}
 


### PR DESCRIPTION
## 관련 이슈
- Close #296 

## 변경 내용
- 인트로 모달의 자동 표시 기준을 `INTRO` phase에서 `canvasId` 기준 첫 입장으로 변경
- 같은 게임에서 새로고침 시 인트로 모달이 다시 자동으로 열리지 않도록 `sessionStorage` 기반 처리 추가
- `INTRO` phase 종료 시 인트로 모달이 자동으로 닫히던 동작 제거
- 인트로 모달은 사용자가 직접 닫을 때만 닫히도록 유지

## 기대 동작
- 게임에 처음 입장했을 때 인트로 모달이 자동으로 열린다
- 같은 게임에서 새로고침하면 인트로 모달이 다시 자동으로 열리지 않는다
- 다음 게임으로 넘어가 `canvasId`가 바뀌면 인트로 모달이 다시 자동으로 열린다
- phase 종료만으로 인트로 모달이 자동으로 닫히지 않는다