### PR TITLE
refactor: gameplay 세션 진입과 bootstrap 책임 분리

### DIFF
--- a/backend/src/config/game-config-profiles/configtest.profile.ts
+++ b/backend/src/config/game-config-profiles/configtest.profile.ts
@@ -4,10 +4,10 @@ export const testGameConfigProfile: GameConfigUpdate = {
   phases: {
     introPhaseSec: 2,
     roundStartWaitSec: 2,
-    roundDurationSec: 2,
+    roundDurationSec: 5,
     roundResultDelaySec: 2,
-    gameEndWaitSec: 2,
-    restartDelaySec: 4,
+    gameEndWaitSec: 5,
+    restartDelaySec: 3,
   },
   rules: {
     totalRounds: 2,
@@ -15,8 +15,8 @@ export const testGameConfigProfile: GameConfigUpdate = {
     participantGracePeriodSec: 15,
   },
   board: {
-    gridSizeX: 30,
-    gridSizeY: 30,
-    cellSize: 50,
+    gridSizeX: 32,
+    gridSizeY: 32,
+    cellSize: 30,
   },
 };

--- a/frontend/src/features/gameplay/session/hooks/useGameSession.ts
+++ b/frontend/src/features/gameplay/session/hooks/useGameSession.ts
@@ -9,6 +9,11 @@ interface UseGameSessionParams {
   onUnauthorized: (message: string) => void;
 }
 
+type SessionAccessResult =
+  | { status: "authorized" }
+  | { status: "unauthorized" }
+  | { status: "failed" };
+
 const BOOTSTRAP_RETRY_DELAY_MS = 2000;
 const BOOTSTRAP_RETRY_MAX_MS = 30000;
 
@@ -161,6 +166,74 @@ export function useGameSession({
     window.location.href = "/login";
   }, [t]);
 
+  const handleBootstrapSuccess = useCallback(
+    (result: SessionBootstrapResult) => {
+      restartDelaySecRef.current = result.gameConfig.phases.restartDelaySec;
+      onBootstrap(result);
+      setError(null);
+      setRetryNonce(0);
+      serviceAlertShownRef.current = false;
+      clearRestartPending();
+      return result;
+    },
+    [onBootstrap],
+  );
+
+  const verifySessionAccess = useCallback(
+    async (): Promise<SessionAccessResult> => {
+      try {
+        await authApi.me();
+        unauthorizedRedirectHandled = false;
+        return { status: "authorized" };
+      } catch (error) {
+        const status = getErrorStatus(error);
+
+        setRetryNonce(0);
+        clearRestartPending();
+
+        if (status === 401) {
+          if (!unauthorizedRedirectHandled) {
+            unauthorizedRedirectHandled = true;
+            onUnauthorized(t("server.auth.requiredLogin"));
+          }
+
+          return { status: "unauthorized" };
+        }
+
+        setError(t("session.authCheckFailed"));
+        return { status: "failed" };
+      }
+    },
+    [onUnauthorized, t],
+  );
+
+  const runBootstrap = useCallback(async (): Promise<SessionBootstrapResult | null> => {
+    try {
+      const result = await bootstrap();
+      return handleBootstrapSuccess(result);
+    } catch (error) {
+      if (isRestartPending() && isRetryableBootstrapError(error)) {
+        const elapsedMs = getRestartElapsedMs();
+
+        if (elapsedMs < BOOTSTRAP_RETRY_MAX_MS) {
+          setError(t("session.preparingGame"));
+          setRetryNonce((prev) => prev + 1);
+          return null;
+        }
+
+        setError(t("session.serviceUnavailable"));
+        setRetryNonce(0);
+        showServiceUnavailableAlert();
+        return null;
+      }
+
+      setError(t("session.loadCanvasFailed"));
+      setRetryNonce(0);
+      clearRestartPending();
+      return null;
+    }
+  }, [bootstrap, handleBootstrapSuccess, showServiceUnavailableAlert, t]);
+
   const initializeSession = useCallback(
     async ({ silent = false }: { silent?: boolean } = {}) => {
       if (!silent) {
@@ -169,64 +242,20 @@ export function useGameSession({
       }
 
       try {
-        try {
-          await authApi.me();
-          unauthorizedRedirectHandled = false;
-        } catch (error) {
-          const status = getErrorStatus(error);
+        const sessionAccess = await verifySessionAccess();
 
-          setRetryNonce(0);
-          clearRestartPending();
-
-          if (status === 401) {
-            if (!unauthorizedRedirectHandled) {
-              unauthorizedRedirectHandled = true;
-              onUnauthorized(t("server.auth.requiredLogin"));
-            }
-            return null;
-          }
-
-          setError(t("session.authCheckFailed"));
+        if (sessionAccess.status !== "authorized") {
           return null;
         }
 
-        try {
-          const result = await bootstrap();
-          restartDelaySecRef.current = result.gameConfig.phases.restartDelaySec;
-          onBootstrap(result);
-          setError(null);
-          setRetryNonce(0);
-          serviceAlertShownRef.current = false;
-          clearRestartPending();
-          return result;
-        } catch (error) {
-          if (isRestartPending() && isRetryableBootstrapError(error)) {
-            const elapsedMs = getRestartElapsedMs();
-
-            if (elapsedMs < BOOTSTRAP_RETRY_MAX_MS) {
-              setError(t("session.preparingGame"));
-              setRetryNonce((prev) => prev + 1);
-              return null;
-            }
-
-            setError(t("session.serviceUnavailable"));
-            setRetryNonce(0);
-            showServiceUnavailableAlert();
-            return null;
-          }
-
-          setError(t("session.loadCanvasFailed"));
-          setRetryNonce(0);
-          clearRestartPending();
-          return null;
-        }
+        return runBootstrap();
       } finally {
         if (!silent) {
           setLoading(false);
         }
       }
     },
-    [bootstrap, onBootstrap, onUnauthorized, showServiceUnavailableAlert, t],
+    [runBootstrap, verifySessionAccess],
   );
 
   useEffect(() => {

--- a/frontend/src/features/gameplay/session/hooks/useGameplayBootstrap.ts
+++ b/frontend/src/features/gameplay/session/hooks/useGameplayBootstrap.ts
@@ -1,7 +1,6 @@
 import { useCallback } from "react";
 import { voteApi } from "@/features/gameplay/vote";
 import { resolveResultTemplateImageUrl } from "@/features/gameplay/canvas/model/background-assets";
-import { setGameConfig } from "@/shared/config/game-config";
 import { GAME_PHASE, isRoundActivePhase } from "../model/game-phase.types";
 import { sessionApi, type RoundStateResponse } from "../api/session.api";
 import { RoundInfoState, SessionBootstrapResult } from "../model/session.types";
@@ -238,8 +237,6 @@ export function useGameplayBootstrap() {
     const { data } = await sessionApi.getCurrentCanvas();
     const { canvas, gameConfig } = data;
     const { phases, rules } = gameConfig;
-
-    setGameConfig(gameConfig);
 
     let roundState: RoundStateResponse | null = null;
     let remaining: number | null = null;

--- a/frontend/src/pages/canvas/model/useCanvasGameplay.ts
+++ b/frontend/src/pages/canvas/model/useCanvasGameplay.ts
@@ -23,6 +23,7 @@ import {
   isRoundActivePhase,
 } from "@/features/gameplay/session/model/game-phase.types";
 import type { GameConfig } from "@/shared/config/game-config";
+import { setGameConfig } from "@/shared/config/game-config";
 import { useVoteTickets } from "@/features/gameplay/vote";
 
 function formatClockTime(date: Date): string {
@@ -231,6 +232,7 @@ export default function useCanvasGameplay({
 
   const applyBootstrap = useCallback(
     (result: SessionBootstrapResult) => {
+      setGameConfig(result.gameConfig);
       phaseTimingRef.current = result.phaseTiming;
       setGameConfigState(result.gameConfig);
       onBootstrapScene(result);

--- a/frontend/test/integration/useGameplayBootstrap.integration.test.ts
+++ b/frontend/test/integration/useGameplayBootstrap.integration.test.ts
@@ -1,7 +1,6 @@
 import { renderHook } from "@testing-library/react";
 import { http } from "msw/core/http";
 import { useGameplayBootstrap } from "@/features/gameplay/session/hooks/useGameplayBootstrap";
-import { getGameConfig } from "@/shared/config/game-config";
 import { server } from "../setup/msw/server";
 
 describe("useGameplayBootstrap integration", () => {
@@ -108,6 +107,6 @@ describe("useGameplayBootstrap integration", () => {
       "1:1:#111111": 2,
       "1:1:#ffffff": 4,
     });
-    expect(getGameConfig().rules.totalRounds).toBe(5);
+    expect(bootstrapResult.gameConfig.rules.totalRounds).toBe(5);
   });
 });


### PR DESCRIPTION
## 관련 이슈
- Close #387

## 개요

gameplay 세션 진입 과정에서 인증 확인, bootstrap 실행, bootstrap 결과 적용 책임이 서로 섞여 있던 구조를 정리했습니다.

이번 변경은 canvas 중심 구조를 유지하면서도, 이후 로비/방 확장과 모바일 지원 시 진입 문맥을 분리하기 쉬운 형태로 만드는 1차 리팩토링입니다.

## 변경사항

- `useGameplayBootstrap`이 bootstrap 데이터 조회만 담당하도록 정리
- bootstrap 내부의 `gameConfig` 전역 적용 제거
- bootstrap 결과의 `gameConfig` 적용 책임을 상위 gameplay orchestration으로 이동
- `useGameSession` 내부에서 세션 접근 확인, bootstrap 실행, bootstrap 성공 후처리 단계를 분리
- `initializeSession()`이 개별 단계를 조합하는 coordinator 역할만 하도록 정리

## 코드 흐름

- 사용자가 gameplay 화면에 진입하면 `useGameSession`이 세션 초기화 흐름을 시작합니다.
- `verifySessionAccess()`가 인증 및 세션 접근 가능 여부를 확인합니다.
- 접근 가능하면 `runBootstrap()`이 bootstrap 데이터를 조회합니다.
- `useGameplayBootstrap`은 현재 canvas/gameplay 진입에 필요한 데이터를 조회해서 반환만 합니다.
- `useCanvasGameplay`가 bootstrap 결과를 받아 현재 문맥에 맞게 `gameConfig`와 gameplay 상태를 적용합니다.
- bootstrap 성공 후 필요한 후처리는 `handleBootstrapSuccess()`가 담당합니다.

## 검증

- `tsc --noEmit -p frontend/tsconfig.app.json` 통과
- 기존 프로필 기준 gameplay 진입 동작 확인
- `config32` 등 기존 프로필은 정상 진입 확인
- `configtest`의 `30x30` 설정 미노출 이슈는 이번 리팩토링 범위가 아니라 별도 설정/렌더링 호환성 이슈로 분리해서 봅니다

## 결정사항

- 이번 단계에서는 `gameConfig` 전역 mutable 의존을 완전히 제거하지 않고, bootstrap 내부 직접 적용만 제거합니다.
- 이번 단계에서는 파일/훅을 대규모로 쪼개지 않고, 기존 파일 내부에서 책임 경계를 먼저 분리합니다.
- participant, summary, ticket 동기화 구조 개편은 이번 PR 범위에 포함하지 않습니다.

## 리뷰 포인트

- bootstrap이 조회만 담당하고, 결과 적용이 상위 orchestration으로 이동한 흐름이 의도에 맞는지
- `useGameSession`의 세션 접근 확인, bootstrap 실행, 성공 후처리 분리 경계가 이후 로비/방 진입 확장에 충분한지
- 이번 단계에서 파일 분리보다 내부 책임 경계 분리를 우선한 접근이 적절한지
