### PR TITLE
feat: 참여자 상태 계산 규칙 통일 및 설정 메뉴 구조 정리

### DIFF
--- a/backend/src/modules/participant/participant-session.service.ts
+++ b/backend/src/modules/participant/participant-session.service.ts
@@ -3,8 +3,6 @@ import { Server } from "socket.io";
 import { redisClient } from "../../config/redis";
 import { sessionStore } from "../../config/session";
 import { gameConfig } from "../../config/game.config";
-import { AppDataSource } from "../../database/data-source";
-import { Canvas } from "../../entities/canvas.entity";
 import { GamePhase } from "../game/game-phase.types";
 
 export type ParticipantStatus = "voting" | "waiting";
@@ -38,8 +36,6 @@ export interface ParticipantSummary {
   status: ParticipantStatus;
   connected: boolean;
 }
-
-const canvasRepository = AppDataSource.getRepository(Canvas);
 
 class ParticipantSessionService {
   private cleanupTimers = new Map<string, NodeJS.Timeout>();
@@ -86,40 +82,8 @@ class ParticipantSessionService {
     return this.parseParticipantState(raw);
   }
 
-  private async getCanvasPhase(canvasId: number): Promise<GamePhase | null> {
-    const canvas = await canvasRepository.findOne({
-      where: { id: canvasId },
-    });
-
-    return canvas?.phase ?? null;
-  }
-
-  private getDefaultStatusByPhase(phase: GamePhase | null): ParticipantStatus {
-    if (phase === GamePhase.GAME_END) {
-      return "waiting";
-    }
-
-    return "voting";
-  }
-
-  private getRestoredStatusByPhase(
-    phase: GamePhase | null,
-    existingStatus: ParticipantStatus,
-  ): ParticipantStatus {
-    if (phase === GamePhase.GAME_END) {
-      return "waiting";
-    }
-
-    if (phase === GamePhase.ROUND_ACTIVE) {
-      return "voting";
-    }
-
-    return existingStatus === "waiting" ? "voting" : existingStatus;
-  }
-
-  private async getDefaultStatus(canvasId: number): Promise<ParticipantStatus> {
-    const phase = await this.getCanvasPhase(canvasId);
-    return this.getDefaultStatusByPhase(phase);
+  private getStatusByConnection(connected: boolean): ParticipantStatus {
+    return connected ? "voting" : "waiting";
   }
 
   private clearCleanupTimer(canvasId: number, sessionId: string): void {
@@ -252,10 +216,7 @@ class ParticipantSessionService {
       !!existing.graceUntil &&
       new Date(existing.graceUntil).getTime() > Date.now();
 
-    const canvasPhase = await this.getCanvasPhase(canvasId);
-    const status = existing
-      ? this.getRestoredStatusByPhase(canvasPhase, existing.status)
-      : await this.getDefaultStatus(canvasId);
+    const status = this.getStatusByConnection(true);
 
     this.clearCleanupTimer(canvasId, sessionId);
 
@@ -326,7 +287,7 @@ class ParticipantSessionService {
 
       await redisClient.hSet(this.buildCanvasSessionKey(canvasId, sessionId), {
         socketId,
-        status: state.status,
+        status: this.getStatusByConnection(false),
         connected: "false",
         disconnectedAt: disconnectedAt.toISOString(),
         graceUntil,
@@ -353,7 +314,7 @@ class ParticipantSessionService {
 
       await redisClient.hSet(this.buildCanvasSessionKey(canvasId, sessionId), {
         socketId: state.socketId ?? "",
-        status: "voting",
+        status: this.getStatusByConnection(state.connected),
         connected: state.connected ? "true" : "false",
         disconnectedAt: state.disconnectedAt ?? "",
         graceUntil: state.graceUntil ?? "",
@@ -418,7 +379,7 @@ class ParticipantSessionService {
         voterId: voter.id,
         voterUuid: voter.uuid,
         nickname: voter.nickname,
-        status: state.status,
+        status: this.getStatusByConnection(state.connected),
         connected: state.connected,
       });
     }

--- a/frontend/src/features/gameplay/vote/components/VotePanel.tsx
+++ b/frontend/src/features/gameplay/vote/components/VotePanel.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import type { Cell, Viewport } from "@/features/gameplay/canvas";
 import { CoordinateNavigator, MiniMap } from "@/features/gameplay/canvas";
 import { RoundInfo } from "@/features/gameplay/round";
@@ -11,6 +11,7 @@ import {
 import { getGameConfig } from "@/shared/config/game-config";
 import { useI18n } from "@/shared/i18n";
 import { BrandLogo } from "@/shared/ui/brand-logo";
+import VotePanelSettings from "./VotePanelSettings";
 import { MAX_VOTE_PANEL_ENTRIES } from "../model/vote.constants";
 import { buildVotePanelEntries } from "../model/vote.utils";
 
@@ -71,6 +72,8 @@ export default function VotePanel({
 }: Props) {
   const { locale, setLocale, t } = useI18n();
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
+  const settingsButtonRef = useRef<HTMLButtonElement | null>(null);
+  const settingsMenuRef = useRef<HTMLDivElement | null>(null);
   const votesPerRound = getGameConfig().rules.votesPerRound;
   const voteEntries = buildVotePanelEntries(votes, cells).slice(
     0,
@@ -82,11 +85,50 @@ export default function VotePanel({
   });
   const isVotingPhase = phase === GAME_PHASE.ROUND_ACTIVE;
 
+  useEffect(() => {
+    if (!isSettingsOpen) {
+      return undefined;
+    }
+
+    const handlePointerDown = (event: MouseEvent) => {
+      const target = event.target as Node | null;
+
+      if (!target) {
+        return;
+      }
+
+      if (settingsButtonRef.current?.contains(target)) {
+        return;
+      }
+
+      if (settingsMenuRef.current?.contains(target)) {
+        return;
+      }
+
+      setIsSettingsOpen(false);
+    };
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        setIsSettingsOpen(false);
+      }
+    };
+
+    document.addEventListener("mousedown", handlePointerDown);
+    document.addEventListener("keydown", handleKeyDown);
+
+    return () => {
+      document.removeEventListener("mousedown", handlePointerDown);
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [isSettingsOpen]);
+
   return (
     <div className="flex h-full flex-col gap-5 overflow-y-auto px-4 py-5">
       <div className="flex flex-col items-center gap-2">
         <div className="relative flex w-full justify-end">
           <button
+            ref={settingsButtonRef}
             type="button"
             onClick={() => setIsSettingsOpen((prev) => !prev)}
             className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-[color:var(--page-theme-border-primary)] bg-[color:var(--page-theme-surface-primary)] text-sm font-semibold text-[color:var(--page-theme-text-secondary)] shadow-sm transition hover:bg-[color:var(--page-theme-surface-secondary)] hover:text-[color:var(--page-theme-text-primary)]"
@@ -97,39 +139,11 @@ export default function VotePanel({
           </button>
 
           {isSettingsOpen ? (
-            <div className="absolute right-0 top-11 z-10 w-56 rounded-2xl border border-[color:var(--page-theme-border-primary)] bg-[color:var(--page-theme-surface-primary)] p-3 shadow-lg">
-              <div className="flex flex-col gap-2">
-                <section className="flex items-center justify-between gap-3 rounded-xl border border-[color:var(--page-theme-border-primary)] bg-[color:var(--page-theme-surface-primary)] px-3 py-2">
-                  <p className="text-xs font-semibold text-[color:var(--page-theme-text-secondary)]">
-                    Language
-                  </p>
-                  <select
-                    value={locale}
-                    onChange={(event) =>
-                      setLocale(event.target.value as "ko" | "en")
-                    }
-                    className="min-w-[108px] rounded-lg border border-[color:var(--page-theme-border-primary)] bg-[color:var(--page-theme-surface-secondary)] px-2 py-1.5 text-xs font-medium text-[color:var(--page-theme-text-primary)] outline-none"
-                  >
-                    <option value="ko">KO</option>
-                    <option value="en">EN</option>
-                  </select>
-                </section>
-
-                <section className="flex items-center justify-between gap-3 rounded-xl border border-[color:var(--page-theme-border-primary)] bg-[color:var(--page-theme-surface-primary)] px-3 py-2">
-                  <p className="text-xs font-semibold text-[color:var(--page-theme-text-secondary)]">
-                    Background
-                  </p>
-                  <select
-                    defaultValue="w"
-                    className="min-w-[108px] rounded-lg border border-[color:var(--page-theme-border-primary)] bg-[color:var(--page-theme-surface-secondary)] px-2 py-1.5 text-xs font-medium text-[color:var(--page-theme-text-primary)] outline-none"
-                  >
-                    <option value="w">W</option>
-                    <option value="g">G</option>
-                    <option value="b">B</option>
-                  </select>
-                </section>
-              </div>
-            </div>
+            <VotePanelSettings
+              ref={settingsMenuRef}
+              locale={locale}
+              onLocaleChange={setLocale}
+            />
           ) : null}
         </div>
 

--- a/frontend/src/features/gameplay/vote/components/VotePanelSettings.tsx
+++ b/frontend/src/features/gameplay/vote/components/VotePanelSettings.tsx
@@ -1,0 +1,57 @@
+import { forwardRef } from "react";
+
+interface Props {
+  locale: "ko" | "en";
+  onLocaleChange: (locale: "ko" | "en") => void;
+}
+
+const VotePanelSettings = forwardRef<HTMLDivElement, Props>(
+  ({ locale, onLocaleChange }, ref) => {
+    return (
+      <div
+        ref={ref}
+        className="absolute right-0 top-11 z-10 w-56 rounded-2xl border border-[color:var(--page-theme-border-primary)] bg-[color:var(--page-theme-surface-primary)] p-3 shadow-lg"
+      >
+      <div className="flex flex-col gap-2">
+        <section className="flex items-center gap-3 rounded-xl border border-[color:var(--page-theme-border-primary)] bg-[color:var(--page-theme-surface-primary)] px-3 py-2">
+          <p className="w-20 shrink-0 text-xs font-semibold text-[color:var(--page-theme-text-secondary)]">
+            Language
+          </p>
+          <div className="flex w-20 shrink-0 justify-end">
+            <select
+              value={locale}
+              onChange={(event) =>
+                onLocaleChange(event.target.value as "ko" | "en")
+              }
+              className="h-8 w-full min-w-0 rounded-lg border border-[color:var(--page-theme-border-primary)] bg-[color:var(--page-theme-surface-secondary)] px-2 py-1.5 text-xs font-medium text-[color:var(--page-theme-text-primary)] outline-none"
+            >
+              <option value="ko">KO</option>
+              <option value="en">EN</option>
+            </select>
+          </div>
+        </section>
+
+        <section className="flex items-center gap-3 rounded-xl border border-[color:var(--page-theme-border-primary)] bg-[color:var(--page-theme-surface-primary)] px-3 py-2">
+          <p className="w-20 shrink-0 text-xs font-semibold text-[color:var(--page-theme-text-secondary)]">
+            Background
+          </p>
+          <div className="flex w-20 shrink-0 justify-end">
+            <select
+              defaultValue="w"
+              className="h-8 w-full min-w-0 rounded-lg border border-[color:var(--page-theme-border-primary)] bg-[color:var(--page-theme-surface-secondary)] px-2 py-1.5 text-xs font-medium text-[color:var(--page-theme-text-primary)] outline-none"
+            >
+              <option value="w">W</option>
+              <option value="g">G</option>
+              <option value="b">B</option>
+            </select>
+          </div>
+        </section>
+      </div>
+      </div>
+    );
+  },
+);
+
+VotePanelSettings.displayName = "VotePanelSettings";
+
+export default VotePanelSettings;

--- a/frontend/src/pages/canvas/model/useCanvasGameplay.ts
+++ b/frontend/src/pages/canvas/model/useCanvasGameplay.ts
@@ -321,13 +321,8 @@ export default function useCanvasGameplay({
       return;
     }
 
-    if (phase === GAME_PHASE.GAME_END) {
-      clearParticipants();
-      return;
-    }
-
     void refreshParticipants();
-  }, [canvasId, clearParticipants, phase, refreshParticipants]);
+  }, [canvasId, clearParticipants, refreshParticipants]);
 
   useEffect(() => {
     if (isRoundActivePhase(phase)) {


### PR DESCRIPTION
## 관련 이슈
- Close #294 

## 개요
참여자 상태 계산 기준을 phase 중심에서 socket 연결 상태 중심으로 통일했다.
추가로 플레이 우측 패널의 설정 메뉴를 별도 컴포넌트로 분리하고, 메뉴 내부 드롭다운 정렬 구조를 정리했다.

## 변경사항
- 참여자 상태 계산 기준을 `connected` 기반으로 통일했다.
  - connected = true -> voting
  - connected = false -> waiting
- 종료 phase에서 강제로 `waiting` 처리하던 phase 기반 분기를 제거했다.
- 프론트에서 `GAME_END` 진입 시 참여자 목록을 초기화하던 처리를 제거했다.
- 종료 phase에서도 참여자 목록과 참여자 수가 유지되도록 정리했다.
- 설정 메뉴를 `VotePanel`에서 분리해 별도 컴포넌트로 정리했다.
- 설정 메뉴 내부 `Language`, `Background` 드롭다운의 시작점과 간격을 맞췄다.
- 설정 메뉴는 바깥 클릭 또는 `Esc` 입력 시 닫히도록 정리했다.

## 코드 흐름
- `participant-session.service`
  - phase를 조회해서 status를 결정하던 로직을 제거했다.
  - 참여자 접속 시 status를 `voting`으로 저장한다.
  - 소켓 연결 종료 시 status를 `waiting`으로 저장한다.
  - 다음 라운드 준비 시에도 `connected` 기준으로 status를 다시 맞춘다.
  - 참여자 목록 응답의 status도 `connected` 기준으로 내려준다.
- `useCanvasGameplay`
  - `GAME_END` 상태에서 `clearParticipants()` 하던 분기를 제거했다.
  - 종료 phase에서도 `refreshParticipants()`가 유지되도록 정리했다.
- `VotePanel`
  - 설정 버튼과 열림 상태만 유지하도록 정리했다.
  - 메뉴 외부 클릭 및 `Esc` 입력 시 닫히는 처리만 담당한다.
- `VotePanelSettings`
  - 설정 메뉴 UI를 별도 컴포넌트로 분리했다.
  - `Language`, `Background`를 2열 고정 구조로 렌더링한다.

## 결정사항
- `status` 필드는 유지한다.
- 다만 `status`의 의미는 phase 상태가 아니라 연결 상태의 파생값으로 본다.
- 결과 요약/투표 통계는 기존처럼 vote 데이터 기준으로 계산한다.
- 이번 변경은 실시간 참여자 상태/참여자 수 표시에 영향을 준다.
- 설정 메뉴 동작은 현재 구조 기준으로 유지하고, 배경 설정 저장/반영은 후속 작업으로 미룬다.

## 검증
- 접속 중인 참여자는 `voting`으로 표시되는 것을 확인했다.
- 연결이 끊긴 참여자는 `waiting`으로 표시되는 것을 확인했다.
- 종료 phase에서도 참여자 수가 0명으로 초기화되지 않고 실제 접속 인원 기준으로 표시되는 것을 확인했다.
- 설정 버튼 클릭 시 메뉴가 열리고, 바깥 클릭 또는 `Esc` 입력 시 닫히는 것을 확인했다.
- 설정 메뉴의 `Language`, `Background` 드롭다운 정렬이 맞는 것을 확인했다.
- 라운드 결과/투표 통계 집계에는 영향이 없는 방향으로 확인했다.