### PR TITLE
fix: 로그인 보드 markdown 본문 스타일을 사용자 테마와 분리

### DIFF
--- a/frontend/src/features/gameplay/canvas/components/MiniMap.tsx
+++ b/frontend/src/features/gameplay/canvas/components/MiniMap.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef } from "react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
 import { MINIMAP_SIZE } from "../model/canvas.constants";
 import { Cell, Viewport } from "../model/canvas.types";
 
@@ -222,29 +222,32 @@ export default function MiniMap({
     viewport,
   ]);
 
-  const navigateFromPointer = (
-    clientX: number,
-    clientY: number,
-    behavior: ScrollBehavior = "auto",
-  ) => {
-    const canvas = canvasRef.current;
-    if (!canvas) return;
+  const navigateFromPointer = useCallback(
+    (
+      clientX: number,
+      clientY: number,
+      behavior: ScrollBehavior = "auto",
+    ) => {
+      const canvas = canvasRef.current;
+      if (!canvas) return;
 
-    const rect = canvas.getBoundingClientRect();
-    const relativeX = Math.min(Math.max(clientX - rect.left, 0), rect.width);
-    const relativeY = Math.min(Math.max(clientY - rect.top, 0), rect.height);
+      const rect = canvas.getBoundingClientRect();
+      const relativeX = Math.min(Math.max(clientX - rect.left, 0), rect.width);
+      const relativeY = Math.min(Math.max(clientY - rect.top, 0), rect.height);
 
-    const nextX = Math.min(
-      gridX - 1,
-      Math.max(0, Math.floor((relativeX / rect.width) * gridX)),
-    );
-    const nextY = Math.min(
-      gridY - 1,
-      Math.max(0, Math.floor((relativeY / rect.height) * gridY)),
-    );
+      const nextX = Math.min(
+        gridX - 1,
+        Math.max(0, Math.floor((relativeX / rect.width) * gridX)),
+      );
+      const nextY = Math.min(
+        gridY - 1,
+        Math.max(0, Math.floor((relativeY / rect.height) * gridY)),
+      );
 
-    onNavigate(nextX, nextY, behavior);
-  };
+      onNavigate(nextX, nextY, behavior);
+    },
+    [gridX, gridY, onNavigate],
+  );
 
   useEffect(() => {
     const handleMouseMove = (event: MouseEvent) => {
@@ -263,7 +266,7 @@ export default function MiniMap({
       window.removeEventListener("mousemove", handleMouseMove);
       window.removeEventListener("mouseup", handleMouseUp);
     };
-  }, [gridX, gridY, onNavigate]);
+  }, [navigateFromPointer]);
 
   return (
     <div className="flex justify-center">

--- a/frontend/src/features/gameplay/session/components/MyInfoCard.tsx
+++ b/frontend/src/features/gameplay/session/components/MyInfoCard.tsx
@@ -51,7 +51,7 @@ export default function MyInfoCard({ participants }: MyInfoCardProps) {
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [t]);
 
   const handleLogout = async () => {
     setLogoutLoading(true);

--- a/frontend/src/features/gameplay/vote/components/ColorPalette.tsx
+++ b/frontend/src/features/gameplay/vote/components/ColorPalette.tsx
@@ -6,6 +6,16 @@ import eyedropperIcon from "@/assets/eyedropper-icon.png";
 const CHECKER_PATTERN =
   "linear-gradient(45deg, #d1d5db 25%, transparent 25%, transparent 75%, #d1d5db 75%, #d1d5db), linear-gradient(45deg, #d1d5db 25%, transparent 25%, transparent 75%, #d1d5db 75%, #d1d5db)";
 
+type EyeDropperResult = {
+  sRGBHex: string;
+};
+
+type EyeDropperInstance = {
+  open: () => Promise<EyeDropperResult>;
+};
+
+type EyeDropperConstructor = new () => EyeDropperInstance;
+
 interface Props {
   selected: string;
   onChange: (color: string) => void;
@@ -36,10 +46,12 @@ export default function ColorPalette({
 
   const handleEyeDropper = async (e: React.MouseEvent) => {
     e.stopPropagation();
-    if (!("EyeDropper" in window)) return;
+    const eyeDropperCtor = (window as Window & {
+      EyeDropper?: EyeDropperConstructor;
+    }).EyeDropper;
+    if (!eyeDropperCtor) return;
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const eyeDropper = new (window as any).EyeDropper();
+    const eyeDropper = new eyeDropperCtor();
 
     try {
       const result = await eyeDropper.open();

--- a/frontend/src/features/gameplay/vote/components/VotePopup.tsx
+++ b/frontend/src/features/gameplay/vote/components/VotePopup.tsx
@@ -228,6 +228,8 @@ export default function VotePopup({
     isVotingPhase,
     phaseBlockedMessage,
     isRoundExpired,
+    locale,
+    t,
     color,
     canvasId,
     selectedCell.x,
@@ -353,12 +355,11 @@ export default function VotePopup({
 
   useEffect(() => {
     onColorChange(color);
-    return () => onColorChange(null);
-  }, []);
+  }, [color, onColorChange, selectedCell.x, selectedCell.y]);
 
   useEffect(() => {
-    onColorChange(color);
-  }, [color, onColorChange, selectedCell.x, selectedCell.y]);
+    return () => onColorChange(null);
+  }, [onColorChange]);
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {

--- a/frontend/src/features/login-board/components/MarkdownContent.tsx
+++ b/frontend/src/features/login-board/components/MarkdownContent.tsx
@@ -14,11 +14,83 @@ export default function MarkdownContent({
   return (
     <div
       className={cn(
-        "text-left text-sm leading-7 text-[color:var(--color-text-secondary)] [&_a]:font-medium [&_a]:text-[color:var(--color-text-primary)] [&_a]:underline [&_a]:decoration-[color:var(--color-border-primary)] [&_a]:underline-offset-4 [&_blockquote]:mb-5 [&_blockquote]:border-l-2 [&_blockquote]:border-[color:var(--color-border-primary)] [&_blockquote]:pl-4 [&_blockquote]:text-[color:var(--color-text-tertiary)] [&_code]:rounded-md [&_code]:bg-[color:var(--color-background-secondary)] [&_code]:px-1.5 [&_code]:py-0.5 [&_code]:text-[0.92em] [&_code]:text-[color:var(--color-text-primary)] [&_h1]:mb-4 [&_h1]:text-2xl [&_h1]:font-semibold [&_h1]:tracking-tight [&_h1]:text-[color:var(--color-text-primary)] [&_h2]:mb-3 [&_h2]:mt-8 [&_h2]:text-lg [&_h2]:font-semibold [&_h2]:text-[color:var(--color-text-primary)] [&_h3]:mb-2 [&_h3]:mt-6 [&_h3]:text-base [&_h3]:font-semibold [&_h3]:text-[color:var(--color-text-primary)] [&_hr]:my-6 [&_hr]:border-[color:var(--color-border-primary)] [&_li]:pl-1 [&_ol]:mb-4 [&_ol]:list-decimal [&_ol]:space-y-1.5 [&_ol]:pl-5 [&_p]:mb-4 [&_p:last-child]:mb-0 [&_pre]:thin-scrollbar [&_pre]:mb-4 [&_pre]:overflow-x-auto [&_pre]:rounded-lg [&_pre]:bg-[color:var(--color-background-secondary)] [&_pre]:p-4 [&_pre]:text-sm [&_pre]:text-[color:var(--color-text-primary)] [&_pre_code]:bg-transparent [&_pre_code]:p-0 [&_pre_code]:text-inherit [&_strong]:font-semibold [&_strong]:text-[color:var(--color-text-primary)] [&_ul]:mb-4 [&_ul]:list-disc [&_ul]:space-y-1.5 [&_ul]:pl-5",
+        "text-left text-sm leading-7 text-[#4b5563] [&_a]:font-medium [&_a]:text-[#111827] [&_a]:underline [&_a]:decoration-[#d1d5db] [&_a]:underline-offset-4 [&_blockquote]:mb-5 [&_blockquote]:border-l-2 [&_blockquote]:border-[#d1d5db] [&_blockquote]:pl-4 [&_blockquote]:text-[#6b7280] [&_code]:rounded-md [&_code]:bg-[#f3f4f6] [&_code]:px-1.5 [&_code]:py-0.5 [&_code]:text-[0.92em] [&_code]:text-[#111827] [&_h1]:mb-4 [&_h1]:text-2xl [&_h1]:font-semibold [&_h1]:tracking-tight [&_h1]:text-[#111827] [&_h2]:mb-3 [&_h2]:mt-8 [&_h2]:text-lg [&_h2]:font-semibold [&_h2]:text-[#111827] [&_h3]:mb-2 [&_h3]:mt-6 [&_h3]:text-base [&_h3]:font-semibold [&_h3]:text-[#111827] [&_hr]:my-6 [&_hr]:border-[#d1d5db] [&_li]:pl-1 [&_ol]:mb-4 [&_ol]:list-decimal [&_ol]:space-y-1.5 [&_ol]:pl-5 [&_p]:mb-4 [&_p:last-child]:mb-0 [&_pre]:thin-scrollbar [&_pre]:mb-4 [&_pre]:overflow-x-auto [&_pre]:rounded-lg [&_pre]:bg-[#f3f4f6] [&_pre]:p-4 [&_pre]:text-sm [&_pre]:text-[#111827] [&_pre_code]:bg-transparent [&_pre_code]:p-0 [&_pre_code]:text-inherit [&_strong]:font-semibold [&_strong]:text-[#111827] [&_ul]:mb-4 [&_ul]:list-disc [&_ul]:space-y-1.5 [&_ul]:pl-5",
         className,
       )}
     >
-      <ReactMarkdown remarkPlugins={[remarkBreaks]}>{content}</ReactMarkdown>
+      <ReactMarkdown
+        remarkPlugins={[remarkBreaks]}
+        components={{
+          h1: ({ node: _node, ...props }) => (
+            <h1
+              style={{ color: "#111827" }}
+              {...props}
+            />
+          ),
+          h2: ({ node: _node, ...props }) => (
+            <h2
+              style={{ color: "#111827" }}
+              {...props}
+            />
+          ),
+          h3: ({ node: _node, ...props }) => (
+            <h3
+              style={{ color: "#111827" }}
+              {...props}
+            />
+          ),
+          p: ({ node: _node, ...props }) => (
+            <p
+              style={{ color: "#4b5563" }}
+              {...props}
+            />
+          ),
+          li: ({ node: _node, ...props }) => (
+            <li
+              style={{ color: "#4b5563" }}
+              {...props}
+            />
+          ),
+          a: ({ node: _node, ...props }) => (
+            <a
+              style={{ color: "#111827" }}
+              {...props}
+            />
+          ),
+          strong: ({ node: _node, ...props }) => (
+            <strong
+              style={{ color: "#111827" }}
+              {...props}
+            />
+          ),
+          blockquote: ({ node: _node, ...props }) => (
+            <blockquote
+              style={{ color: "#6b7280", borderColor: "#d1d5db" }}
+              {...props}
+            />
+          ),
+          code: ({ node: _node, ...props }) => (
+            <code
+              style={{ color: "#111827", backgroundColor: "#f3f4f6" }}
+              {...props}
+            />
+          ),
+          pre: ({ node: _node, ...props }) => (
+            <pre
+              style={{ color: "#111827", backgroundColor: "#f3f4f6" }}
+              {...props}
+            />
+          ),
+          hr: ({ node: _node, ...props }) => (
+            <hr
+              style={{ borderColor: "#d1d5db" }}
+              {...props}
+            />
+          ),
+        }}
+      >
+        {content}
+      </ReactMarkdown>
     </div>
   );
 }

--- a/frontend/src/features/login-board/components/MarkdownContent.tsx
+++ b/frontend/src/features/login-board/components/MarkdownContent.tsx
@@ -21,72 +21,105 @@ export default function MarkdownContent({
       <ReactMarkdown
         remarkPlugins={[remarkBreaks]}
         components={{
-          h1: ({ node: _node, ...props }) => (
-            <h1
-              style={{ color: "#111827" }}
-              {...props}
-            />
-          ),
-          h2: ({ node: _node, ...props }) => (
-            <h2
-              style={{ color: "#111827" }}
-              {...props}
-            />
-          ),
-          h3: ({ node: _node, ...props }) => (
-            <h3
-              style={{ color: "#111827" }}
-              {...props}
-            />
-          ),
-          p: ({ node: _node, ...props }) => (
-            <p
-              style={{ color: "#4b5563" }}
-              {...props}
-            />
-          ),
-          li: ({ node: _node, ...props }) => (
-            <li
-              style={{ color: "#4b5563" }}
-              {...props}
-            />
-          ),
-          a: ({ node: _node, ...props }) => (
-            <a
-              style={{ color: "#111827" }}
-              {...props}
-            />
-          ),
-          strong: ({ node: _node, ...props }) => (
-            <strong
-              style={{ color: "#111827" }}
-              {...props}
-            />
-          ),
-          blockquote: ({ node: _node, ...props }) => (
-            <blockquote
-              style={{ color: "#6b7280", borderColor: "#d1d5db" }}
-              {...props}
-            />
-          ),
-          code: ({ node: _node, ...props }) => (
-            <code
-              style={{ color: "#111827", backgroundColor: "#f3f4f6" }}
-              {...props}
-            />
-          ),
-          pre: ({ node: _node, ...props }) => (
-            <pre
-              style={{ color: "#111827", backgroundColor: "#f3f4f6" }}
-              {...props}
-            />
-          ),
-          hr: ({ node: _node, ...props }) => (
-            <hr
-              style={{ borderColor: "#d1d5db" }}
-              {...props}
-            />
-          ),
+          h1: ({ node, ...props }) => {
+            void node;
+            return (
+              <h1
+                style={{ color: "#111827" }}
+                {...props}
+              />
+            );
+          },
+          h2: ({ node, ...props }) => {
+            void node;
+            return (
+              <h2
+                style={{ color: "#111827" }}
+                {...props}
+              />
+            );
+          },
+          h3: ({ node, ...props }) => {
+            void node;
+            return (
+              <h3
+                style={{ color: "#111827" }}
+                {...props}
+              />
+            );
+          },
+          p: ({ node, ...props }) => {
+            void node;
+            return (
+              <p
+                style={{ color: "#4b5563" }}
+                {...props}
+              />
+            );
+          },
+          li: ({ node, ...props }) => {
+            void node;
+            return (
+              <li
+                style={{ color: "#4b5563" }}
+                {...props}
+              />
+            );
+          },
+          a: ({ node, ...props }) => {
+            void node;
+            return (
+              <a
+                style={{ color: "#111827" }}
+                {...props}
+              />
+            );
+          },
+          strong: ({ node, ...props }) => {
+            void node;
+            return (
+              <strong
+                style={{ color: "#111827" }}
+                {...props}
+              />
+            );
+          },
+          blockquote: ({ node, ...props }) => {
+            void node;
+            return (
+              <blockquote
+                style={{ color: "#6b7280", borderColor: "#d1d5db" }}
+                {...props}
+              />
+            );
+          },
+          code: ({ node, ...props }) => {
+            void node;
+            return (
+              <code
+                style={{ color: "#111827", backgroundColor: "#f3f4f6" }}
+                {...props}
+              />
+            );
+          },
+          pre: ({ node, ...props }) => {
+            void node;
+            return (
+              <pre
+                style={{ color: "#111827", backgroundColor: "#f3f4f6" }}
+                {...props}
+              />
+            );
+          },
+          hr: ({ node, ...props }) => {
+            void node;
+            return (
+              <hr
+                style={{ borderColor: "#d1d5db" }}
+                {...props}
+              />
+            );
+          },
         }}
       >
         {content}


### PR DESCRIPTION
## 관련 이슈
- Close #352 

## 변경 내용

- 로그인 보드 Markdown 렌더링에 `remark-breaks`를 적용해 일반 줄바꿈이 반영되도록 수정
- Markdown 컨테이너의 제목, 본문, 링크, 코드, 구분선, 인용문 색상을 사용자 테마 변수 대신 고정 팔레트로 정리
- `ReactMarkdown.components`를 사용해 `h1`, `h2`, `h3`, `p`, `li`, `a`, `strong`, `blockquote`, `code`, `pre`, `hr`를 직접 렌더링하도록 변경
- 제목 색상을 inline style로 고정해 다크 테마 등 전역 스타일보다 우선 적용되도록 수정

## 기대 동작

- 로그인 보드 Markdown 본문은 사용자 테마가 바뀌어도 동일한 색상 톤으로 보인다
- `##`를 포함한 Markdown 제목이 다크 테마에서도 하얗게 보이지 않고 검정 계열로 고정된다
- 일반 줄바꿈이 로그인 보드 화면에 반영된다
- 링크, 코드 블록, 인용문, 구분선도 테마와 무관하게 일관된 스타일을 유지한다

## 확인 내용

- `frontend: npm exec tsc -b` 통과
- 다크 테마에서 로그인 보드 Markdown 제목이 검정 계열로 표시되는지 확인 필요
- 로그인 보드 본문 줄바꿈이 반영되는지 확인 필요
- 링크, 코드 블록, 구분선, 인용문 스타일이 고정 팔레트로 보이는지 확인 필요