### PR TITLE
feat: 랜딩과 인게임 안내 UI를 개선

### DIFF
--- a/frontend/src/features/gameplay/history/components/GameHistoryPanel.tsx
+++ b/frontend/src/features/gameplay/history/components/GameHistoryPanel.tsx
@@ -30,7 +30,7 @@ function HistoryTimelineButton({
       <button
         type="button"
         onClick={() => onOpenGameSummary(item.data)}
-        className="h-9 w-full shrink-0 rounded-lg border border-[color:var(--page-theme-accent-warm)] bg-[color:var(--page-theme-accent-warm-soft)] text-xs font-bold text-[color:var(--page-theme-accent-warm)] transition hover:opacity-90"
+        className="h-11 w-full shrink-0 rounded-xl border border-[color:var(--page-theme-accent-warm)] bg-[color:var(--page-theme-accent-warm-soft)] px-3 text-sm font-bold text-[color:var(--page-theme-accent-warm)] transition hover:opacity-90"
       >
         {resultLabel}
       </button>
@@ -41,7 +41,7 @@ function HistoryTimelineButton({
     <button
       type="button"
       onClick={() => onOpenRoundSummary(item.data)}
-      className="h-9 w-full shrink-0 rounded-lg border border-[color:var(--page-theme-border-primary)] bg-[color:var(--page-theme-surface-primary)] text-xs font-bold text-[color:var(--page-theme-text-primary)] transition hover:border-[color:var(--page-theme-primary-action)] hover:bg-[color:var(--page-theme-surface-secondary)] hover:text-[color:var(--page-theme-primary-action)]"
+      className="h-11 w-full shrink-0 rounded-xl border border-[color:var(--page-theme-border-primary)] bg-[color:var(--page-theme-surface-primary)] px-3 text-sm font-bold text-[color:var(--page-theme-text-primary)] transition hover:border-[color:var(--page-theme-primary-action)] hover:bg-[color:var(--page-theme-surface-secondary)] hover:text-[color:var(--page-theme-primary-action)]"
     >
       {item.roundNumber}R
     </button>
@@ -59,30 +59,30 @@ export default function GameHistoryPanel({
   const { t } = useI18n();
 
   return (
-    <aside className="flex h-full min-h-0 w-[88px] max-w-[88px] shrink-0 flex-col gap-2 overflow-hidden border-r border-[color:var(--page-theme-border-primary)] bg-[color:var(--page-theme-panel-background)] p-2">
+    <aside className="flex h-full min-h-0 w-[176px] max-w-[176px] shrink-0 flex-col gap-3 overflow-hidden border-r border-[color:var(--page-theme-border-primary)] bg-[color:var(--page-theme-panel-background)] p-3">
       <button
         type="button"
         onClick={onOpenIntroGuide}
-        className="h-9 w-full shrink-0 rounded-lg border border-[color:var(--page-theme-primary-action)] bg-[color:var(--page-theme-primary-action)] text-xs font-bold text-[color:var(--page-theme-primary-action-text)] transition hover:bg-[color:var(--page-theme-primary-action-hover)]"
+        className="h-11 w-full shrink-0 rounded-xl border border-[color:var(--page-theme-primary-action)] bg-[color:var(--page-theme-primary-action)] px-3 text-sm font-bold text-[color:var(--page-theme-primary-action-text)] transition hover:bg-[color:var(--page-theme-primary-action-hover)]"
       >
         {t("history.introButton")}
       </button>
 
       <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain pr-1">
         {historyLoading && (
-          <div className="rounded-lg border border-dashed border-[color:var(--page-theme-border-primary)] bg-[color:var(--page-theme-surface-secondary)] px-1 py-2 text-center text-[10px] font-medium text-[color:var(--page-theme-text-tertiary)]">
+          <div className="rounded-xl border border-dashed border-[color:var(--page-theme-border-primary)] bg-[color:var(--page-theme-surface-secondary)] px-2 py-3 text-center text-xs font-medium text-[color:var(--page-theme-text-tertiary)]">
             {t("history.loadingShort")}
           </div>
         )}
 
         {!historyLoading && historyError && (
-          <div className="rounded-lg border border-[color:var(--page-theme-alert)] bg-[color:var(--page-theme-alert-soft)] px-1 py-2 text-center text-[10px] font-medium text-[color:var(--page-theme-alert)]">
+          <div className="rounded-xl border border-[color:var(--page-theme-alert)] bg-[color:var(--page-theme-alert-soft)] px-2 py-3 text-center text-xs font-medium text-[color:var(--page-theme-alert)]">
             {t("history.errorShort")}
           </div>
         )}
 
         {!historyLoading && !historyError && historyItems.length > 0 && (
-          <div className="flex min-h-0 flex-col gap-1.5 pb-1">
+          <div className="flex min-h-0 flex-col gap-2 pb-1">
             {historyItems.map((item) => (
               <HistoryTimelineButton
                 key={item.id}

--- a/frontend/src/features/gameplay/intro/components/IntroGuideModal.tsx
+++ b/frontend/src/features/gameplay/intro/components/IntroGuideModal.tsx
@@ -126,7 +126,7 @@ export default function IntroGuideModal({
           key: "intro.vote.selectCell",
           highlightPhrases: [
             "마우스로 클릭",
-            "키보드 방향키로도 이동",
+            "키보드 방향키로 이동",
             "with your mouse",
             "with the arrow keys",
           ],
@@ -284,13 +284,13 @@ export default function IntroGuideModal({
 
       <div
         ref={modalRef}
-        className="pointer-events-auto fixed flex max-h-[calc(100vh-48px)] w-[1400px] max-w-[calc(100vw-24px)] flex-col overflow-hidden rounded-3xl border border-[color:var(--page-theme-border-primary)] bg-[color:var(--page-theme-surface-primary)] shadow-2xl"
+        className="pointer-events-auto fixed flex max-h-[calc(100vh-24px)] w-[1400px] max-w-[calc(100vw-24px)] flex-col overflow-hidden rounded-3xl border border-[color:var(--page-theme-border-primary)] bg-[color:var(--page-theme-surface-primary)] shadow-2xl"
         style={{ top: position.y, left: position.x }}
         onMouseDown={(event) => event.stopPropagation()}
         onClick={(event) => event.stopPropagation()}
       >
         <div
-          className="relative flex cursor-move items-center justify-center border-b border-[color:var(--page-theme-border-secondary)] px-5 py-4"
+          className="relative flex cursor-move items-center justify-center border-b border-[color:var(--page-theme-border-secondary)] px-4 py-3"
           onMouseDown={(event) => {
             isDraggingRef.current = true;
             dragOffsetRef.current = {
@@ -313,24 +313,24 @@ export default function IntroGuideModal({
           </button>
         </div>
 
-        <div className="min-h-0 flex-1 overflow-y-auto px-7 py-6">
-          <div className="grid gap-6 xl:grid-cols-[max-content_minmax(0,1fr)]">
-            <section className="rounded-3xl border border-[color:var(--page-theme-border-primary)] bg-[color:var(--page-theme-surface-secondary)] p-5 xl:w-fit xl:justify-self-start">
-              <div className="mx-auto flex w-fit flex-col items-center gap-6">
+        <div className="min-h-0 flex-1 overflow-y-auto px-5 py-4">
+          <div className="grid gap-4 xl:grid-cols-[max-content_minmax(0,1fr)]">
+            <section className="rounded-3xl border border-[color:var(--page-theme-border-primary)] bg-[color:var(--page-theme-surface-secondary)] p-4 xl:w-fit xl:justify-self-start">
+              <div className="mx-auto flex w-fit flex-col items-center gap-4">
                 <div className="w-fit">
                   <IntroCanvasPreview
                     playBackgroundImageUrl={playBackgroundImageUrl}
                     resultTemplateImageUrl={resultTemplateImageUrl}
                     gridX={gridX}
                     gridY={gridY}
-                    maxSize={560}
+                    maxSize={500}
                   />
                 </div>
 
-                <div className="w-full rounded-2xl border border-[color:var(--page-theme-border-primary)] bg-[color:var(--page-theme-surface-primary)] px-5 py-4 text-sm font-bold text-[color:var(--page-theme-text-primary)]">
+                <div className="w-full rounded-2xl border border-[color:var(--page-theme-border-primary)] bg-[color:var(--page-theme-surface-primary)] px-4 py-3 text-sm font-bold text-[color:var(--page-theme-text-primary)]">
                   <div className="mx-auto w-fit text-left">
                     {introStats.map((stat) => (
-                      <p key={stat.label} className="py-1">
+                      <p key={stat.label} className="py-0.5">
                         {stat.label} : {stat.value}
                       </p>
                     ))}
@@ -339,13 +339,13 @@ export default function IntroGuideModal({
               </div>
             </section>
 
-            <div className="space-y-6">
-              <section className="rounded-3xl border border-[color:var(--page-theme-border-primary)] bg-[color:var(--page-theme-surface-secondary)] p-6 text-sm leading-6 text-[color:var(--page-theme-text-secondary)]">
+            <div className="space-y-4">
+              <section className="rounded-3xl border border-[color:var(--page-theme-border-primary)] bg-[color:var(--page-theme-surface-secondary)] p-4 text-sm leading-6 text-[color:var(--page-theme-text-secondary)]">
                 <h3 className="text-center font-semibold text-[color:var(--page-theme-primary-action)]">
                   {t("intro.section.gameDescription")}
                 </h3>
-                <div className="mt-4 rounded-2xl border border-[color:var(--page-theme-border-primary)] bg-[color:var(--page-theme-surface-primary)] px-5 py-4">
-                  <ul className="space-y-2 text-left">
+                <div className="mt-3 rounded-2xl border border-[color:var(--page-theme-border-primary)] bg-[color:var(--page-theme-surface-primary)] px-4 py-3">
+                  <ul className="space-y-1.5 text-left">
                     <li>
                       {t("intro.rule.totalRoundsPrefix")}
                       <span className="text-[19px] font-bold text-[color:var(--page-theme-accent-warm)]">
@@ -369,12 +369,12 @@ export default function IntroGuideModal({
                     <li>{t("intro.rule.tieBreaker")}</li>
                   </ul>
 
-                  <div className="mt-4 rounded-2xl border border-[#DE5548]/30 bg-[#FFF5F3] px-4 py-3 text-left">
+                  <div className="mt-3 rounded-2xl border border-[#DE5548]/30 bg-[#FFF5F3] px-3 py-2.5 text-left">
                     <p className="font-bold text-[#DE5548]">{warningGuide.title}</p>
                     {warningGuide.bodyLines.map((line, index) => (
                       <p
                         key={`${warningGuide.title}-${index}`}
-                        className="mt-2 text-sm leading-6 text-[color:var(--page-theme-text-secondary)]"
+                        className="mt-1.5 text-sm leading-6 text-[color:var(--page-theme-text-secondary)]"
                       >
                         {line}
                       </p>
@@ -383,23 +383,23 @@ export default function IntroGuideModal({
                 </div>
               </section>
 
-              <section className="rounded-3xl border border-[color:var(--page-theme-border-primary)] bg-[color:var(--page-theme-surface-secondary)] p-6">
+              <section className="rounded-3xl border border-[color:var(--page-theme-border-primary)] bg-[color:var(--page-theme-surface-secondary)] p-4">
                 <h3 className="text-center font-semibold text-[color:var(--page-theme-primary-action)]">
                   {t("intro.section.voteGuide")}
                 </h3>
 
-                <div className="mt-5 space-y-4">
+                <div className="mt-3 space-y-3">
                   {interactionGuides.map((guide) => (
                     <article
                       key={guide.key}
-                      className="rounded-2xl border border-[color:var(--page-theme-border-primary)] bg-[color:var(--page-theme-surface-primary)] px-5 py-4"
+                      className="rounded-2xl border border-[color:var(--page-theme-border-primary)] bg-[color:var(--page-theme-surface-primary)] px-4 py-3"
                     >
-                      <div className="flex items-start gap-4">
-                        <span className="inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-full border border-[color:var(--page-theme-border-primary)] bg-[color:var(--page-theme-surface-secondary)] text-sm font-bold text-[color:var(--page-theme-primary-action)]">
+                      <div className="flex items-start gap-3">
+                        <span className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-full border border-[color:var(--page-theme-border-primary)] bg-[color:var(--page-theme-surface-secondary)] text-sm font-bold text-[color:var(--page-theme-primary-action)]">
                           {guide.order}
                         </span>
 
-                        <div className="min-w-0 space-y-2">
+                        <div className="min-w-0 space-y-1.5">
                           <h4 className="text-base font-semibold text-[color:var(--page-theme-text-primary)]">
                             {guide.title}
                           </h4>

--- a/frontend/src/pages/canvas/model/modal-position.ts
+++ b/frontend/src/pages/canvas/model/modal-position.ts
@@ -1,6 +1,6 @@
 import { PANEL_WIDTH } from "@/features/gameplay/canvas";
 
-export const HISTORY_PANEL_WIDTH = 88;
+export const HISTORY_PANEL_WIDTH = 176;
 const MODAL_EDGE_GAP = 12;
 const MODAL_TOP_OFFSET = 24;
 

--- a/frontend/src/pages/canvas/model/useCanvasPage.ts
+++ b/frontend/src/pages/canvas/model/useCanvasPage.ts
@@ -45,11 +45,11 @@ export default function useCanvasPage({
   );
   const [backgroundMode, setBackgroundMode] = useState<PlayBackgroundMode>(() => {
     if (typeof window === "undefined") {
-      return "w";
+      return "g";
     }
 
     const stored = window.localStorage.getItem(PLAY_BACKGROUND_MODE_STORAGE_KEY);
-    return stored === "g" || stored === "b" ? stored : "w";
+    return stored === "w" || stored === "g" || stored === "b" ? stored : "g";
   });
 
   const {

--- a/frontend/src/pages/landing/LandingPage.tsx
+++ b/frontend/src/pages/landing/LandingPage.tsx
@@ -26,13 +26,12 @@ interface LandingPageProps {
 function buildPublicText(locale: PublicSiteLocale) {
   if (locale === "ko") {
     return {
-      heroTitle: "모두의 한 표가 모여, 한 장의 픽셀 캔버스를 완성합니다.",
-      heroDescription:
-        "실시간으로 같은 보드를 바라보며 한 라운드씩 결과를 쌓아 가는 VoteDots의 현재 게임과 종료 게임들을 바로 확인해 보세요.",
+      heroTitle: "직접 그리고,\n함께 투표하는 픽셀 캔버스",
+      heroDescription: "색을 고르고, 투표를 하고, 함께 완성하세요.",
       liveLoadError: "랜딩 데이터를 불러오지 못했습니다.",
       livePanelEmpty: "현재 진행 중인 게임이 없습니다.",
       livePreviewFallback: "기본 템플릿 미리보기",
-      featuredTitle: "그리드 크기별 종료 게임",
+      featuredTitle: "완성된 캔버스",
       featuredDescription:
         "현재 로테이션에 포함된 보드 크기별로 가장 많은 참여자를 모은 종료 게임을 보여줍니다.",
       participants: "참여자",
@@ -40,20 +39,19 @@ function buildPublicText(locale: PublicSiteLocale) {
       topVoter: "최다 투표자",
       participantList: "참여자 목록",
       noTopVoter: "아직 집계된 최다 투표자가 없습니다.",
-      tutorialTitle: "처음 들어와도 바로 이해되는 플레이 흐름",
+      tutorialTitle: "게임 소개",
       footerDescription:
         "서비스 규칙, 개인정보 처리 기준, 커뮤니티 안내, 문의 정책을 이곳에서 확인할 수 있습니다.",
     };
   }
 
   return {
-    heroTitle: "Every vote adds a pixel, and every round reveals more of the canvas.",
-    heroDescription:
-      "See the live board, browse finished games by grid size, and jump into VoteDots when you are ready to shape the next round.",
+    heroTitle: "Draw directly,\na pixel canvas where everyone votes together.",
+    heroDescription: "Pick a color, cast your vote, and complete it together.",
     liveLoadError: "Failed to load landing data.",
     livePanelEmpty: "There is no live game right now.",
     livePreviewFallback: "Default template preview",
-    featuredTitle: "Finished games by grid size",
+    featuredTitle: "Completed canvases",
     featuredDescription:
       "These are the finished boards with the highest participant counts for the active rotation sizes.",
     participants: "Players",
@@ -61,7 +59,7 @@ function buildPublicText(locale: PublicSiteLocale) {
     topVoter: "Top voter",
     participantList: "Participant list",
     noTopVoter: "No top voter has been recorded yet.",
-    tutorialTitle: "A quick way to understand the play loop",
+    tutorialTitle: "Game introduction",
     footerDescription:
       "Review the service rules, privacy handling, community notes, and contact policy in one place.",
   };
@@ -107,13 +105,7 @@ function SnapshotImage({
   );
 }
 
-function InfoStat({
-  label,
-  value,
-}: {
-  label: string;
-  value: string;
-}) {
+function InfoStat({ label, value }: { label: string; value: string }) {
   return (
     <div className="rounded-2xl bg-[#f6ede5] px-4 py-3 shadow-[0_10px_24px_rgba(39,46,55,0.05)]">
       <p className="text-[11px] font-semibold uppercase tracking-[0.14em] text-[#7b6b62]">
@@ -143,15 +135,20 @@ function FeaturedGameCard({
 }) {
   const copy = buildPublicText(locale);
   const siteContent = getSiteContent(locale);
-  const formatNumber = new Intl.NumberFormat(locale === "ko" ? "ko-KR" : "en-US");
+  const formatNumber = new Intl.NumberFormat(
+    locale === "ko" ? "ko-KR" : "en-US",
+  );
   const imageUrl = card.game?.snapshotUrl ?? card.fallbackImageUrl;
   const participantNames = getParticipantNames(card.game?.participants ?? null);
 
   return (
     <article className="overflow-hidden rounded-[30px] bg-white shadow-[0_24px_70px_rgba(39,46,55,0.08)]">
       <div className="px-5 pb-5 pt-5">
-        <div className="flex items-center justify-between gap-3">
-          <h2 className="text-xl font-semibold" style={{ color: "#000000" }}>
+        <div className="flex items-center justify-center gap-3">
+          <h2
+            className="w-full text-center text-xl font-semibold"
+            style={{ color: "#000000" }}
+          >
             {card.gridX} x {card.gridY}
           </h2>
         </div>
@@ -175,18 +172,22 @@ function FeaturedGameCard({
           </div>
         ) : (
           <div className="mt-4 space-y-4 rounded-[24px] bg-[#fffaf4] px-4 py-4 text-left">
-            <div className="grid gap-3 sm:grid-cols-2">
-              <InfoStat
-                label={copy.participants}
-                value={formatNumber.format(card.game.participantCount)}
-              />
-              <InfoStat
-                label={copy.votes}
-                value={formatNumber.format(card.game.totalVotes)}
-              />
+            <div className="rounded-2xl bg-[#f6ede5] px-4 py-3 text-center shadow-[0_10px_24px_rgba(39,46,55,0.05)]">
+              <p className="text-[11px] font-semibold uppercase tracking-[0.14em] text-[#7b6b62]">
+                {copy.participants}
+              </p>
+              <p className="mt-1 text-base font-semibold text-[#272E37]">
+                {formatNumber.format(card.game.participantCount)}
+              </p>
+              <p className="mt-3 text-[11px] font-semibold uppercase tracking-[0.14em] text-[#7b6b62]">
+                {copy.votes}
+              </p>
+              <p className="mt-1 text-base font-semibold text-[#272E37]">
+                {formatNumber.format(card.game.totalVotes)}
+              </p>
             </div>
 
-            <div className="space-y-3 text-sm leading-6 text-[#51545a]">
+            <div className="space-y-3 text-center text-sm leading-6 text-[#51545a]">
               <div>
                 <p className="font-semibold text-[#7b6b62]">{copy.topVoter}</p>
                 <p className="mt-1 text-base font-semibold text-[#272E37]">
@@ -198,10 +199,12 @@ function FeaturedGameCard({
                 </p>
               </div>
               <div>
-                <p className="font-semibold text-[#7b6b62]">{copy.participantList}</p>
+                <p className="font-semibold text-[#7b6b62]">
+                  {copy.participantList}
+                </p>
                 <div className="mt-2 rounded-2xl bg-white px-3 py-3 shadow-[inset_0_0_0_1px_rgba(234,215,200,0.95)]">
                   {participantNames.length > 0 ? (
-                    <div className="flex h-24 flex-wrap content-start gap-2 overflow-y-auto pr-1">
+                    <div className="flex h-24 flex-wrap content-start justify-center gap-2 overflow-y-auto pr-1">
                       {participantNames.map((name, index) => (
                         <span
                           key={`${name}-${index}`}
@@ -212,7 +215,9 @@ function FeaturedGameCard({
                       ))}
                     </div>
                   ) : (
-                    <p className="flex h-24 items-center text-sm text-[#7b6b62]">-</p>
+                    <p className="flex h-24 items-center justify-center text-sm text-[#7b6b62]">
+                      -
+                    </p>
                   )}
                 </div>
               </div>
@@ -308,7 +313,7 @@ export default function LandingPage({ locale }: LandingPageProps) {
   const currentGame = landingData?.currentGame ?? null;
 
   return (
-    <div className="min-h-screen bg-[radial-gradient(circle_at_top_left,rgba(222,85,72,0.18),transparent_30%),radial-gradient(circle_at_82%_18%,rgba(61,214,140,0.16),transparent_28%),radial-gradient(circle_at_76%_62%,rgba(70,154,229,0.12),transparent_28%),linear-gradient(180deg,#fbf3ec_0%,#fff8f2_44%,#f6f1ea_100%)] text-[#272E37]">
+    <div className="min-h-screen bg-[#fefbf7] text-[#272E37]">
       <SiteHeader
         locale={locale}
         items={[
@@ -326,12 +331,12 @@ export default function LandingPage({ locale }: LandingPageProps) {
       />
 
       <main className="px-4 pb-20 pt-6 sm:px-6 lg:px-10">
-        <section className="mx-auto max-w-7xl rounded-[42px] bg-[#DE5548] px-6 py-7 text-white shadow-[0_40px_120px_rgba(39,46,55,0.24)] sm:px-8 sm:py-8">
+        <section className="mx-auto max-w-7xl rounded-[42px] bg-[#ff8870] px-6 py-7 text-white shadow-[0_40px_120px_rgba(39,46,55,0.24)] sm:px-8 sm:py-8">
           <div className="grid gap-8 xl:grid-cols-[minmax(0,1fr)_584px] xl:items-stretch">
             <div className="flex flex-col items-center justify-center text-left xl:items-start">
               <div>
                 <h1
-                  className="max-w-3xl text-4xl font-semibold leading-tight sm:text-5xl"
+                  className="max-w-3xl whitespace-pre-line text-4xl font-semibold leading-tight sm:text-5xl"
                   style={{ color: "#000000" }}
                 >
                   {copy.heroTitle}
@@ -368,7 +373,9 @@ export default function LandingPage({ locale }: LandingPageProps) {
                   </h2>
 
                   <SnapshotImage
-                    imageUrl={currentGame.snapshotUrl ?? currentGame.fallbackImageUrl}
+                    imageUrl={
+                      currentGame.snapshotUrl ?? currentGame.fallbackImageUrl
+                    }
                     alt={
                       currentGame.snapshotUrl
                         ? siteContent.currentGame.snapshotLabel
@@ -423,7 +430,11 @@ export default function LandingPage({ locale }: LandingPageProps) {
 
           <div className="mt-8 grid gap-6 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4">
             {(landingData?.featuredGames ?? []).map((card) => (
-              <FeaturedGameCard key={card.profileKey} locale={locale} card={card} />
+              <FeaturedGameCard
+                key={card.profileKey}
+                locale={locale}
+                card={card}
+              />
             ))}
           </div>
         </section>
@@ -442,7 +453,11 @@ export default function LandingPage({ locale }: LandingPageProps) {
                 className="grid gap-5 rounded-[34px] bg-white shadow-[0_24px_80px_rgba(39,46,55,0.06)] xl:grid-cols-[552px_minmax(0,1fr)]"
               >
                 <div className="bg-[linear-gradient(180deg,#fff4e9_0%,#f6ede5_100%)] p-5">
-                  <SnapshotImage imageUrl={card.imageUrl} alt={card.imageAlt} size={512} />
+                  <SnapshotImage
+                    imageUrl={card.imageUrl}
+                    alt={card.imageAlt}
+                    size={512}
+                  />
                 </div>
 
                 <div className="flex flex-col justify-center px-6 py-6 text-left sm:px-8">

--- a/frontend/src/shared/i18n/resources.ts
+++ b/frontend/src/shared/i18n/resources.ts
@@ -22,12 +22,18 @@ export const resources: Record<Locale, Record<string, string>> = {
     "auth.register.usernameLabel": "아이디",
     "auth.register.nicknameLabel": "닉네임",
     "auth.register.passwordLabel": "비밀번호",
-    "auth.register.usernameHint": "영문 소문자와 숫자만 사용해 4~20자로 입력해 주세요.",
-    "auth.register.nicknameHint": "한글, 영문, 숫자만 사용해 2~20자로 입력해 주세요.",
-    "auth.register.passwordHint": "8~64자이며 영문과 숫자를 포함해야 하고 공백은 사용할 수 없어요.",
-    "auth.register.usernameRule": "아이디는 영문 소문자와 숫자만 사용하며 4~20자여야 해요.",
-    "auth.register.nicknameRule": "닉네임은 한글, 영문, 숫자만 사용하며 2~20자여야 해요.",
-    "auth.register.passwordRule": "비밀번호는 8~64자이며 영문과 숫자를 포함해야 하고 공백은 사용할 수 없어요.",
+    "auth.register.usernameHint":
+      "영문 소문자와 숫자만 사용해 4~20자로 입력해 주세요.",
+    "auth.register.nicknameHint":
+      "한글, 영문, 숫자만 사용해 2~20자로 입력해 주세요.",
+    "auth.register.passwordHint":
+      "8~64자이며 영문과 숫자를 포함해야 하고 공백은 사용할 수 없어요.",
+    "auth.register.usernameRule":
+      "아이디는 영문 소문자와 숫자만 사용하며 4~20자여야 해요.",
+    "auth.register.nicknameRule":
+      "닉네임은 한글, 영문, 숫자만 사용하며 2~20자여야 해요.",
+    "auth.register.passwordRule":
+      "비밀번호는 8~64자이며 영문과 숫자를 포함해야 하고 공백은 사용할 수 없어요.",
     "auth.register.submit": "회원가입",
     "auth.register.hasAccount": "이미 계정이 있으신가요?",
     "auth.register.login": "로그인",
@@ -38,11 +44,15 @@ export const resources: Record<Locale, Record<string, string>> = {
     "server.auth.invalidCredentials": "아이디 또는 비밀번호가 올바르지 않아요.",
     "server.auth.missingCredentials": "아이디와 비밀번호를 입력해주세요.",
     "server.auth.missingFields": "모든 항목을 입력해주세요.",
-    "server.auth.invalidUsername": "아이디는 영문 소문자와 숫자만 사용하며 4~20자여야 해요.",
-    "server.auth.invalidNickname": "닉네임은 한글, 영문, 숫자만 사용하며 2~20자여야 해요.",
-    "server.auth.invalidPassword": "비밀번호는 8~64자이며 영문과 숫자를 포함해야 하고 공백은 사용할 수 없어요.",
+    "server.auth.invalidUsername":
+      "아이디는 영문 소문자와 숫자만 사용하며 4~20자여야 해요.",
+    "server.auth.invalidNickname":
+      "닉네임은 한글, 영문, 숫자만 사용하며 2~20자여야 해요.",
+    "server.auth.invalidPassword":
+      "비밀번호는 8~64자이며 영문과 숫자를 포함해야 하고 공백은 사용할 수 없어요.",
     "server.vote.missingSession": "세션 정보를 찾을 수 없어요.",
-    "server.vote.missingFields": "캔버스 ID, 라운드 ID, 좌표, 색상을 모두 입력해주세요.",
+    "server.vote.missingFields":
+      "캔버스 ID, 라운드 ID, 좌표, 색상을 모두 입력해주세요.",
     "server.vote.noRound": "진행 중인 라운드가 없어요.",
     "server.vote.canvasNotFound": "캔버스를 찾을 수 없어요.",
     "server.vote.invalidCell": "유효하지 않은 셀 좌표예요.",
@@ -105,16 +115,16 @@ export const resources: Record<Locale, Record<string, string>> = {
     "intro.rule.voteFlexibility":
       "- 투표권은 여러 칸에 나눠 쓰거나, 한 칸에 여러 번 사용할 수 있습니다.",
     "intro.rule.applyVotes":
-      "- 라운드가 끝나면 가장 많은 표를 받은 색으로 해당 칸이 칠해집니다.",
-    "intro.rule.tieBreaker": "- 동점일 경우 색상은 무작위로 결정됩니다.",
+      "- 라운드가 끝나면 가장 많은 표를 받은 색으로 해당 칸이 선택됩니다.",
+    "intro.rule.tieBreaker": "- 동점일 경우 색상은 무작위로 선택됩니다.",
     "intro.vote.selectCell":
-      "【칸 선택】\n- 원하는 칸을 마우스로 클릭하세요. \n- 이후에는 키보드 방향키로도 이동할 수 있습니다.",
+      "【칸 선택】\n- 원하는 칸을 마우스로 클릭하세요. \n- 이후에는 키보드 방향키로 이동할 수 있습니다.",
     "intro.vote.submit":
       "【색상 선택】\n- 팔레트에서 색을 고른 뒤 '투표하기' 버튼을 클릭하거나 스페이스바를 누르면 투표됩니다.",
     "intro.vote.favorite":
       "【즐겨찾기】\n- 팔레트 칸 선택 후 '+' 버튼을 누르면 자주 쓰는 색을 저장할 수 있습니다.",
     "intro.vote.warning":
-      "【⚠️ 주의】\n- 한 번 투표한 내용은 되돌릴 수 없습니다. 신중하게 선택해 주세요.",
+      "【주의】 투표는 취소할 수 없습니다. 신중하게 선택해 주세요.",
 
     "round.status": "상태",
     "round.round": "라운드",
@@ -150,7 +160,8 @@ export const resources: Record<Locale, Record<string, string>> = {
     "gameSummary.noSnapshot": "최종 스냅샷이 없어요.",
     "gameSummary.download": "이미지 다운로드",
     "gameSummary.downloadRetry": "이미지 다시 시도",
-    "gameSummary.downloadError": "이미지 다운로드에 실패했습니다. 다시 시도해 주세요.",
+    "gameSummary.downloadError":
+      "이미지 다운로드에 실패했습니다. 다시 시도해 주세요.",
     "gameSummary.downloading": "다운로드 중...",
     "gameSummary.downloadHd": "HD 다운로드",
     "gameSummary.downloadHdRetry": "HD 다시 시도",
@@ -236,11 +247,16 @@ export const resources: Record<Locale, Record<string, string>> = {
     "auth.register.nicknameLabel": "Nickname",
     "auth.register.passwordLabel": "Password",
     "auth.register.usernameHint": "Use 4-20 lowercase letters or numbers.",
-    "auth.register.nicknameHint": "Use 2-20 Korean, English, or numeric characters without spaces.",
-    "auth.register.passwordHint": "Use 8-64 characters with at least one letter and one number, without spaces.",
-    "auth.register.usernameRule": "Username must be 4-20 characters using only lowercase letters and numbers.",
-    "auth.register.nicknameRule": "Nickname must be 2-20 characters using only Korean, English, or numbers without spaces.",
-    "auth.register.passwordRule": "Password must be 8-64 characters, include at least one letter and one number, and contain no spaces.",
+    "auth.register.nicknameHint":
+      "Use 2-20 Korean, English, or numeric characters without spaces.",
+    "auth.register.passwordHint":
+      "Use 8-64 characters with at least one letter and one number, without spaces.",
+    "auth.register.usernameRule":
+      "Username must be 4-20 characters using only lowercase letters and numbers.",
+    "auth.register.nicknameRule":
+      "Nickname must be 2-20 characters using only Korean, English, or numbers without spaces.",
+    "auth.register.passwordRule":
+      "Password must be 8-64 characters, include at least one letter and one number, and contain no spaces.",
     "auth.register.submit": "Sign up",
     "auth.register.hasAccount": "Already have an account?",
     "auth.register.login": "Sign in",
@@ -249,11 +265,15 @@ export const resources: Record<Locale, Record<string, string>> = {
     "server.auth.requiredLogin": "You need to sign in.",
     "server.auth.usernameTaken": "This username is already in use.",
     "server.auth.invalidCredentials": "Your username or password is incorrect.",
-    "server.auth.missingCredentials": "Please enter your username and password.",
+    "server.auth.missingCredentials":
+      "Please enter your username and password.",
     "server.auth.missingFields": "Please fill in all required fields.",
-    "server.auth.invalidUsername": "Username must be 4-20 characters using only lowercase letters and numbers.",
-    "server.auth.invalidNickname": "Nickname must be 2-20 characters using only Korean, English, or numbers without spaces.",
-    "server.auth.invalidPassword": "Password must be 8-64 characters, include at least one letter and one number, and contain no spaces.",
+    "server.auth.invalidUsername":
+      "Username must be 4-20 characters using only lowercase letters and numbers.",
+    "server.auth.invalidNickname":
+      "Nickname must be 2-20 characters using only Korean, English, or numbers without spaces.",
+    "server.auth.invalidPassword":
+      "Password must be 8-64 characters, include at least one letter and one number, and contain no spaces.",
     "server.vote.missingSession": "We couldn't find your session.",
     "server.vote.missingFields":
       "Please provide the canvas ID, round ID, coordinates, and color.",
@@ -261,7 +281,8 @@ export const resources: Record<Locale, Record<string, string>> = {
     "server.vote.canvasNotFound": "We couldn't find the canvas.",
     "server.vote.invalidCell": "The selected cell coordinates are invalid.",
     "server.vote.noTickets": "You don't have any vote tickets left.",
-    "server.vote.submitFailed": "Something went wrong while submitting your vote.",
+    "server.vote.submitFailed":
+      "Something went wrong while submitting your vote.",
 
     "canvas.sessionEnded": "Your session has ended. Please sign in again.",
     "canvas.resetZoom": "Reset to the initial zoom level",
@@ -275,7 +296,8 @@ export const resources: Record<Locale, Record<string, string>> = {
     "session.serviceUnavailable":
       "The service is temporarily unavailable. Please try again in a moment.",
     "session.authCheckFailed": "We couldn't verify your sign-in status.",
-    "session.preparingGame": "A new game is being prepared. Please wait a moment.",
+    "session.preparingGame":
+      "A new game is being prepared. Please wait a moment.",
     "session.loadCanvasFailed": "We couldn't load the current canvas.",
     "session.gameEnded": "The game has ended. A new game will start soon.",
     "session.myInfoLoadFailed": "We couldn't load your account information.",
@@ -301,7 +323,8 @@ export const resources: Record<Locale, Record<string, string>> = {
     "intro.panel.button": "Open",
     "intro.modal.title": "Game guide",
     "intro.modal.close": "Close game guide",
-    "intro.modal.subtitle": "Color the dots together to complete a single canvas.",
+    "intro.modal.subtitle":
+      "Color the dots together to complete a single canvas.",
     "intro.label.canvasSize": "Canvas size",
     "intro.label.totalRounds": "Total rounds",
     "intro.label.roundDuration": "Round duration",
@@ -319,9 +342,9 @@ export const resources: Record<Locale, Record<string, string>> = {
     "intro.rule.voteFlexibility":
       "- You can split your vote tickets across multiple cells or focus them on a single cell.",
     "intro.rule.applyVotes":
-      "- When the round ends, each cell is painted with the color that received the most votes.",
+      "- When the round ends, each cell is selected with the color that received the most votes.",
     "intro.rule.tieBreaker":
-      "- If there is a tie, the color is chosen at random.",
+      "- If there is a tie, the color is selected at random.",
     "intro.vote.selectCell":
       "【Select a cell】\n- Click the cell you want with your mouse. \n- After the first click, you can also move with the arrow keys.",
     "intro.vote.submit":
@@ -329,7 +352,7 @@ export const resources: Record<Locale, Record<string, string>> = {
     "intro.vote.favorite":
       "【Favorites】\n- Select a palette slot and press the + button to save frequently used colors.",
     "intro.vote.warning":
-      "【⚠️Warning】\n- Once a vote is submitted, it cannot be undone. Please choose carefully.",
+      "【Notice】 Votes cannot be canceled. Please choose carefully.",
 
     "round.status": "Status",
     "round.round": "Round",
@@ -410,9 +433,12 @@ export const resources: Record<Locale, Record<string, string>> = {
     "vote.remainingVotes": "Votes left",
     "vote.status": "Vote activity",
     "vote.popup.blockedIntro": "Voting is disabled during the intro guide.",
-    "vote.popup.blockedStartWait": "Voting is disabled while waiting for the round to start.",
-    "vote.popup.blockedResult": "Voting is disabled while results are being counted.",
-    "vote.popup.blockedGameEnd": "Voting is disabled because the game has ended.",
+    "vote.popup.blockedStartWait":
+      "Voting is disabled while waiting for the round to start.",
+    "vote.popup.blockedResult":
+      "Voting is disabled while results are being counted.",
+    "vote.popup.blockedGameEnd":
+      "Voting is disabled because the game has ended.",
     "vote.popup.disabled": "Voting unavailable",
     "vote.popup.closed": "Voting closed",
     "vote.popup.loading": "Submitting vote...",


### PR DESCRIPTION
## 관련 이슈
- Close #372 

## 변경 내용

- 랜딩 페이지 히어로 카피와 섹션 문구를 새 기준으로 정리
- 완료 게임 전시 카드에서 통계 패널 구조와 정렬 방식을 재구성
- 인트로 모달 내부 여백과 프리뷰 크기를 조정해 스크롤을 줄이고 문구를 수정
- 인트로 모달 관련 ko/en 로컬라이즈를 함께 갱신
- 히스토리 패널 폭을 2배로 확장하고 버튼 크기와 간격을 조정
- 히스토리 패널 폭 변경에 맞춰 모달 위치 계산 기준을 동기화
- 캔버스 기본 배경 모드를 회색으로 변경

## 기대 동작

- 랜딩 히어로 영역에서 새 타이틀과 설명 문구가 반영된다
- `완성된 캔버스` 카드에서 참여자/총 투표 수가 한 패널로 보이고, 최다 투표자와 참여자 목록이 가운데 정렬된다
- 인트로 모달이 기존보다 덜 길어져 스크롤이 줄어든다
- 인트로 안내 문구와 경고 문구가 새 문장과 형식으로 표시된다
- 히스토리 패널이 더 넓어지고 버튼도 그 폭에 맞게 커진다
- 저장된 설정이 없을 때 캔버스 배경은 회색으로 시작한다

## 확인 내용

- `frontend`: `npx tsc -b`
- 수동 확인 필요:
  - 랜딩 페이지 카피/정렬
  - 인트로 모달 스크롤 여부
  - 히스토리 패널 폭과 버튼 크기
  - 회색 기본 배경 적용 여부