### PR TITLE
feat: 키보드 셀 이동과 연속 투표 흐름을 개선

### DIFF
--- a/frontend/src/features/gameplay/canvas/hooks/useCanvasInteraction.ts
+++ b/frontend/src/features/gameplay/canvas/hooks/useCanvasInteraction.ts
@@ -13,9 +13,7 @@ interface UseCanvasInteractionParams {
   worldOffsetX: number;
   worldOffsetY: number;
   onPan: (dx: number, dy: number) => void;
-  onSelectCell: (cell: Cell) => void;
-  onResetPreviewColor: () => void;
-  onOpenPopup: (position: { x: number; y: number }) => void;
+  onActivateCell: (cell: Cell, position: { x: number; y: number }) => void;
 }
 
 function isInsideCanvas(clientX: number, clientY: number, rect: DOMRect) {
@@ -54,9 +52,7 @@ export function useCanvasInteraction({
   worldOffsetX,
   worldOffsetY,
   onPan,
-  onSelectCell,
-  onResetPreviewColor,
-  onOpenPopup,
+  onActivateCell,
 }: UseCanvasInteractionParams) {
   const isPanning = useRef(false);
   const hasPanned = useRef(false);
@@ -142,9 +138,10 @@ export function useCanvasInteraction({
       } as Cell);
 
     hasPanned.current = false;
-    onResetPreviewColor();
-    onSelectCell(targetCell);
-    onOpenPopup({ x: event.clientX, y: event.clientY });
+    onActivateCell(targetCell, {
+      x: event.clientX,
+      y: event.clientY,
+    });
   };
 
   const handleMouseLeave = () => {

--- a/frontend/src/pages/canvas/model/useCanvasPage.ts
+++ b/frontend/src/pages/canvas/model/useCanvasPage.ts
@@ -271,9 +271,8 @@ export default function useCanvasPage({
   }, [closePopup]);
 
   const handleVoteSuccess = useCallback(() => {
-    clearSelectedCell();
     gameplay.handleVoteSuccess();
-  }, [clearSelectedCell, gameplay]);
+  }, [gameplay]);
 
   return {
     paintCanvasRef,

--- a/frontend/src/pages/canvas/model/useCanvasScene.ts
+++ b/frontend/src/pages/canvas/model/useCanvasScene.ts
@@ -80,6 +80,10 @@ function clampZoom(nextZoom: number, bounds: ZoomBounds) {
   return Math.min(bounds.maxZoom, Math.max(bounds.minZoom, nextZoom));
 }
 
+function clamp(value: number, min: number, max: number) {
+  return Math.min(Math.max(value, min), max);
+}
+
 function getNextZoom(currentZoom: number, zoomIn: boolean, bounds: ZoomBounds) {
   const scaledZoom = zoomIn
     ? currentZoom * ZOOM_SCALE
@@ -124,6 +128,21 @@ function isCellInsideVisibleBounds(
     x <= bounds.endCellX &&
     y >= bounds.startCellY &&
     y <= bounds.endCellY
+  );
+}
+
+function isTextInputElement(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) {
+    return false;
+  }
+
+  const tagName = target.tagName;
+
+  return (
+    tagName === "INPUT" ||
+    tagName === "TEXTAREA" ||
+    tagName === "SELECT" ||
+    target.isContentEditable
   );
 }
 
@@ -422,6 +441,130 @@ export default function useCanvasScene({
     zoom,
   });
 
