### PR TITLE
fix: CI와 CD 워크플로 트리거를 분리

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,6 @@ name: CI
 
 on:
   pull_request:
-  push:
-    branches:
-      - main
 
 jobs:
   test-and-build:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,10 +1,9 @@
 name: CD
 
 on:
-  workflow_run:
-    workflows: ["CI"]
-    types:
-      - completed
+  push:
+    branches:
+      - main
   workflow_dispatch:
 
 concurrency:
@@ -13,14 +12,6 @@ concurrency:
 
 jobs:
   deploy:
-    if: >-
-      ${{
-        github.event_name == 'workflow_dispatch' ||
-        (
-          github.event.workflow_run.conclusion == 'success' &&
-          github.event.workflow_run.head_branch == 'main'
-        )
-      }}
     runs-on: ubuntu-latest
     steps:
       - name: Deploy to production server


### PR DESCRIPTION
## 관련 이슈
- Close #359 

## 변경 내용

- CI 워크플로에서 `push: main` 트리거를 제거하고 `pull_request` 전용으로 변경
- CD 워크플로의 트리거를 `workflow_run: CI`에서 `push: main`으로 변경
- CD의 수동 실행(`workflow_dispatch`)은 그대로 유지
- `workflow_run` 전용 조건식 제거로 CD 실행 조건을 단순화

## 기대 동작

- PR 생성/업데이트 시 CI가 1회만 실행된다
- PR 머지 후 `main` 반영 시 CI는 다시 실행되지 않는다
- `main` 반영 시 CD가 직접 실행된다
- 필요 시 수동으로 CD를 실행할 수 있다

## 확인 내용

- workflow YAML 파싱 확인 완료
- PR 이벤트에서 CI만 실행되는지 확인 필요
- `main` 머지 후 CD만 실행되는지 확인 필요
- 수동 실행(`workflow_dispatch`)이 계속 동작하는지 확인 필요
