### PR TITLE
fix: 스냅샷 API 경로에 /api prefix를 추가

### DIFF
--- a/backend/src/modules/history/history.service.ts
+++ b/backend/src/modules/history/history.service.ts
@@ -130,21 +130,21 @@ function getRoundSummaryForSnapshot(
 }
 
 function buildRoundSnapshotApiPath(canvasId: number, roundId: number): string {
-  return `/canvas/${canvasId}/rounds/${roundId}/snapshot`;
+  return `/api/canvas/${canvasId}/rounds/${roundId}/snapshot`;
 }
 
 function buildRoundDownloadSnapshotApiPath(
   canvasId: number,
   roundId: number,
 ): string {
-  return `/canvas/${canvasId}/rounds/${roundId}/download-snapshot`;
+  return `/api/canvas/${canvasId}/rounds/${roundId}/download-snapshot`;
 }
 
 function buildRoundHighResolutionDownloadSnapshotApiPath(
   canvasId: number,
   roundId: number,
 ): string {
-  return `/canvas/${canvasId}/rounds/${roundId}/download-snapshot-hd`;
+  return `/api/canvas/${canvasId}/rounds/${roundId}/download-snapshot-hd`;
 }
 
 function getRoundSnapshotUrl(

--- a/backend/src/modules/history/round-snapshot.service.ts
+++ b/backend/src/modules/history/round-snapshot.service.ts
@@ -35,18 +35,18 @@ type RoundDownloadVariant = "grid" | "hd";
 
 export const roundSnapshotService = {
   buildRoundSnapshotApiPath(canvasId: number, roundId: number): string {
-    return `/canvas/${canvasId}/rounds/${roundId}/snapshot`;
+    return `/api/canvas/${canvasId}/rounds/${roundId}/snapshot`;
   },
 
   buildRoundDownloadSnapshotApiPath(canvasId: number, roundId: number): string {
-    return `/canvas/${canvasId}/rounds/${roundId}/download-snapshot`;
+    return `/api/canvas/${canvasId}/rounds/${roundId}/download-snapshot`;
   },
 
   buildRoundHighResolutionDownloadSnapshotApiPath(
     canvasId: number,
     roundId: number,
   ): string {
-    return `/canvas/${canvasId}/rounds/${roundId}/download-snapshot-hd`;
+    return `/api/canvas/${canvasId}/rounds/${roundId}/download-snapshot-hd`;
   },
 
   resolveRoundSnapshotAbsolutePath(snapshot: RoundSnapshot): string {

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -1,6 +1,6 @@
 server {
     listen 80;
-    server_name votedots.duckdns.org;
+    server_name votedots.space www.votedots.space;
 
     location ^~ /.well-known/acme-challenge/ {
         root /var/www/certbot;
@@ -13,13 +13,13 @@ server {
 
 server {
     listen 443 ssl http2;
-    server_name votedots.duckdns.org;
+    server_name votedots.space www.votedots.space;
 
     root /usr/share/nginx/html;
     index index.html;
 
-    ssl_certificate /etc/letsencrypt/live/votedots.duckdns.org/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/votedots.duckdns.org/privkey.pem;
+    ssl_certificate /etc/letsencrypt/live/votedots.space/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/votedots.space/privkey.pem;
 
     location / {
         try_files $uri $uri/ /index.html;


### PR DESCRIPTION
## 관련 이슈
- Close #344 

## 변경 내용

- 라운드 스냅샷 URL 생성 경로를 `/canvas/...`에서 `/api/canvas/...`로 변경
- 다운로드 스냅샷 URL 생성 경로를 `/api/canvas/...` 기준으로 변경
- 고해상도 다운로드 스냅샷 URL 생성 경로를 `/api/canvas/...` 기준으로 변경
- 히스토리/게임 요약에서 사용하는 스냅샷 관련 URL도 동일한 prefix 기준으로 통일

## 기대 동작

- 브라우저가 스냅샷 요청을 프론트 정적 경로가 아니라 nginx의 backend 프록시 경로로 올바르게 보낸다
- 라운드 결과 모달과 미니맵에서 사용하는 스냅샷 URL이 정상적으로 backend 스냅샷 엔드포인트를 가리킨다
- 다운로드 스냅샷과 고해상도 다운로드 스냅샷 URL도 동일한 프록시 구조로 동작한다

## 확인 내용

- `backend: npm run build` 통과
- 배포 후 `snapshotUrl`이 `/api/canvas/.../snapshot` 형태로 응답되는지 확인 필요
- 라운드 결과 모달, 게임 결과 모달, 미니맵에서 스냅샷이 정상 표시되는지 확인 필요
- 다운로드 스냅샷 URL도 정상적으로 열리는지 확인 필요