+  const buildCellAtCoordinate = useCallback(
+    (x: number, y: number): Cell =>
+      cells.find((cell) => cell.x === x && cell.y === y) ??
+      ({
+        x,
+        y,
+        color: null,
+        status: "idle",
+      } as Cell),
+    [cells],
+  );
+
+  const centerCameraOnCell = useCallback(
+    (x: number, y: number) => {
+      const container = containerRef.current;
+
+      if (!container || gridX === 0 || gridY === 0 || zoomRef.current <= 0) {
+        return null;
+      }
+
+      const cellSize = getGameConfig().board.cellSize;
+      const viewportWorldWidth = container.clientWidth / zoomRef.current;
+      const viewportWorldHeight = container.clientHeight / zoomRef.current;
+      const targetWorldCenterX = x * cellSize + cellSize / 2;
+      const targetWorldCenterY = y * cellSize + cellSize / 2;
+
+      return {
+        x: clamp(
+          targetWorldCenterX - viewportWorldWidth / 2,
+          0,
+          Math.max(0, worldWidth - viewportWorldWidth),
+        ),
+        y: clamp(
+          targetWorldCenterY - viewportWorldHeight / 2,
+          0,
+          Math.max(0, worldHeight - viewportWorldHeight),
+        ),
+      };
+    },
+    [gridX, gridY, worldHeight, worldWidth],
+  );
+
+  const getPopupPositionForCell = useCallback(
+    (
+      x: number,
+      y: number,
+      cameraOverride?: { x: number; y: number } | null,
+    ): { x: number; y: number } | null => {
+      const container = containerRef.current;
+
+      if (!container || zoomRef.current <= 0) {
+        return null;
+      }
+
+      const rect = container.getBoundingClientRect();
+      const cellSize = getGameConfig().board.cellSize;
+      const resolvedCamera = cameraOverride ?? {
+        x: cameraXRef.current,
+        y: cameraYRef.current,
+      };
+
+      return {
+        x:
+          rect.left +
+          worldOffset.x -
+          resolvedCamera.x * zoomRef.current +
+          (x + 0.5) * cellSize * zoomRef.current,
+        y:
+          rect.top +
+          worldOffset.y -
+          resolvedCamera.y * zoomRef.current +
+          (y + 0.5) * cellSize * zoomRef.current,
+      };
+    },
+    [worldOffset.x, worldOffset.y],
+  );
+
+  const activateCell = useCallback(
+    (cell: Cell, position?: { x: number; y: number }) => {
+      resetPreviewColor();
+      setSelectedCell(cell);
+      selectedCellRef.current = cell;
+      openPopup(position ?? getPopupPositionForCell(cell.x, cell.y) ?? { x: 0, y: 0 });
+    },
+    [getPopupPositionForCell, openPopup, resetPreviewColor],
+  );
+
+  const activateCellAtCoordinate = useCallback(
+    (x: number, y: number) => {
+      if (x < 0 || x >= gridX || y < 0 || y >= gridY) {
+        return;
+      }
+
+      const nextCell = buildCellAtCoordinate(x, y);
+      const shouldCenterCamera = !isCellInsideVisibleBounds(
+        x,
+        y,
+        visibleCellBounds,
+      );
+      const nextCamera = shouldCenterCamera ? centerCameraOnCell(x, y) : null;
+
+      if (nextCamera) {
+        setCameraX(nextCamera.x);
+        setCameraY(nextCamera.y);
+        cameraXRef.current = nextCamera.x;
+        cameraYRef.current = nextCamera.y;
+      }
+
+      activateCell(
+        nextCell,
+        getPopupPositionForCell(x, y, nextCamera) ?? undefined,
+      );
+    },
+    [
+      activateCell,
+      buildCellAtCoordinate,
+      centerCameraOnCell,
+      getPopupPositionForCell,
+      gridX,
+      gridY,
+      visibleCellBounds,
+    ],
+  );
+
   useLayoutEffect(() => {
     const container = containerRef.current;
     const pending = pendingZoomAdjustmentRef.current;
@@ -481,11 +624,6 @@ export default function useCanvasScene({
     worldOffsetY: worldOffset.y,
   });
 
-  const handleSelectCell = useCallback((cell: Cell) => {
-    setSelectedCell(cell);
-    selectedCellRef.current = cell;
-  }, []);
-
   const handlePan = useCallback(
     (dx: number, dy: number) => {
       const container = containerRef.current;
@@ -522,10 +660,68 @@ export default function useCanvasScene({
       worldOffsetX: worldOffset.x,
       worldOffsetY: worldOffset.y,
       onPan: handlePan,
-      onSelectCell: handleSelectCell,
-      onResetPreviewColor: resetPreviewColor,
-      onOpenPopup: openPopup,
+      onActivateCell: activateCell,
     });
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.metaKey || event.ctrlKey || event.altKey) {
+        return;
+      }
+
+      if (isTextInputElement(event.target)) {
+        return;
+      }
+
+      const key = event.key.toLowerCase();
+      let deltaX = 0;
+      let deltaY = 0;
+
+      switch (key) {
+        case "arrowup":
+        case "w":
+          deltaY = -1;
+          break;
+        case "arrowdown":
+        case "s":
+          deltaY = 1;
+          break;
+        case "arrowleft":
+        case "a":
+          deltaX = -1;
+          break;
+        case "arrowright":
+        case "d":
+          deltaX = 1;
+          break;
+        default:
+          return;
+      }
+
+      event.preventDefault();
+
+      const currentCell = selectedCellRef.current;
+
+      if (!currentCell) {
+        return;
+      }
+
+      const nextX = currentCell.x + deltaX;
+      const nextY = currentCell.y + deltaY;
+
+      if (nextX < 0 || nextX >= gridX || nextY < 0 || nextY >= gridY) {
+        return;
+      }
+
+      activateCellAtCoordinate(nextX, nextY);
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [activateCellAtCoordinate, gridX, gridY]);
 
   const resetCanvasZoom = useCallback(() => {
     const container = containerRef.current;


### PR DESCRIPTION
## 관련 이슈
- Close #300 

## 변경 내용
- 선택된 셀 기준으로 방향키와 `WASD` 입력 시 인접 셀로 이동할 수 있도록 키보드 이동 기능 추가
- 키보드로 이동한 셀도 마우스 클릭과 동일하게 선택 상태가 갱신되고 투표 팝업이 열리도록 처리
- 키를 길게 누를 때 브라우저 기본 반복 keydown에 따라 연속 이동되도록 구성
- 경계 밖 이동 방지, 입력창 포커스 중 단축키 무시, 방향키 기본 스크롤 방지 처리 추가
- 투표 성공 후 팝업은 닫되 마지막 선택 셀은 유지되도록 변경
- 마지막 선택 셀 기준으로 바로 다음 셀로 이동해 연속 투표할 수 있도록 흐름 개선

## 기대 동작
- 셀을 한 번 선택한 뒤 방향키 또는 `WASD`로 상하좌우 인접 셀 이동이 가능하다
- 키보드로 이동한 셀에서도 클릭과 동일하게 투표 팝업이 열린다
- 키를 길게 누르면 팝업이 선택 셀을 따라가며 연속 이동한다
- 투표 후 팝업은 닫히지만 선택 상태는 유지되어 바로 다음 셀로 이동할 수 있다
- 입력창 포커스 중에는 키보드 이동이 동작하지 않고, 방향키 입력으로 페이지 스크롤이 발생하지 않는다

## 확인 내용
- 셀 선택 후 방향키/`WASD` 이동 동작 수동 확인 필요
- 키 길게 누를 때 팝업 추적 동작 수동 확인 필요
- 투표 후 팝업 닫힘, 선택 유지, 다음 셀 연속 이동 흐름 수동 확인 필요