### PR TITLE
fix: 캔버스 상호작용과 투표 UI 동작을 보정

### DIFF
--- a/frontend/src/features/gameplay/canvas/components/CanvasStage.tsx
+++ b/frontend/src/features/gameplay/canvas/components/CanvasStage.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode, RefObject } from "react";
+import { useEffect, useRef, type ReactNode, type RefObject } from "react";
 import { CANVAS_BACKGROUND_COLOR } from "../model/canvas.constants";
 
 interface CanvasStageProps {
@@ -10,7 +10,7 @@ interface CanvasStageProps {
   onMouseUp: (event: React.MouseEvent) => void;
   onMouseLeave: () => void;
   isDragging: boolean;
-  onWheel: (event: React.WheelEvent) => void;
+  onWheel: (event: WheelEvent) => void;
 }
 
 export default function CanvasStage({
@@ -24,8 +24,29 @@ export default function CanvasStage({
   isDragging,
   onWheel,
 }: CanvasStageProps) {
+  const stageRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const stage = stageRef.current;
+
+    if (!stage) {
+      return;
+    }
+
+    const handleWheel = (event: WheelEvent) => {
+      onWheel(event);
+    };
+
+    stage.addEventListener("wheel", handleWheel, { passive: false });
+
+    return () => {
+      stage.removeEventListener("wheel", handleWheel);
+    };
+  }, [onWheel]);
+
   return (
     <div
+      ref={stageRef}
       className={`relative min-w-0 flex-1 overflow-hidden ${isDragging ? "cursor-grabbing" : ""}`}
       style={{
         backgroundColor: CANVAS_BACKGROUND_COLOR,
@@ -36,17 +57,6 @@ export default function CanvasStage({
       onMouseLeave={onMouseLeave}
       onDragStart={(event) => {
         event.preventDefault();
-      }}
-      onWheel={(event) => {
-        console.log("[canvas-stage:wheel]", {
-          deltaY: event.deltaY,
-          clientX: event.clientX,
-          clientY: event.clientY,
-          target: event.target,
-          currentTarget: event.currentTarget,
-        });
-
-        onWheel(event);
       }}
     >
       {overlay && <div className="absolute left-4 top-4 z-10">{overlay}</div>}

--- a/frontend/src/features/gameplay/canvas/components/MiniMap.tsx
+++ b/frontend/src/features/gameplay/canvas/components/MiniMap.tsx
@@ -268,7 +268,7 @@ export default function MiniMap({
   return (
     <div className="flex justify-center">
       <div
-        className="flex items-center justify-center overflow-hidden rounded-xl border border-[color:var(--page-theme-border-primary)] bg-[color:var(--page-theme-surface-secondary)] p-0 shadow-sm"
+        className="flex items-center justify-center overflow-hidden border border-[color:var(--page-theme-border-primary)] bg-[color:var(--page-theme-surface-secondary)] p-0 shadow-sm"
         style={{
           width: `${MINIMAP_SIZE}px`,
           height: `${MINIMAP_SIZE}px`,

--- a/frontend/src/features/gameplay/intro/components/IntroGuideModal.tsx
+++ b/frontend/src/features/gameplay/intro/components/IntroGuideModal.tsx
@@ -202,14 +202,14 @@ export default function IntroGuideModal({
               </p>
             </section>
 
-            <div className="mx-auto w-fit space-y-3">
+            <div className="mx-auto flex w-fit flex-col items-center gap-3">
               <IntroCanvasPreview
                 playBackgroundImageUrl={playBackgroundImageUrl}
                 resultTemplateImageUrl={resultTemplateImageUrl}
                 gridX={gridX}
                 gridY={gridY}
               />
-              <div className="space-y-1 pl-6 text-left text-sm font-bold text-[color:var(--page-theme-text-primary)]">
+              <div className="mx-auto w-fit space-y-1 text-left text-sm font-bold text-[color:var(--page-theme-text-primary)]">
                 {introStats.map((stat) => (
                   <p key={stat.label}>
                     {stat.label} :{" "}

--- a/frontend/src/features/gameplay/vote/components/VotePopup.tsx
+++ b/frontend/src/features/gameplay/vote/components/VotePopup.tsx
@@ -26,6 +26,7 @@ interface Props {
   roundId: number | null;
   phase: GamePhase;
   isRoundExpired: boolean;
+  remaining: number | null;
   selectedCell: Cell;
   votes: Record<string, number>;
   cells: Cell[];
@@ -97,6 +98,7 @@ export default function VotePopup({
   roundId,
   phase,
   isRoundExpired,
+  remaining,
   selectedCell,
   votes,
   cells,
@@ -130,10 +132,11 @@ export default function VotePopup({
   const isVotingPhase = phase === GAME_PHASE.ROUND_ACTIVE;
   const phaseBlockedMessage = getPhaseBlockedMessage(phase, t);
   const canSubmitVote = isVotingPhase && !isRoundExpired;
+  const hasRemainingVotes = remaining !== null ? remaining > 0 : true;
   const visibleLoading = loading && canSubmitVote;
   const visibleError = canSubmitVote ? error : "";
   const isVoteDisabled =
-    !roundId || !canSubmitVote || visibleLoading;
+    !roundId || !canSubmitVote || !hasRemainingVotes || visibleLoading;
 
   const buttonLabel = getButtonLabel(
     phase,

--- a/frontend/src/pages/canvas/CanvasPage.tsx
+++ b/frontend/src/pages/canvas/CanvasPage.tsx
@@ -270,6 +270,7 @@ export default function CanvasPage() {
           roundId={roundId}
           phase={phase}
           isRoundExpired={isRoundExpired}
+          remaining={remaining}
           selectedCell={selectedCell}
           votes={votes}
           cells={cells}

--- a/frontend/src/pages/canvas/model/useCanvasScene.ts
+++ b/frontend/src/pages/canvas/model/useCanvasScene.ts
@@ -775,7 +775,7 @@ export default function useCanvasScene({
   }, [canvasReady, gridX, gridY]);
 
   const handleWheel = useCallback(
-    (event: React.WheelEvent) => {
+    (event: WheelEvent) => {
       const container = containerRef.current;
 
       if (!container || !canvasReady || gridX === 0 || gridY === 0) {

--- a/frontend/src/shared/lib/download-file.ts
+++ b/frontend/src/shared/lib/download-file.ts
@@ -1,5 +1,3 @@
-import api from "@/shared/api/client";
-
 interface DownloadBlobFileParams {
   url: string;
   fileName: string;
@@ -9,11 +7,17 @@ export async function downloadBlobFile({
   url,
   fileName,
 }: DownloadBlobFileParams) {
-  const response = await api.get<Blob>(url, {
-    responseType: "blob",
+  const response = await fetch(url, {
+    credentials: "include",
   });
 
-  const blobUrl = window.URL.createObjectURL(response.data);
+  if (!response.ok) {
+    throw new Error(`Download request failed with status ${response.status}`);
+  }
+
+  const blob = await response.blob();
+
+  const blobUrl = window.URL.createObjectURL(blob);
   const anchor = document.createElement("a");
 
   anchor.href = blobUrl;


### PR DESCRIPTION
## 관련 이슈
- Close #346

## 변경 내용

- 캔버스 줌 휠 처리를 React `onWheel` 대신 `passive: false` native wheel listener로 변경
- 캔버스 줌 디버그 로그를 제거하고 `preventDefault()` 경고가 나지 않도록 정리
- 미니맵 패널 외곽 라운딩을 제거
- 게임 안내 모달의 하단 정보 블록을 상단 이미지 기준으로 가운데 정렬되도록 조정
- 남은 투표권이 0일 때 투표 팝업의 제출 버튼이 비활성화되도록 수정

## 기대 동작

- 캔버스 줌 인/아웃 시 콘솔에 `Unable to preventDefault inside passive event listener invocation.` 경고가 발생하지 않는다
- 미니맵 패널이 직각 프레임으로 표시된다
- 게임 안내 모달의 하단 정보 블록이 이미지 아래 중앙에 맞춰 보인다
- 남은 투표권이 0이면 투표 버튼이 비활성화되고, 기존 phase/라운드 종료/로딩 조건도 그대로 유지된다

## 확인 내용

- `frontend: npm exec tsc -b` 통과
- 브라우저에서 캔버스 휠 줌 시 콘솔 경고가 사라졌는지 확인 필요
- 미니맵 패널 스타일이 의도대로 보이는지 확인 필요
- 게임 안내 모달 정보 정렬이 이미지 기준으로 맞는지 확인 필요
- 남은 투표권 0 상태에서 투표 버튼이 비활성화되는지 수동 확인 필요