### PR TITLE
feat: GitHub Actions 기반 CD 워크플로를 추가

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,38 @@
+name: CD
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types:
+      - completed
+  workflow_dispatch:
+
+concurrency:
+  group: production-deploy
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    if: >-
+      ${{
+        github.event_name == 'workflow_dispatch' ||
+        (
+          github.event.workflow_run.conclusion == 'success' &&
+          github.event.workflow_run.head_branch == 'main'
+        )
+      }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Deploy to production server
+        uses: appleboy/ssh-action@v1.2.0
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ${{ secrets.EC2_USER }}
+          key: ${{ secrets.EC2_SSH_KEY }}
+          port: ${{ secrets.EC2_PORT }}
+          script_stop: true
+          command_timeout: 30m
+          script: |
+            cd /opt/votedots/app
+            bash scripts/deploy.sh

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+APP_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+COMPOSE_FILE="${APP_DIR}/docker-compose.prod.yml"
+
+compose() {
+  docker compose -f "${COMPOSE_FILE}" "$@"
+}
+
+cd "${APP_DIR}"
+
+echo "[deploy] syncing repository"
+git fetch origin main
+git reset --hard origin/main
+
+echo "[deploy] building production images"
+compose build backend nginx
+
+echo "[deploy] ensuring runtime dependencies are up"
+compose up -d redis
+
+echo "[deploy] running database migrations"
+compose run --rm backend npm run migration:run
+
+echo "[deploy] starting application services"
+compose up -d --remove-orphans backend nginx redis
+
+echo "[deploy] checking backend health"
+compose exec -T backend node -e "fetch('http://127.0.0.1:4000/health').then(async (res) => { if (!res.ok) process.exit(1); console.log(await res.text()); }).catch((error) => { console.error(error); process.exit(1); })"
+
+echo "[deploy] done"


### PR DESCRIPTION
## 관련 이슈
- Close #336 

## 개요

현재 저장소에는 CI만 구성되어 있고, `main` 반영 이후 실제 서버에 자동으로 배포하는 CD 파이프라인은 없다. 따라서 머지 후에도 서버에서 직접 `git pull`, `docker compose`, `migration` 등을 수동으로 실행해야 하며, 배포 절차가 반복적이고 실수 가능성이 있다.

이번 작업에서는 GitHub Actions를 이용해 `main` 기준 검증이 끝난 변경을 EC2 서버에 자동으로 배포하는 CD 워크플로를 추가한다. 배포 방식은 현재 운영 구조에 맞춰 서버에서 최신 코드를 동기화하고, 프로덕션 compose 빌드/기동, 마이그레이션, 헬스체크까지 수행하는 흐름으로 구성한다.

## 목표

현재 운영 서버 구조를 유지하면서, `main` 반영 후 자동으로 서버 배포가 실행되는 GitHub Actions 기반 CD 워크플로를 구축한다.

## 요구사항

- GitHub Actions에 배포용 워크플로를 추가한다.
- 배포는 `main` 기준 검증 성공 이후 실행되도록 구성한다.
- 필요 시 수동 실행도 가능해야 한다.
- 배포 워크플로는 EC2에 SSH로 접속해 서버 배포 스크립트를 실행해야 한다.
- 서버 배포 스크립트는 최신 코드 동기화, 프로덕션 이미지 빌드, 마이그레이션, 서비스 재기동, 헬스체크를 포함해야 한다.
- 현재 운영 구조(`docker-compose.prod.yml`, nginx, backend, redis)를 기준으로 동작해야 한다.
- GitHub Secrets를 통해 서버 접속 정보와 개인키를 안전하게 사용해야 한다.

## 기대 효과

- `main` 반영 이후 서버 배포를 자동화할 수 있다.
- 수동 배포 절차에서 발생하는 반복 작업과 실수 가능성을 줄일 수 있다.
- 배포 과정을 GitHub Actions 로그로 추적할 수 있다.
- 이후 운영 절차와 배포 정책을 더 일관되게 관리할 수 있다.

## 구현 전 결정사항

## 배포 기준

- 배포 트리거는 `CI 성공 후 main`을 기본으로 한다.
- `workflow_dispatch`를 통해 수동 실행도 허용한다.
- 서버 배포는 EC2 내부에서 `git fetch/reset`, `docker compose`, `migration`, `health check` 순서로 수행한다.
- 운영 env 파일은 현재 서버 구조 기준으로 `backend/.env.server`를 사용한다.
- 배포 대상 서버 정보는 GitHub Actions Secrets(`EC2_HOST`, `EC2_USER`, `EC2_PORT`, `EC2_SSH_KEY`)로 관리한다.

## 완료 조건

- GitHub Actions에 CD 워크플로가 추가되어 있다.
- 서버 배포 스크립트가 저장소에 추가되어 있다.
- `main` 기준 검증 성공 후 자동 배포가 실행될 수 있다.
- 수동 실행(`workflow_dispatch`)도 가능하다.
- 배포 스크립트가 마이그레이션과 헬스체크까지 수행한다.

