### PR TITLE
fix: 스냅샷 응답과 운영 API 기준을 상대경로로 통일

### DIFF
--- a/backend/src/modules/canvas/canvas.controller.ts
+++ b/backend/src/modules/canvas/canvas.controller.ts
@@ -39,47 +39,28 @@ function serializeCell(cell: Cell) {
   };
 }
 
-function buildRoundSnapshotUrl(
-  req: Request,
-  canvasId: number,
-  roundId: number,
-): string {
-  const relativePath = roundSnapshotService.buildRoundSnapshotApiPath(
-    canvasId,
-    roundId,
-  );
-  const host = req.get("host");
-
-  return host ? `${req.protocol}://${host}${relativePath}` : relativePath;
+function buildRoundSnapshotUrl(canvasId: number, roundId: number): string {
+  return roundSnapshotService.buildRoundSnapshotApiPath(canvasId, roundId);
 }
 
 function buildRoundDownloadSnapshotUrl(
-  req: Request,
   canvasId: number,
   roundId: number,
 ): string {
-  const relativePath = roundSnapshotService.buildRoundDownloadSnapshotApiPath(
+  return roundSnapshotService.buildRoundDownloadSnapshotApiPath(
     canvasId,
     roundId,
   );
-  const host = req.get("host");
-
-  return host ? `${req.protocol}://${host}${relativePath}` : relativePath;
 }
 
 function buildRoundHighResolutionDownloadSnapshotUrl(
-  req: Request,
   canvasId: number,
   roundId: number,
 ): string {
-  const relativePath =
-    roundSnapshotService.buildRoundHighResolutionDownloadSnapshotApiPath(
-      canvasId,
-      roundId,
-    );
-  const host = req.get("host");
-
-  return host ? `${req.protocol}://${host}${relativePath}` : relativePath;
+  return roundSnapshotService.buildRoundHighResolutionDownloadSnapshotApiPath(
+    canvasId,
+    roundId,
+  );
 }
 
 // 게임 summary 응답 구조를 명시적으로 고정
@@ -216,14 +197,13 @@ export const canvasController = {
         data: serializeGameSummary(
           summary,
           snapshot?.round?.id
-            ? buildRoundSnapshotUrl(req, canvasId, snapshot.round.id)
+            ? buildRoundSnapshotUrl(canvasId, snapshot.round.id)
             : null,
           snapshot?.round?.id
-            ? buildRoundDownloadSnapshotUrl(req, canvasId, snapshot.round.id)
+            ? buildRoundDownloadSnapshotUrl(canvasId, snapshot.round.id)
             : null,
           snapshot?.round?.id
             ? buildRoundHighResolutionDownloadSnapshotUrl(
-                req,
                 canvasId,
                 snapshot.round.id,
               )

--- a/backend/src/modules/history/history.controller.ts
+++ b/backend/src/modules/history/history.controller.ts
@@ -17,18 +17,8 @@ function parseCanvasId(value: unknown): number | null {
   return canvasId;
 }
 
-function toAbsoluteUrl(req: Request, url: string | null) {
-  if (!url) {
-    return null;
-  }
-
-  if (/^https?:\/\//i.test(url)) {
-    return url;
-  }
-
-  const host = req.get("host");
-
-  return host ? `${req.protocol}://${host}${url}` : url;
+function toRelativeUrl(url: string | null) {
+  return url;
 }
 
 export const historyController = {
@@ -53,25 +43,23 @@ export const historyController = {
       ...history,
       rounds: history.rounds.map((round) => ({
         ...round,
-        snapshotUrl: toAbsoluteUrl(req, round.snapshotUrl),
+        snapshotUrl: toRelativeUrl(round.snapshotUrl),
         snapshot: round.snapshot
           ? {
               ...round.snapshot,
-              imageUrl: toAbsoluteUrl(req, round.snapshot.imageUrl),
-              snapshotUrl: toAbsoluteUrl(req, round.snapshot.snapshotUrl),
+              imageUrl: toRelativeUrl(round.snapshot.imageUrl),
+              snapshotUrl: toRelativeUrl(round.snapshot.snapshotUrl),
             }
           : null,
       })),
       gameSummary: history.gameSummary
         ? {
             ...history.gameSummary,
-            snapshotUrl: toAbsoluteUrl(req, history.gameSummary.snapshotUrl),
-            downloadSnapshotUrl: toAbsoluteUrl(
-              req,
+            snapshotUrl: toRelativeUrl(history.gameSummary.snapshotUrl),
+            downloadSnapshotUrl: toRelativeUrl(
               history.gameSummary.downloadSnapshotUrl,
             ),
-            highResolutionDownloadSnapshotUrl: toAbsoluteUrl(
-              req,
+            highResolutionDownloadSnapshotUrl: toRelativeUrl(
               history.gameSummary.highResolutionDownloadSnapshotUrl,
             ),
           }

--- a/backend/src/modules/round/round.controller.ts
+++ b/backend/src/modules/round/round.controller.ts
@@ -6,18 +6,8 @@ import { RoundSummary } from "../../entities/round-summary.entity";
 import { roundSnapshotService } from "../history/round-snapshot.service";
 import { summaryService } from "../summary/summary.service";
 
-function buildRoundSnapshotUrl(
-  req: Request,
-  canvasId: number,
-  roundId: number,
-): string {
-  const relativePath = roundSnapshotService.buildRoundSnapshotApiPath(
-    canvasId,
-    roundId,
-  );
-  const host = req.get("host");
-
-  return host ? `${req.protocol}://${host}${relativePath}` : relativePath;
+function buildRoundSnapshotUrl(canvasId: number, roundId: number): string {
+  return roundSnapshotService.buildRoundSnapshotApiPath(canvasId, roundId);
 }
 
 // 엔티티를 그대로 노출하지 않고 API 응답 필드를 명시적으로 고정
@@ -122,7 +112,7 @@ export const roundController = {
       return res.json({
         data: serializeRoundSummary(
           summary,
-          snapshot ? buildRoundSnapshotUrl(req, canvasId, roundId) : null,
+          snapshot ? buildRoundSnapshotUrl(canvasId, roundId) : null,
         ),
       });
     } catch (err) {


### PR DESCRIPTION
## 변경 내용

- 백엔드가 라운드 스냅샷 URL을 절대 URL이 아니라 상대경로로 반환하도록 수정
- 백엔드가 다운로드 스냅샷 URL과 고해상도 다운로드 URL도 상대경로로 반환하도록 수정
- 히스토리 응답에서 스냅샷 관련 URL을 절대 URL로 강제 변환하지 않도록 변경
- 프론트 production API 기준을 `/api`, 소켓 기준을 `/` 상대경로로 변경

## 기대 동작

- `votedots.space`, `www.votedots.space` 어느 호스트로 접속해도 스냅샷 요청이 현재 origin 기준으로 동작한다
- 라운드 결과 모달과 미니맵에서 같은 `snapshotUrl`을 사용해도 호스트 불일치로 인한 표시 실패가 줄어든다
- 다운로드 스냅샷 URL도 현재 접속한 origin 기준으로 요청된다

## 확인 내용

- `backend: npm run build` 통과
- `frontend: npm exec tsc -b` 통과
- 배포 후 `snapshotUrl`이 `/canvas/.../snapshot` 형태로 응답되는지 확인 필요
- `votedots.space`, `www.votedots.space` 양쪽에서 라운드 결과 모달과 미니맵 스냅샷이 정상 표시되는지 확인 필요