### PR TITLE
fix: 로그인 보드와 게임 결과 모달 UI를 정리

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -19,6 +19,7 @@
         "react-dom": "^19.2.4",
         "react-markdown": "^10.1.0",
         "react-router-dom": "^6.28.0",
+        "remark-breaks": "^4.0.0",
         "shadcn": "^4.1.0",
         "socket.io-client": "^4.8.3",
         "tailwind-merge": "^3.5.0",
@@ -6252,6 +6253,34 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/mdast-util-find-and-replace": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
+      "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "escape-string-regexp": "^5.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/mdast-util-from-markdown": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
@@ -6330,6 +6359,20 @@
         "devlop": "^1.0.0",
         "mdast-util-from-markdown": "^2.0.0",
         "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-newline-to-break": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-newline-to-break/-/mdast-util-newline-to-break-2.0.0.tgz",
+      "integrity": "sha512-MbgeFca0hLYIEx/2zGsszCSEJJ1JSCdiY5xQxRcLDDGa8EPvlLPupJ4DSajbMPAnC0je8jfb9TiUATnxxrHUog==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-find-and-replace": "^3.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -7855,6 +7898,21 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/remark-breaks": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/remark-breaks/-/remark-breaks-4.0.0.tgz",
+      "integrity": "sha512-IjEjJOkH4FuJvHZVIW0QCDWxcG96kCq7An/KVH2NfJe6rKZU2AsHeB3OEjPNRxi4QC34Xdx7I2KGYn6IpT7gxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-newline-to-break": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/remark-parse": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -25,6 +25,7 @@
     "react-dom": "^19.2.4",
     "react-markdown": "^10.1.0",
     "react-router-dom": "^6.28.0",
+    "remark-breaks": "^4.0.0",
     "shadcn": "^4.1.0",
     "socket.io-client": "^4.8.3",
     "tailwind-merge": "^3.5.0",

