### PR TITLE
fix: 미니맵과 스냅샷 모달 렌더링 정합성을 조정

### DIFF
--- a/backend/src/modules/history/round-snapshot-render.service.ts
+++ b/backend/src/modules/history/round-snapshot-render.service.ts
@@ -145,19 +145,21 @@ function createBasePng(
   gridHeight: number,
   backgroundImageBuffer: Buffer | null = null,
 ): PNG {
+  const basePng = new PNG({ width: gridWidth, height: gridHeight });
+
   if (backgroundImageBuffer) {
     try {
       const backgroundPng = decodeRasterBuffer(backgroundImageBuffer);
 
       if (backgroundPng) {
-        return backgroundPng;
+        return resizePng(backgroundPng, gridWidth, gridHeight);
       }
     } catch {
-      return new PNG({ width: gridWidth, height: gridHeight });
+      return basePng;
     }
   }
 
-  return new PNG({ width: gridWidth, height: gridHeight });
+  return basePng;
 }
 
 function getCellPixelBounds(params: {

--- a/frontend/src/features/gameplay/canvas/components/MiniMap.tsx
+++ b/frontend/src/features/gameplay/canvas/components/MiniMap.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useRef } from "react";
+import { MINIMAP_SIZE } from "../model/canvas.constants";
 import { Cell, Viewport } from "../model/canvas.types";
 
-const MINIMAP_BOX_SIZE = 220;
 const VIEWPORT_STROKE = "#ef4444";
 const VIEWPORT_FILL = "rgba(239, 68, 68, 0.12)";
 const SELECTED_CELL_STROKE = "#f97316";
@@ -100,7 +100,7 @@ export default function MiniMap({
 
   const minimapDimensions = useMemo(() => {
     const longestSide = Math.max(gridX, gridY, 1);
-    const scale = MINIMAP_BOX_SIZE / longestSide;
+    const scale = MINIMAP_SIZE / longestSide;
 
     return {
       width: Math.max(1, Math.round(gridX * scale)),
@@ -144,11 +144,22 @@ export default function MiniMap({
         viewportRect.width,
         viewportRect.height,
       );
+
+      const viewportStrokeRect = getInsetStrokeRect(
+        viewportRect.x,
+        viewportRect.y,
+        viewportRect.width,
+        viewportRect.height,
+        MINIMAP_STROKE_WIDTH,
+        canvas.width,
+        canvas.height,
+      );
+
       ctx.strokeRect(
-        viewportRect.x + MINIMAP_STROKE_WIDTH / 2,
-        viewportRect.y + MINIMAP_STROKE_WIDTH / 2,
-        Math.max(0, viewportRect.width - MINIMAP_STROKE_WIDTH),
-        Math.max(0, viewportRect.height - MINIMAP_STROKE_WIDTH),
+        viewportStrokeRect.x,
+        viewportStrokeRect.y,
+        viewportStrokeRect.width,
+        viewportStrokeRect.height,
       );
       ctx.restore();
     }
@@ -256,91 +267,89 @@ export default function MiniMap({
 
   return (
     <div className="flex justify-center">
-      <div className="relative flex h-[220px] w-full items-center justify-center overflow-hidden rounded-xl border border-[color:var(--page-theme-border-primary)] bg-[color:var(--page-theme-surface-secondary)] p-0 shadow-sm">
-        {snapshotUrl ? (
-          <>
-            {playBackgroundImageUrl && (
+      <div
+        className="flex items-center justify-center overflow-hidden rounded-xl border border-[color:var(--page-theme-border-primary)] bg-[color:var(--page-theme-surface-secondary)] p-0 shadow-sm"
+        style={{
+          width: `${MINIMAP_SIZE}px`,
+          height: `${MINIMAP_SIZE}px`,
+        }}
+      >
+        <div
+          className="relative shrink-0"
+          style={{
+            width: `${minimapDimensions.width}px`,
+            height: `${minimapDimensions.height}px`,
+          }}
+        >
+          {snapshotUrl ? (
+            <>
+              {playBackgroundImageUrl && (
+                <img
+                  src={playBackgroundImageUrl}
+                  alt="Minimap play background"
+                  className="pointer-events-none absolute inset-0 block h-full w-full select-none"
+                  style={{ imageRendering: "pixelated" }}
+                  draggable={false}
+                  onDragStart={(event) => {
+                    event.preventDefault();
+                  }}
+                />
+              )}
               <img
-                src={playBackgroundImageUrl}
-                alt="Minimap play background"
-                className="pointer-events-none absolute block h-full w-full select-none"
-                style={{
-                  width: `${minimapDimensions.width}px`,
-                  height: `${minimapDimensions.height}px`,
-                  imageRendering: "pixelated",
-                }}
+                src={snapshotUrl}
+                alt="Minimap snapshot"
+                className="pointer-events-none absolute inset-0 block h-full w-full select-none"
+                style={{ imageRendering: "pixelated" }}
                 draggable={false}
                 onDragStart={(event) => {
                   event.preventDefault();
                 }}
               />
-            )}
-          <img
-            src={snapshotUrl}
-            alt="Minimap snapshot"
-            className="pointer-events-none absolute block h-full w-full select-none"
+            </>
+          ) : (
+            <>
+              {playBackgroundImageUrl && (
+                <img
+                  src={playBackgroundImageUrl}
+                  alt="Minimap play background"
+                  className="pointer-events-none absolute inset-0 block h-full w-full select-none"
+                  style={{ imageRendering: "pixelated" }}
+                  draggable={false}
+                  onDragStart={(event) => {
+                    event.preventDefault();
+                  }}
+                />
+              )}
+              {resultTemplateImageUrl && (
+                <img
+                  src={resultTemplateImageUrl}
+                  alt="Minimap result template"
+                  className="pointer-events-none absolute inset-0 block h-full w-full select-none"
+                  style={{ imageRendering: "pixelated" }}
+                  draggable={false}
+                  onDragStart={(event) => {
+                    event.preventDefault();
+                  }}
+                />
+              )}
+            </>
+          )}
+
+          <canvas
+            ref={canvasRef}
+            onMouseDown={(event) => {
+              isDraggingRef.current = true;
+              navigateFromPointer(event.clientX, event.clientY, "auto");
+            }}
+            onDragStart={(event) => event.preventDefault()}
+            className="absolute inset-0 z-[1] block cursor-crosshair bg-transparent"
             style={{
               width: `${minimapDimensions.width}px`,
               height: `${minimapDimensions.height}px`,
               imageRendering: "pixelated",
             }}
-            draggable={false}
-            onDragStart={(event) => {
-              event.preventDefault();
-            }}
           />
-          </>
-        ) : (
-          <>
-            {playBackgroundImageUrl && (
-              <img
-                src={playBackgroundImageUrl}
-                alt="Minimap play background"
-                className="pointer-events-none absolute block h-full w-full select-none"
-                style={{
-                  width: `${minimapDimensions.width}px`,
-                  height: `${minimapDimensions.height}px`,
-                  imageRendering: "pixelated",
-                }}
-                draggable={false}
-                onDragStart={(event) => {
-                  event.preventDefault();
-                }}
-              />
-            )}
-            {resultTemplateImageUrl && (
-              <img
-                src={resultTemplateImageUrl}
-                alt="Minimap result template"
-                className="pointer-events-none absolute block h-full w-full select-none"
-                style={{
-                  width: `${minimapDimensions.width}px`,
-                  height: `${minimapDimensions.height}px`,
-                  imageRendering: "pixelated",
-                }}
-                draggable={false}
-                onDragStart={(event) => {
-                  event.preventDefault();
-                }}
-              />
-            )}
-          </>
-        )}
-
-        <canvas
-          ref={canvasRef}
-          onMouseDown={(event) => {
-            isDraggingRef.current = true;
-            navigateFromPointer(event.clientX, event.clientY, "auto");
-          }}
-          onDragStart={(event) => event.preventDefault()}
-          className="relative z-[1] block cursor-crosshair bg-transparent"
-          style={{
-            width: `${minimapDimensions.width}px`,
-            height: `${minimapDimensions.height}px`,
-            imageRendering: "pixelated",
-          }}
-        />
+        </div>
       </div>
     </div>
   );

--- a/frontend/src/features/gameplay/canvas/model/canvas.constants.ts
+++ b/frontend/src/features/gameplay/canvas/model/canvas.constants.ts
@@ -1,5 +1,5 @@
-export const PANEL_WIDTH = 280;
-export const MINIMAP_SIZE = 220;
+export const PANEL_WIDTH = 320;
+export const MINIMAP_SIZE = 256;
 
 export const CHECKER_LIGHT = "#6f6f6f";
 export const CHECKER_DARK = "#5f5f5f";

--- a/frontend/src/features/gameplay/intro/components/IntroCanvasPreview.tsx
+++ b/frontend/src/features/gameplay/intro/components/IntroCanvasPreview.tsx
@@ -8,7 +8,7 @@ interface Props {
   maxSize?: number;
 }
 
-const DEFAULT_PREVIEW_SIZE = 260;
+const DEFAULT_PREVIEW_SIZE = 512;
 
 export default function IntroCanvasPreview({
   playBackgroundImageUrl,

--- a/frontend/src/features/gameplay/intro/components/IntroGuideModal.tsx
+++ b/frontend/src/features/gameplay/intro/components/IntroGuideModal.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import type { GameConfig } from "@/shared/config/game-config";
 import { useI18n } from "@/shared/i18n";
+import { getCanvasTopCenterModalPosition } from "@/pages/canvas/model/modal-position";
 import IntroCanvasPreview from "./IntroCanvasPreview";
 
 interface Props {
@@ -23,13 +24,7 @@ function buildDescription(config: GameConfig) {
 }
 
 function getDefaultPosition() {
-  const modalWidth = Math.min(720, window.innerWidth - 24);
-  const modalHeight = Math.min(window.innerHeight - 80, 680);
-
-  return {
-    x: Math.max(12, Math.round((window.innerWidth - modalWidth) / 2)),
-    y: Math.max(12, Math.round((window.innerHeight - modalHeight) / 2)),
-  };
+  return getCanvasTopCenterModalPosition(700);
 }
 
 export default function IntroGuideModal({
@@ -170,7 +165,7 @@ export default function IntroGuideModal({
     >
       <div
         ref={modalRef}
-        className="pointer-events-auto fixed flex max-h-[min(calc(100vh-80px),680px)] w-[720px] max-w-[calc(100vw-24px)] flex-col overflow-hidden rounded-3xl border border-[color:var(--page-theme-border-primary)] bg-[color:var(--page-theme-surface-primary)] shadow-2xl"
+        className="pointer-events-auto fixed flex max-h-[calc(100vh-48px)] w-[700px] max-w-[calc(100vw-24px)] flex-col overflow-hidden rounded-3xl border border-[color:var(--page-theme-border-primary)] bg-[color:var(--page-theme-surface-primary)] shadow-2xl"
         style={{ top: position.y, left: position.x }}
         onMouseDown={(event) => event.stopPropagation()}
         onClick={(event) => event.stopPropagation()}

--- a/frontend/src/features/gameplay/round/components/RoundSummaryModal.tsx
+++ b/frontend/src/features/gameplay/round/components/RoundSummaryModal.tsx
@@ -1,6 +1,7 @@
 import { useEffect, type MouseEvent } from "react";
 import type { RoundSummaryData } from "@/features/gameplay/session/api/session.api";
 import { useI18n } from "@/shared/i18n";
+import { PixelSnapshotPreview } from "@/shared/ui/pixel-snapshot-preview";
 
 interface RoundSummaryModalProps {
   open: boolean;
@@ -42,7 +43,7 @@ export default function RoundSummaryModal({
   onClose,
   onDragStart,
 }: RoundSummaryModalProps) {
-  const { formatPercent, locale, t } = useI18n();
+  const { locale, t } = useI18n();
 
   useEffect(() => {
     if (!open || !summary) {
@@ -69,95 +70,73 @@ export default function RoundSummaryModal({
     return null;
   }
 
-  const progressPercent =
-    summary.totalCellCount > 0
-      ? (
-        (summary.currentPaintedCellCount / summary.totalCellCount) *
-        100
-      ).toFixed(1)
-      : "0.0";
   const roundSnapshot = summary.snapshotUrl ?? snapshot;
 
   return (
-    <div
-      className="fixed inset-0 z-50"
-      onMouseDown={(event) => event.stopPropagation()}
-      onClick={(event) => event.stopPropagation()}
-    >
+    <>
       <div
-        className="pointer-events-auto fixed flex max-h-[calc(100vh-48px)] w-[560px] max-w-[calc(100vw-24px)] flex-col overflow-hidden rounded-3xl border border-[color:var(--page-theme-border-primary)] bg-[color:var(--page-theme-surface-primary)] shadow-2xl"
-        style={{ top: position.y, left: position.x }}
+        className="fixed inset-0 z-50"
         onMouseDown={(event) => event.stopPropagation()}
         onClick={(event) => event.stopPropagation()}
       >
         <div
-          className="relative flex cursor-move items-center justify-center border-b border-[color:var(--page-theme-border-secondary)] px-5 py-4"
-          onMouseDown={onDragStart}
+        className="pointer-events-auto fixed flex max-h-[calc(100vh-48px)] w-[700px] max-w-[calc(100vw-24px)] flex-col overflow-hidden rounded-3xl border border-[color:var(--page-theme-border-primary)] bg-[color:var(--page-theme-surface-primary)] shadow-2xl"
+          style={{ top: position.y, left: position.x }}
+          onMouseDown={(event) => event.stopPropagation()}
+          onClick={(event) => event.stopPropagation()}
         >
-          <p className="text-center text-lg font-bold text-[color:var(--page-theme-primary-action)]">
-            {t("roundSummary.title", { round: summary.roundNumber })}
-          </p>
-
-          <button
-            type="button"
-            onClick={onClose}
-            className="absolute right-5 top-1/2 flex h-8 w-8 -translate-y-1/2 items-center justify-center rounded-full text-[color:var(--page-theme-text-tertiary)] hover:bg-[color:var(--page-theme-surface-secondary)] hover:text-[color:var(--page-theme-text-primary)]"
-            aria-label={t("roundSummary.close")}
+          <div
+            className="relative flex cursor-move items-center justify-center border-b border-[color:var(--page-theme-border-secondary)] px-5 py-4"
+            onMouseDown={onDragStart}
           >
-            ×
-          </button>
-        </div>
+            <p className="text-center text-lg font-bold text-[color:var(--page-theme-primary-action)]">
+              {t("roundSummary.title", { round: summary.roundNumber })}
+            </p>
 
-        <div className="min-h-0 flex-1 overflow-y-auto px-6 py-6">
-          <div className="space-y-5">
-            {roundSnapshot && (
-              <div className="mx-auto w-1/2 min-w-[180px] rounded-2xl border border-[color:var(--page-theme-border-primary)] bg-[color:var(--page-theme-surface-primary)] p-3 shadow-sm">
-                <div className="relative overflow-hidden rounded border border-[color:var(--page-theme-border-secondary)] bg-[color:var(--page-theme-surface-secondary)]">
-                  {playBackgroundImageUrl && (
-                    <img
-                      src={playBackgroundImageUrl}
-                      alt="Round summary play background"
-                      className="absolute inset-0 block h-full w-full"
-                      style={{ imageRendering: "pixelated" }}
-                      draggable={false}
-                      onDragStart={(event) => {
-                        event.preventDefault();
-                      }}
-                    />
-                  )}
-                  <img
-                    src={roundSnapshot}
-                    alt={t("roundSummary.snapshotAlt", {
-                      round: summary.roundNumber,
-                    })}
-                    className="relative block w-full bg-transparent"
-                    style={{ imageRendering: "pixelated" }}
-                    draggable={false}
-                    onDragStart={(event) => {
-                      event.preventDefault();
-                    }}
-                  />
-                </div>
-              </div>
-            )}
-            <section className="mx-auto w-4/6 space-y-3 rounded-2xl border-2 border-[color:var(--page-theme-primary-action)] px-5 py-4 text-center text-[15px] font-bold leading-7 text-[color:var(--page-theme-text-primary)]">
-              <p>{renderParticipantCopy(summary.participantCount, t, locale)}</p>
-              <p>
-                <span className="text-[22px] text-[color:var(--page-theme-alert)]">
-                  {summary.totalVotes}
-                </span>{" "}
-                {t("roundSummary.totalVotes")}
-              </p>
-              <p>
-                <span className="text-[22px] text-[color:var(--page-theme-alert)]">
-                  {summary.paintedCellCount}
-                </span>{" "}
-                {t("roundSummary.paintedCells")}
-              </p>
-            </section>
+            <button
+              type="button"
+              onClick={onClose}
+              className="absolute right-5 top-1/2 flex h-8 w-8 -translate-y-1/2 items-center justify-center rounded-full text-[color:var(--page-theme-text-tertiary)] hover:bg-[color:var(--page-theme-surface-secondary)] hover:text-[color:var(--page-theme-text-primary)]"
+              aria-label={t("roundSummary.close")}
+            >
+              ×
+            </button>
+          </div>
+
+          <div className="min-h-0 flex-1 overflow-y-auto px-6 py-6">
+            <div className="space-y-5">
+              {roundSnapshot && (
+                <PixelSnapshotPreview
+                  snapshotUrl={roundSnapshot}
+                  alt={t("roundSummary.snapshotAlt", {
+                    round: summary.roundNumber,
+                  })}
+                  backgroundImageUrl={playBackgroundImageUrl}
+                  backgroundAlt="Round summary play background"
+                  maxLongestSide={512}
+                />
+              )}
+
+              <section className="mx-auto w-4/6 space-y-3 rounded-2xl border-2 border-[color:var(--page-theme-primary-action)] px-5 py-4 text-center text-[15px] font-bold leading-7 text-[color:var(--page-theme-text-primary)]">
+                <p>{renderParticipantCopy(summary.participantCount, t, locale)}</p>
+                <p>
+                  <span className="text-[22px] text-[color:var(--page-theme-alert)]">
+                    {summary.totalVotes}
+                  </span>{" "}
+                  {t("roundSummary.totalVotes")}
+                </p>
+                <p>
+                  <span className="text-[22px] text-[color:var(--page-theme-alert)]">
+                    {summary.paintedCellCount}
+                  </span>{" "}
+                  {t("roundSummary.paintedCells")}
+                </p>
+              </section>
+            </div>
           </div>
         </div>
       </div>
-    </div>
+
+    </>
   );
 }

--- a/frontend/src/features/gameplay/session/components/GameSummaryModal.tsx
+++ b/frontend/src/features/gameplay/session/components/GameSummaryModal.tsx
@@ -6,11 +6,13 @@ import type {
 } from "@/features/gameplay/session/api/session.api";
 import { useI18n } from "@/shared/i18n";
 import { useSnapshotDownload } from "@/shared/hooks/useSnapshotDownload";
+import { PixelSnapshotPreview } from "@/shared/ui/pixel-snapshot-preview";
 
 interface GameSummaryModalProps {
   summary: GameSummaryData;
   snapshotUrl?: string | null;
   playBackgroundImageUrl?: string | null;
+  position: { x: number; y: number };
   onClose: () => void;
 }
 
@@ -192,6 +194,7 @@ export default function GameSummaryModal({
   summary,
   snapshotUrl,
   playBackgroundImageUrl,
+  position,
   onClose,
 }: GameSummaryModalProps) {
   const { formatNumber, formatPercent, locale, t } = useI18n();
@@ -243,12 +246,13 @@ export default function GameSummaryModal({
 
   return (
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-[color:var(--page-theme-overlay)] px-3 py-6"
+      className="fixed inset-0 z-50 bg-[color:var(--page-theme-overlay)] px-3 py-6"
       onMouseDown={(event) => event.stopPropagation()}
       onClick={(event) => event.stopPropagation()}
     >
       <div
-        className="pointer-events-auto flex max-h-[min(calc(100vh-80px),680px)] w-[720px] max-w-[calc(100vw-24px)] flex-col overflow-hidden rounded-3xl border border-[color:var(--page-theme-border-primary)] bg-[color:var(--page-theme-surface-primary)] shadow-2xl"
+        className="pointer-events-auto fixed flex max-h-[calc(100vh-48px)] w-[700px] max-w-[calc(100vw-24px)] flex-col overflow-hidden rounded-3xl border border-[color:var(--page-theme-border-primary)] bg-[color:var(--page-theme-surface-primary)] shadow-2xl"
+        style={{ top: position.y, left: position.x }}
         onMouseDown={(event) => event.stopPropagation()}
         onClick={(event) => event.stopPropagation()}
       >
@@ -270,32 +274,13 @@ export default function GameSummaryModal({
         <div className="min-h-0 flex-1 overflow-y-auto px-7 py-6">
           <div className="space-y-5">
             {finalSnapshotUrl ? (
-              <div className="mx-auto w-1/2 min-w-[180px] rounded-2xl border border-[color:var(--page-theme-border-primary)] bg-[color:var(--page-theme-surface-primary)] p-3 shadow-sm">
-                <div className="relative overflow-hidden rounded border border-[color:var(--page-theme-border-secondary)] bg-[color:var(--page-theme-surface-secondary)]">
-                  {playBackgroundImageUrl && (
-                    <img
-                      src={playBackgroundImageUrl}
-                      alt="Game summary play background"
-                      className="absolute inset-0 block h-full w-full"
-                      style={{ imageRendering: "pixelated" }}
-                      draggable={false}
-                      onDragStart={(event) => {
-                        event.preventDefault();
-                      }}
-                    />
-                  )}
-                  <img
-                    src={finalSnapshotUrl}
-                    alt={t("gameSummary.snapshotAlt")}
-                    className="relative block w-full bg-transparent"
-                    style={{ imageRendering: "pixelated" }}
-                    draggable={false}
-                    onDragStart={(event) => {
-                      event.preventDefault();
-                    }}
-                  />
-                </div>
-              </div>
+              <PixelSnapshotPreview
+                snapshotUrl={finalSnapshotUrl}
+                alt={t("gameSummary.snapshotAlt")}
+                backgroundImageUrl={playBackgroundImageUrl}
+                backgroundAlt="Game summary play background"
+                maxLongestSide={512}
+              />
             ) : (
               <div className="mx-auto flex aspect-square w-1/2 min-w-[180px] items-center justify-center rounded-2xl border border-dashed border-[color:var(--page-theme-border-primary)] bg-[color:var(--page-theme-surface-secondary)] px-4 text-center text-sm font-medium text-[color:var(--page-theme-text-tertiary)]">
                 {t("gameSummary.noSnapshot")}

--- a/frontend/src/features/gameplay/vote/components/VotePanel.tsx
+++ b/frontend/src/features/gameplay/vote/components/VotePanel.tsx
@@ -188,16 +188,18 @@ export default function VotePanel({
         )}
       </div>
 
-      <MiniMap
-        snapshotUrl={latestRoundSnapshot}
-        playBackgroundImageUrl={playBackgroundImageUrl}
-        resultTemplateImageUrl={resultTemplateImageUrl}
-        gridX={gridX}
-        gridY={gridY}
-        viewport={viewport}
-        selectedCell={selectedCell}
-        onNavigate={onNavigateToCoordinate}
-      />
+      <div className="shrink-0">
+        <MiniMap
+          snapshotUrl={latestRoundSnapshot}
+          playBackgroundImageUrl={playBackgroundImageUrl}
+          resultTemplateImageUrl={resultTemplateImageUrl}
+          gridX={gridX}
+          gridY={gridY}
+          viewport={viewport}
+          selectedCell={selectedCell}
+          onNavigate={onNavigateToCoordinate}
+        />
+      </div>
 
       <CoordinateNavigator
         gridX={gridX}

--- a/frontend/src/features/gameplay/vote/components/VotePopup.tsx
+++ b/frontend/src/features/gameplay/vote/components/VotePopup.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 import type { Cell } from "@/features/gameplay/canvas";
 import {
   GAME_PHASE,
@@ -116,6 +116,7 @@ export default function VotePopup({
   const [pos, setPos] = useState(position);
 
   const isDragging = useRef(false);
+  const hasManualPositionRef = useRef(false);
   const dragOffset = useRef({ x: 0, y: 0 });
   const popupRef = useRef<HTMLDivElement>(null);
 
@@ -227,6 +228,7 @@ export default function VotePopup({
 
   const handleDragStart = (event: React.MouseEvent) => {
     isDragging.current = true;
+    hasManualPositionRef.current = true;
     dragOffset.current = {
       x: event.clientX - pos.x,
       y: event.clientY - pos.y,
@@ -303,8 +305,12 @@ export default function VotePopup({
     };
   }, [onClose]);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (!popupRef.current) {
+      return;
+    }
+
+    if (hasManualPositionRef.current) {
       return;
     }
 
@@ -328,7 +334,11 @@ export default function VotePopup({
     }
 
     setPos({ x, y });
-  }, [position]);
+  }, [position, error, phaseBlockedMessage, isVotingPhase]);
+
+  useEffect(() => {
+    hasManualPositionRef.current = false;
+  }, [position.x, position.y, selectedCell.x, selectedCell.y]);
 
   useEffect(() => {
     onColorChange(color);

--- a/frontend/src/pages/canvas/CanvasPage.tsx
+++ b/frontend/src/pages/canvas/CanvasPage.tsx
@@ -293,6 +293,7 @@ export default function CanvasPage() {
           summary={gameSummaryModal}
           snapshotUrl={latestRoundSnapshot}
           playBackgroundImageUrl={playBackgroundImageUrl}
+          position={roundSummaryPosition}
           onClose={handleCloseGameSummaryModal}
         />
       )}

--- a/frontend/src/pages/canvas/model/modal-position.ts
+++ b/frontend/src/pages/canvas/model/modal-position.ts
@@ -1,0 +1,21 @@
+import { PANEL_WIDTH } from "@/features/gameplay/canvas";
+
+const HISTORY_PANEL_WIDTH = 88;
+const MODAL_EDGE_GAP = 12;
+const MODAL_TOP_OFFSET = 24;
+
+export function getCanvasTopCenterModalPosition(modalWidth: number) {
+  const viewportWidth = window.innerWidth;
+  const canvasAreaLeft = HISTORY_PANEL_WIDTH;
+  const canvasAreaRight = Math.max(canvasAreaLeft, viewportWidth - PANEL_WIDTH);
+  const canvasAreaWidth = Math.max(0, canvasAreaRight - canvasAreaLeft);
+  const fittedModalWidth = Math.min(modalWidth, viewportWidth - MODAL_EDGE_GAP * 2);
+  const centeredX =
+    canvasAreaLeft + Math.round((canvasAreaWidth - fittedModalWidth) / 2);
+  const maxX = viewportWidth - fittedModalWidth - MODAL_EDGE_GAP;
+
+  return {
+    x: Math.max(MODAL_EDGE_GAP, Math.min(centeredX, maxX)),
+    y: MODAL_TOP_OFFSET,
+  };
+}

--- a/frontend/src/pages/canvas/model/useCanvasPage.ts
+++ b/frontend/src/pages/canvas/model/useCanvasPage.ts
@@ -18,6 +18,7 @@ import {
 import type { CanvasBatchUpdatedPayload } from "@/features/gameplay/session/model/socket.types";
 import useCanvasGameplay from "./useCanvasGameplay";
 import useCanvasScene from "./useCanvasScene";
+import { getCanvasTopCenterModalPosition } from "./modal-position";
 
 interface UseCanvasPageParams {
   onSessionEnded: () => void;
@@ -27,13 +28,7 @@ interface UseCanvasPageParams {
 const PLAY_BACKGROUND_MODE_STORAGE_KEY = "votedots:play-background-mode";
 
 function getDefaultRoundSummaryModalPosition() {
-  const modalWidth = Math.min(560, window.innerWidth - 24);
-  const modalHeight = Math.min(window.innerHeight - 48, 720);
-
-  return {
-    x: Math.max(12, Math.round((window.innerWidth - modalWidth) / 2)),
-    y: Math.max(24, Math.round((window.innerHeight - modalHeight) / 2)),
-  };
+  return getCanvasTopCenterModalPosition(700);
 }
 
 function isRoundSummaryPhase(phase: GamePhase) {

--- a/frontend/src/shared/ui/pixel-snapshot-preview.tsx
+++ b/frontend/src/shared/ui/pixel-snapshot-preview.tsx
@@ -1,0 +1,111 @@
+import { useMemo, useState, type SyntheticEvent } from "react";
+
+interface PixelSnapshotPreviewProps {
+  snapshotUrl: string;
+  alt: string;
+  backgroundImageUrl?: string | null;
+  backgroundAlt: string;
+  maxLongestSide?: number;
+}
+
+interface PreviewDimensions {
+  width: number;
+  height: number;
+}
+
+const DEFAULT_MAX_LONGEST_SIDE = 256;
+
+function getPreviewDimensions(
+  naturalWidth: number,
+  naturalHeight: number,
+  maxLongestSide: number,
+): PreviewDimensions | null {
+  if (naturalWidth <= 0 || naturalHeight <= 0) {
+    return null;
+  }
+
+  const longestSide = Math.max(naturalWidth, naturalHeight);
+  const scale = maxLongestSide / longestSide;
+
+  return {
+    width: Math.round(naturalWidth * scale),
+    height: Math.round(naturalHeight * scale),
+  };
+}
+
+export function PixelSnapshotPreview({
+  snapshotUrl,
+  alt,
+  backgroundImageUrl = null,
+  backgroundAlt,
+  maxLongestSide = DEFAULT_MAX_LONGEST_SIDE,
+}: PixelSnapshotPreviewProps) {
+  const [naturalDimensions, setNaturalDimensions] =
+    useState<PreviewDimensions | null>(null);
+
+  const previewDimensions = useMemo(() => {
+    if (!naturalDimensions) {
+      return null;
+    }
+
+    return getPreviewDimensions(
+      naturalDimensions.width,
+      naturalDimensions.height,
+      maxLongestSide,
+    );
+  }, [maxLongestSide, naturalDimensions]);
+
+  const previewStyle = previewDimensions
+    ? {
+        width: `${previewDimensions.width}px`,
+        height: `${previewDimensions.height}px`,
+      }
+    : undefined;
+
+  const handleSnapshotLoad = (event: SyntheticEvent<HTMLImageElement>) => {
+    const image = event.currentTarget;
+
+    setNaturalDimensions({
+      width: image.naturalWidth,
+      height: image.naturalHeight,
+    });
+  };
+
+  return (
+    <div className="mx-auto w-fit max-w-full rounded-2xl border border-[color:var(--page-theme-border-primary)] bg-[color:var(--page-theme-surface-primary)] p-3 shadow-sm">
+      <div className="max-w-full overflow-auto">
+        <div
+          className="relative overflow-hidden rounded border border-[color:var(--page-theme-border-secondary)] bg-[color:var(--page-theme-surface-secondary)]"
+          style={previewStyle}
+        >
+          {backgroundImageUrl && (
+            <img
+              src={backgroundImageUrl}
+              alt={backgroundAlt}
+              className="absolute inset-0 block h-full w-full"
+              style={{ imageRendering: "pixelated" }}
+              draggable={false}
+              onDragStart={(event) => {
+                event.preventDefault();
+              }}
+            />
+          )}
+          <img
+            src={snapshotUrl}
+            alt={alt}
+            className={[
+              "relative block bg-transparent",
+              previewDimensions ? "h-full w-full" : "max-w-full",
+            ].join(" ")}
+            style={{ imageRendering: "pixelated" }}
+            draggable={false}
+            onDragStart={(event) => {
+              event.preventDefault();
+            }}
+            onLoad={handleSnapshotLoad}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## 관련 이슈
- Close #329 

## 변경 내용

- 미니맵의 배경, 스냅샷, 오버레이 캔버스가 같은 좌표계를 사용하도록 정리
- 미니맵 viewport 계산 기준 상수를 실제 렌더 크기와 동일한 `256`으로 맞추고, 우측 패널 폭도 함께 조정
- 미니맵 프레임을 실제 `256x256` 정사각형으로 고정
- 스냅샷 렌더러가 background 유무와 관계없이 항상 `gridWidth x gridHeight` 기준으로 nearest-neighbor 정규화 후 셀을 칠하도록 수정
- 인트로, 라운드 결과, 게임 결과 모달의 스냅샷 미리보기 기준 크기를 `512`로 통일
- 인트로, 라운드 결과, 게임 결과 모달 위치를 캔버스 영역 기준 상단 중앙으로 통일
- 라운드 결과 모달 폭 확장에 맞춰 기본 위치 계산도 함께 보정
- 스냅샷 자세히 보기 기능 제거
- 투표권 소진 등으로 팝업 하단 에러 메시지가 추가될 때, 투표 팝업 높이 증가를 반영해 자동 위치를 다시 계산하도록 수정

## 기대 동작

- 미니맵 viewport가 실제 맵 끝까지 정확히 이동하고, 스냅샷/배경/마커가 어긋나지 않는다
- 스냅샷은 background가 있어도 셀 크기가 균일하게 렌더링된다
- 인트로, 라운드 결과, 게임 결과 모달의 스냅샷 미리보기 크기와 모달 위치가 일관되게 보인다
- 스냅샷 미리보기 클릭 시 추가 상세 모달이 열리지 않는다
- 하단 셀에서 투표권 부족 에러가 표시되더라도 투표 팝업이 그 높이만큼 위로 보정된다

## 확인 내용

- `backend: npm run build` 통과
- `frontend: npm exec tsc -b` 통과
- 미니맵 viewport와 선택 마커가 맵 경계까지 정확히 맞는지 수동 확인 필요
- background 포함 스냅샷의 셀 크기가 균일한지 수동 확인 필요
- 인트로, 라운드 결과, 게임 결과 모달 위치와 스냅샷 미리보기 크기 수동 확인 필요
- 투표권 소진 에러 표시 시 팝업 위치 재계산 동작 수동 확인 필요