### PR TITLE
chore: AdSense ads.txt 정적 파일을 추가

### DIFF
--- a/frontend/public/ads.txt
+++ b/frontend/public/ads.txt
@@ -1,0 +1,1 @@
+google.com, pub-4187205008561363, DIRECT, f08c47fec0942fa0


### PR DESCRIPTION
## 관련 이슈
- Close #351 

## 변경 내용

- 프론트 정적 자산 경로에 `ads.txt` 파일 추가
- AdSense 퍼블리셔 ID `pub-4187205008561363` 기준 레코드 반영
- 배포 후 사이트 루트 `/ads.txt`에서 접근 가능하도록 구성

## 기대 동작

- `https://votedots.space/ads.txt` 경로에서 `ads.txt` 파일이 정상 응답한다
- 필요 시 `https://www.votedots.space/ads.txt`에서도 같은 파일이 제공된다
- AdSense의 `ads.txt를 찾을 수 없음` 경고 해소 기준을 충족한다

## 확인 내용

- `frontend/public/ads.txt` 파일 추가 확인
- 배포 후 `/ads.txt` 경로 직접 확인 필요
- AdSense 관리자에서 안내한 레코드와 파일 내용이 일치하는지 확인 필요