--- a/frontend/src/features/gameplay/session/components/GameSummaryModal.tsx
+++ b/frontend/src/features/gameplay/session/components/GameSummaryModal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, type ReactNode } from "react";
+import { useEffect, type MouseEvent, type ReactNode } from "react";
 import type {
   GameSummaryData,
   GameSummaryParticipant,
@@ -13,6 +13,7 @@ interface GameSummaryModalProps {
   snapshotUrl?: string | null;
   playBackgroundImageUrl?: string | null;
   position: { x: number; y: number };
+  onDragStart: (event: MouseEvent<HTMLDivElement>) => void;
   onClose: () => void;
 }
 
@@ -111,6 +112,7 @@ export default function GameSummaryModal({
   snapshotUrl,
   playBackgroundImageUrl,
   position,
+  onDragStart,
   onClose,
 }: GameSummaryModalProps) {
   const { formatNumber, formatPercent, locale, t } = useI18n();
@@ -172,7 +174,10 @@ export default function GameSummaryModal({
         onMouseDown={(event) => event.stopPropagation()}
         onClick={(event) => event.stopPropagation()}
       >
-        <div className="relative flex items-center justify-center border-b border-[color:var(--page-theme-border-secondary)] px-5 py-4">
+        <div
+          className="relative flex cursor-move items-center justify-center border-b border-[color:var(--page-theme-border-secondary)] px-5 py-4"
+          onMouseDown={onDragStart}
+        >
           <p className="text-center text-lg font-bold text-[color:var(--page-theme-primary-action)]">
             {t("gameSummary.title")}
           </p>

--- a/frontend/src/features/login-board/components/LoginBoardPanel.tsx
+++ b/frontend/src/features/login-board/components/LoginBoardPanel.tsx
@@ -51,22 +51,17 @@ export default function LoginBoardPanel() {
 
   return (
     <div className="flex h-full min-h-screen flex-col px-5 py-6 text-left lg:px-7 lg:py-8">
-      <div className="space-y-3">
-        <div className="space-y-1.5">
-          <p className="text-sm font-medium text-[color:var(--color-text-tertiary)]">
-            {t("loginBoard.subtitle")}
-          </p>
-          <h1 className="m-0 text-[2rem] font-semibold tracking-tight text-[color:var(--color-text-primary)]">
-            {t("loginBoard.title")}
-          </h1>
-        </div>
-
+      <div>
         <div className="inline-flex w-fit items-center gap-1 rounded-lg border-[0.5px] border-[color:var(--color-border-primary)] bg-[color:var(--color-background-secondary)] p-1">
           <Button
             type="button"
             variant={activeTab === "patches" ? "secondary" : "ghost"}
             size="sm"
-            className="rounded-md px-3 text-[13px]"
+            className={`rounded-md px-4 py-2 text-sm font-semibold ${
+              activeTab === "patches"
+                ? "border-[color:var(--color-border-primary)] bg-[color:var(--color-background-primary)] text-[color:var(--color-text-primary)] shadow-sm"
+                : "text-[color:var(--color-text-secondary)]"
+            }`}
             onClick={() => setActiveTab("patches")}
           >
             {t("loginBoard.tab.patches")}
@@ -75,7 +70,11 @@ export default function LoginBoardPanel() {
             type="button"
             variant={activeTab === "roadmap" ? "secondary" : "ghost"}
             size="sm"
-            className="rounded-md px-3 text-[13px]"
+            className={`rounded-md px-4 py-2 text-sm font-semibold ${
+              activeTab === "roadmap"
+                ? "border-[color:var(--color-border-primary)] bg-[color:var(--color-background-primary)] text-[color:var(--color-text-primary)] shadow-sm"
+                : "text-[color:var(--color-text-secondary)]"
+            }`}
             onClick={() => setActiveTab("roadmap")}
           >
             {t("loginBoard.tab.roadmap")}

--- a/frontend/src/features/login-board/components/MarkdownContent.tsx
+++ b/frontend/src/features/login-board/components/MarkdownContent.tsx
@@ -1,4 +1,5 @@
 import ReactMarkdown from "react-markdown";
+import remarkBreaks from "remark-breaks";
 import { cn } from "@/shared/utils";
 
 interface MarkdownContentProps {
@@ -17,7 +18,7 @@ export default function MarkdownContent({
         className,
       )}
     >
-      <ReactMarkdown>{content}</ReactMarkdown>
+      <ReactMarkdown remarkPlugins={[remarkBreaks]}>{content}</ReactMarkdown>
     </div>
   );
 }

--- a/frontend/src/features/login-board/components/PatchNotesPanel.tsx
+++ b/frontend/src/features/login-board/components/PatchNotesPanel.tsx
@@ -153,7 +153,7 @@ export default function PatchNotesPanel({ groups }: PatchNotesPanelProps) {
                               </span>
                             </div>
 
-                            <h3 className="m-0 text-base font-semibold text-[color:var(--color-text-primary)]">
+                            <h3 className="m-0 text-2xl font-semibold tracking-tight text-[color:var(--color-text-primary)]">
                               {item.title}
                             </h3>
 

--- a/frontend/src/features/login-board/components/RoadmapPanel.tsx
+++ b/frontend/src/features/login-board/components/RoadmapPanel.tsx
@@ -136,7 +136,7 @@ export default function RoadmapPanel({ groups }: RoadmapPanelProps) {
                             </div>
 
                             <div>
-                              <h3 className="m-0 text-base font-semibold text-[color:var(--color-text-primary)]">
+                              <h3 className="m-0 text-2xl font-semibold tracking-tight text-[color:var(--color-text-primary)]">
                                 {item.title}
                               </h3>
                               <p className="mt-1 text-sm leading-6 text-[color:var(--color-text-tertiary)]">

--- a/frontend/src/pages/canvas/CanvasPage.tsx
+++ b/frontend/src/pages/canvas/CanvasPage.tsx
@@ -297,6 +297,7 @@ export default function CanvasPage() {
           snapshotUrl={latestRoundSnapshot}
           playBackgroundImageUrl={playBackgroundImageUrl}
           position={roundSummaryPosition}
+          onDragStart={handleRoundSummaryDragStart}
           onClose={handleCloseGameSummaryModal}
         />
       )}

--- a/frontend/src/shared/i18n/resources.ts
+++ b/frontend/src/shared/i18n/resources.ts
@@ -151,9 +151,9 @@ export const resources: Record<Locale, Record<string, string>> = {
     "gameSummary.downloadRetry": "이미지 다시 시도",
     "gameSummary.downloadError": "이미지 다운로드에 실패했습니다. 다시 시도해 주세요.",
     "gameSummary.downloading": "다운로드 중...",
-    "gameSummary.downloadHd": "고화질 다운로드",
-    "gameSummary.downloadHdRetry": "고화질 다시 시도",
-    "gameSummary.downloadingHd": "고화질 다운로드 중...",
+    "gameSummary.downloadHd": "HD 다운로드",
+    "gameSummary.downloadHdRetry": "HD 다시 시도",
+    "gameSummary.downloadingHd": "HD 다운로드 중...",
     "gameSummary.stat.totalRounds": "총 라운드 수",
     "gameSummary.stat.participants": "투표 인원 수",
     "gameSummary.stat.ticketUsage": "투표권 사용률",
@@ -212,7 +212,7 @@ export const resources: Record<Locale, Record<string, string>> = {
     "coordinate.numbersOnly": "X, Y 좌표는 숫자만 입력할 수 있습니다.",
     "coordinate.range": "이동 가능한 범위는 X: 0-{{maxX}}, Y: 0-{{maxY}} 입니다.",
 
-    "loginBoard.title": "패치 내역 & 로드맵",
+    "loginBoard.title": "업데이트 보드",
     "loginBoard.subtitle": "업데이트 보드",
     "loginBoard.tab.patches": "패치 내역",
     "loginBoard.tab.roadmap": "로드맵",
@@ -433,7 +433,7 @@ export const resources: Record<Locale, Record<string, string>> = {
     "coordinate.range":
       "The available range is X: 0-{{maxX}}, Y: 0-{{maxY}}.",
 
-    "loginBoard.title": "Patch Notes & Roadmap",
+    "loginBoard.title": "Update Board",
     "loginBoard.subtitle": "Update board",
     "loginBoard.tab.patches": "Patch Notes",
     "loginBoard.tab.roadmap": "Roadmap",


### PR DESCRIPTION
## 관련 이슈
- Close #348 

## 변경 내용

- 로그인 보드 제목을 "업데이트 보드" 기준으로 정리하고 상단 헤더 영역을 제거
- 로그인 보드 탭 버튼 크기를 키우고, 선택된 탭이 더 잘 보이도록 활성 스타일을 강화
- 패치/로드맵 상세 카드의 상단 제목 크기를 키워 본문 소제목보다 더 크게 보이도록 조정
- 로그인 보드 Markdown 렌더러에 `remark-breaks`를 적용해 일반 줄바꿈이 반영되도록 수정
- 게임 결과 모달의 이미지 다운로드 문구를 "고화질" 대신 "HD" 표기로 변경
- 게임 결과 모달이 라운드 결과 모달과 동일하게 드래그 이동 가능하도록 수정

## 기대 동작

- 로그인 보드 상단은 탭 영역부터 바로 시작하고, 선택된 탭이 시각적으로 더 분명하게 보인다
- 패치/로드맵 상세 제목이 본문 소제목보다 더 크게 표시된다
- 로그인 보드 Markdown 본문에서 일반 줄바꿈이 반영된다
- 게임 결과 모달의 다운로드 버튼 문구가 "HD" 기준으로 보인다
- 게임 결과 모달을 헤더 영역에서 드래그 이동할 수 있다

## 확인 내용

- `frontend: npm exec tsc -b` 통과
- 로그인 보드 탭 크기와 활성 스타일 수동 확인 필요
- 패치/로드맵 상세 제목 크기 수동 확인 필요
- 로그인 보드 Markdown 줄바꿈 반영 수동 확인 필요
- 게임 결과 모달 드래그 이동 동작 수동 확인 필요
- 게임 결과 모달 다운로드 문구가 "HD"로 표시되는지 확인 필요