### PR TITLE
fix: 인트로 모달 게임 설명과 조작 문구를 정리

### DIFF
--- a/frontend/src/features/gameplay/intro/components/IntroGuideModal.tsx
+++ b/frontend/src/features/gameplay/intro/components/IntroGuideModal.tsx
@@ -349,7 +349,7 @@ export default function IntroGuideModal({
                   {t("intro.section.gameDescription")}
                 </h3>
                 <div className="mt-3 rounded-2xl border border-[color:var(--page-theme-border-primary)] bg-[color:var(--page-theme-surface-primary)] px-4 py-3">
-                  <ul className="space-y-1.5 text-left">
+                  <ul className="list-disc space-y-1.5 pl-8 text-left marker:text-[color:var(--page-theme-text-secondary)]">
                     <li>
                       {t("intro.rule.totalRoundsPrefix")}
                       <span className="text-[19px] font-bold text-[color:var(--page-theme-accent-warm)]">
@@ -374,7 +374,9 @@ export default function IntroGuideModal({
                   </ul>
 
                   <div className="mt-3 rounded-2xl border border-[#DE5548]/30 bg-[#FFF5F3] px-3 py-2.5 text-left">
-                    <p className="font-bold text-[#DE5548]">{warningGuide.title}</p>
+                    <p className="font-bold text-[#DE5548]">
+                      {warningGuide.title}
+                    </p>
                     {warningGuide.bodyLines.map((line, index) => (
                       <p
                         key={`${warningGuide.title}-${index}`}
@@ -412,7 +414,10 @@ export default function IntroGuideModal({
                               key={`${guide.key}-${index}`}
                               className="text-sm leading-6 text-[color:var(--page-theme-text-secondary)]"
                             >
-                              {renderHighlightedText(line, guide.highlightPhrases)}
+                              {renderHighlightedText(
+                                line,
+                                guide.highlightPhrases,
+                              )}
                             </p>
                           ))}
                         </div>

--- a/frontend/src/shared/i18n/resources.ts
+++ b/frontend/src/shared/i18n/resources.ts
@@ -107,18 +107,18 @@ export const resources: Record<Locale, Record<string, string>> = {
     "intro.unit.votes": "개",
     "intro.section.gameDescription": "게임 설명",
     "intro.section.voteGuide": "조작 방법",
-    "intro.rule.totalRoundsPrefix": "- 게임은 총 ",
+    "intro.rule.totalRoundsPrefix": "게임은 총 ",
     "intro.rule.totalRoundsSuffix": "라운드로 진행됩니다.",
-    "intro.rule.roundDurationPrefix": "- 각 라운드는 ",
+    "intro.rule.roundDurationPrefix": "각 라운드는 ",
     "intro.rule.roundDurationMiddle": "초 동안 진행되며, 라운드마다 ",
     "intro.rule.roundDurationSuffix": "개의 투표권이 주어집니다.",
     "intro.rule.voteFlexibility":
-      "- 투표권은 여러 칸에 나눠 쓰거나, 한 칸에 여러 번 사용할 수 있습니다.",
+      "투표권은 여러 칸에 나눠 쓰거나, 한 칸에 여러 번 사용할 수 있습니다.",
     "intro.rule.applyVotes":
-      "- 라운드가 끝나면 가장 많은 표를 받은 색으로 해당 칸이 선택됩니다.",
-    "intro.rule.tieBreaker": "- 동점일 경우 색상은 무작위로 선택됩니다.",
+      "라운드가 끝나면 가장 많은 표를 받은 색으로 해당 칸이 선택됩니다.",
+    "intro.rule.tieBreaker": "동점일 경우 색상은 무작위로 선택됩니다.",
     "intro.vote.selectCell":
-      "【칸 선택】\n- 원하는 칸을 마우스로 클릭하세요. \n- 이후에는 키보드 방향키로 이동할 수 있습니다.",
+      "【칸 선택】\n원하는 칸을 마우스로 클릭하거나 키보드 방향키로 이동할 수 있습니다.",
     "intro.vote.submit":
       "【색상 선택】\n- 팔레트에서 색을 고른 뒤 '투표하기' 버튼을 클릭하거나 스페이스바를 누르면 투표됩니다.",
     "intro.vote.favorite":
@@ -367,19 +367,19 @@ export const resources: Record<Locale, Record<string, string>> = {
     "intro.unit.votes": " votes",
     "intro.section.gameDescription": "How the game works",
     "intro.section.voteGuide": "Controls",
-    "intro.rule.totalRoundsPrefix": "- The game runs for ",
+    "intro.rule.totalRoundsPrefix": "The game runs for ",
     "intro.rule.totalRoundsSuffix": " rounds in total.",
-    "intro.rule.roundDurationPrefix": "- Each round lasts ",
+    "intro.rule.roundDurationPrefix": "Each round lasts ",
     "intro.rule.roundDurationMiddle": " seconds, and you receive ",
     "intro.rule.roundDurationSuffix": " vote tickets per round.",
     "intro.rule.voteFlexibility":
-      "- You can split your vote tickets across multiple cells or focus them on a single cell.",
+      "You can split your vote tickets across multiple cells or focus them on a single cell.",
     "intro.rule.applyVotes":
-      "- When the round ends, each cell is selected with the color that received the most votes.",
+      "When the round ends, each cell is selected with the color that received the most votes.",
     "intro.rule.tieBreaker":
-      "- If there is a tie, the color is selected at random.",
+      "If there is a tie, the color is selected at random.",
     "intro.vote.selectCell":
-      "【Select a cell】\n- Click the cell you want with your mouse. \n- After the first click, you can also move with the arrow keys.",
+      "【Select a cell】\nClick the cell you want with your mouse or move with the arrow keys.",
     "intro.vote.submit":
       "【Choose a color】\n- Pick a color from the palette, then click the Vote button or press the space bar to cast your vote.",
     "intro.vote.favorite":


### PR DESCRIPTION
## 관련 이슈
- Close #379 

## 변경 내용

- 인트로 모달 게임 설명 리스트를 `-` 문자 대신 점 불릿 스타일로 정리
- 게임 설명 리스트 들여쓰기를 줄여 레이아웃을 조정
- 조작 방법의 `칸 선택` 문구를 한 줄 설명으로 수정
- 한국어/영문 로컬라이즈를 함께 갱신

## 기대 동작

- 게임 설명 영역이 점 불릿 기준으로 더 자연스럽게 보인다
- 리스트 들여쓰기가 과하지 않게 정리된다
- `칸 선택` 문구가 한 줄로 더 간결하게 보인다
- ko/en 모두 같은 의미로 반영된다

## 확인 내용

- `frontend`: `npx tsc -b`
- 수동 확인 필요:
  - 인트로 모달 게임 설명 불릿 표시
  - 리스트 들여쓰기 정도
  - `칸 선택` 문구 한 줄 표시


## 참고
377 브랜치에 동일한 커밋 sync되어 있고 반영 안됨, 이 브랜치의 작업이 맞음