### PR TITLE
fix: 런타임 컨테이너 기준으로 마이그레이션 실행 경로를 조정

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -15,7 +15,7 @@
     "test:integration": "vitest run test/integration",
     "test:coverage": "vitest run --coverage",
     "migration:generate": "ts-node --require tsconfig-paths/register ./node_modules/typeorm/cli.js migration:generate -d src/database/data-source.ts",
-    "migration:run": "ts-node --require tsconfig-paths/register ./node_modules/typeorm/cli.js migration:run -d src/database/data-source.ts",
+    "migration:run": "node ./node_modules/typeorm/cli.js migration:run -d dist/database/data-source.js",
     "migration:revert": "ts-node --require tsconfig-paths/register ./node_modules/typeorm/cli.js migration:revert -d src/database/data-source.ts"
   },
   "keywords": [],

--- a/backend/src/database/data-source.ts
+++ b/backend/src/database/data-source.ts
@@ -1,4 +1,5 @@
 import "reflect-metadata";
+import path from "node:path";
 import { DataSource } from "typeorm";
 import { loadEnvironment } from "../config/load-env";
 import { Voter } from "../entities/voter.entity";
@@ -40,5 +41,5 @@ export const AppDataSource = new DataSource({
     RoundSummary,
     RoundSnapshot,
   ],
-  migrations: ["src/database/migrations/*.ts"],
+  migrations: [path.join(__dirname, "migrations/*.{js,ts}")],
 });


### PR DESCRIPTION
## 관련 이슈
- Close #340 

- `migration:run` 스크립트를 `ts-node` 기반 개발 경로가 아니라 런타임 컨테이너의 `dist/database/data-source.js` 기준으로 변경
- DataSource의 migration 경로를 `__dirname` 기준 `migrations/*.{js,ts}`로 수정해 빌드 후 `dist`의 migration 파일도 인식하도록 변경

## 기대 동작

- CD 배포 중 backend 컨테이너에서 `npm run migration:run`이 dev dependency 없이 정상 실행된다
- 런타임 컨테이너가 `dist` 기준 migration 파일을 읽을 수 있다
- 기존처럼 production dependency만 포함한 runner 이미지로도 migration 단계가 실패하지 않는다

## 확인 내용

- `backend: npm run build` 통과
- CD 재실행 시 `Cannot find module 'tsconfig-paths/register'` 오류가 발생하지 않는지 확인 필요
- CD migration 단계가 `dist/database/data-source.js` 기준으로 정상 완료되는지 확인 필요