### PR TITLE
fix: 마이그레이션에서 삭제된 컬럼 참조 제거

### DIFF
--- a/backend/src/database/migrations/1783800000000-RenameLegacyResultTemplateAssetKeys.ts
+++ b/backend/src/database/migrations/1783800000000-RenameLegacyResultTemplateAssetKeys.ts
@@ -14,19 +14,8 @@ export class RenameLegacyResultTemplateAssetKeys1783800000000
           WHEN 'cat-front-128x128' THEN 'cat-front-256x256'
           WHEN 'Farrot-oblique-128x128' THEN 'Farrot-oblique-512x512'
           ELSE "resultTemplateAssetKey"
-        END,
-        "backgroundAssetKey" = CASE "backgroundAssetKey"
-          WHEN 'cat-oblique-64x64' THEN 'cat-oblique-128x128'
-          WHEN 'cat-front-128x128' THEN 'cat-front-256x256'
-          WHEN 'Farrot-oblique-128x128' THEN 'Farrot-oblique-512x512'
-          ELSE "backgroundAssetKey"
         END
       WHERE "resultTemplateAssetKey" IN (
-        'cat-oblique-64x64',
-        'cat-front-128x128',
-        'Farrot-oblique-128x128'
-      )
-      OR "backgroundAssetKey" IN (
         'cat-oblique-64x64',
         'cat-front-128x128',
         'Farrot-oblique-128x128'
@@ -43,19 +32,8 @@ export class RenameLegacyResultTemplateAssetKeys1783800000000
           WHEN 'cat-front-256x256' THEN 'cat-front-128x128'
           WHEN 'Farrot-oblique-512x512' THEN 'Farrot-oblique-128x128'
           ELSE "resultTemplateAssetKey"
-        END,
-        "backgroundAssetKey" = CASE "backgroundAssetKey"
-          WHEN 'cat-oblique-128x128' THEN 'cat-oblique-64x64'
-          WHEN 'cat-front-256x256' THEN 'cat-front-128x128'
-          WHEN 'Farrot-oblique-512x512' THEN 'Farrot-oblique-128x128'
-          ELSE "backgroundAssetKey"
         END
       WHERE "resultTemplateAssetKey" IN (
-        'cat-oblique-128x128',
-        'cat-front-256x256',
-        'Farrot-oblique-512x512'
-      )
-      OR "backgroundAssetKey" IN (
         'cat-oblique-128x128',
         'cat-front-256x256',
         'Farrot-oblique-512x512'

--- a/backend/src/database/migrations/1783900000000-RemoveCatFront256Template.ts
+++ b/backend/src/database/migrations/1783900000000-RemoveCatFront256Template.ts
@@ -12,13 +12,8 @@ export class RemoveCatFront256Template1783900000000
         "resultTemplateAssetKey" = CASE "resultTemplateAssetKey"
           WHEN 'cat-front-256x256' THEN 'empty-256x256'
           ELSE "resultTemplateAssetKey"
-        END,
-        "backgroundAssetKey" = CASE "backgroundAssetKey"
-          WHEN 'cat-front-256x256' THEN 'empty-256x256'
-          ELSE "backgroundAssetKey"
         END
       WHERE "resultTemplateAssetKey" = 'cat-front-256x256'
-         OR "backgroundAssetKey" = 'cat-front-256x256'
     `);
   }
 


### PR DESCRIPTION
## 관련 이슈
- Close #310 

## 개요
<!-- 이 PR에서 변경한 내용을 간략히 설명한다. -->
마이그레이션에서 삭제된 컬럼을 참고하던 문제 해결

## 확인

아래 순서로 명령어 실행
  1. `docker compose down -v`
  2. `docker compose up -d`
  3. `docker exec -it votedots-backend-1 npm run migration:run`

<img width="684" height="85" alt="image" src="https://github.com/user-attachments/assets/40eb00d9-0a31-4845-b10d-1433e57251ea" />

<img width="1085" height="252" alt="image" src="https://github.com/user-attachments/assets/a8650bb7-15be-4abd-af9a-a886d557f9b1" />

