### PR TITLE
refactor: gameplay 세션 책임 분리와 phase/timer 동기화 

### DIFF
--- a/backend/src/modules/canvas/canvas.controller.ts
+++ b/backend/src/modules/canvas/canvas.controller.ts
@@ -140,6 +140,7 @@ export const canvasController = {
 
       return res.json({
         canvas: serializeCanvas(canvas),
+        serverNow: new Date().toISOString(),
         gameConfig: getCanvasGameConfigSnapshot(canvas),
       });
     } catch (err) {

--- a/backend/src/modules/game/game.timer.ts
+++ b/backend/src/modules/game/game.timer.ts
@@ -154,6 +154,7 @@ async function transitionToRoundStartWait(
     roundNumber,
     roundDurationSec: canvasGameConfig.phases.roundStartWaitSec,
     remainingSeconds: canvasGameConfig.phases.roundStartWaitSec,
+    serverNow: phaseStartedAt,
     totalRounds: canvasGameConfig.rules.totalRounds,
     phaseStartedAt,
     phaseEndsAt,
@@ -213,6 +214,7 @@ async function transitionToGameEnd(
     roundNumber,
     roundDurationSec: canvasGameConfig.phases.gameEndWaitSec,
     remainingSeconds: canvasGameConfig.phases.gameEndWaitSec,
+    serverNow: phaseStartedAt,
     totalRounds: canvasGameConfig.rules.totalRounds,
     phaseStartedAt,
     phaseEndsAt,
@@ -271,6 +273,7 @@ function emitPhaseUpdated(
     roundNumber: number | null;
     roundDurationSec: number | null;
     remainingSeconds: number | null;
+    serverNow: Date;
     totalRounds: number;
     phaseStartedAt: Date | null;
     phaseEndsAt: Date | null;
@@ -283,6 +286,7 @@ function emitPhaseUpdated(
     roundNumber: payload.roundNumber,
     roundDurationSec: payload.roundDurationSec,
     remainingSeconds: payload.remainingSeconds,
+    serverNow: payload.serverNow.toISOString(),
     totalRounds: payload.totalRounds,
     phaseStartedAt: payload.phaseStartedAt?.toISOString() ?? null,
     phaseEndsAt: payload.phaseEndsAt?.toISOString() ?? null,
@@ -484,6 +488,7 @@ async function resumeRoundStartWaitFromBoundary(
     roundNumber: nextRoundNumber,
     roundDurationSec: canvasGameConfig.phases.roundStartWaitSec,
     remainingSeconds: getPhaseRemainingSeconds(waitEndsAt),
+    serverNow: new Date(),
     totalRounds: canvasGameConfig.rules.totalRounds,
     phaseStartedAt: waitStartedAt,
     phaseEndsAt: waitEndsAt,
@@ -542,6 +547,7 @@ async function resumeGameEndFromBoundary(
     roundNumber,
     roundDurationSec: canvasGameConfig.phases.gameEndWaitSec,
     remainingSeconds: getPhaseRemainingSeconds(gameEndEndsAt),
+    serverNow: new Date(),
     totalRounds: canvasGameConfig.rules.totalRounds,
     phaseStartedAt: gameEndStartedAt,
     phaseEndsAt: gameEndEndsAt,

--- a/backend/src/modules/game/game.timer.ts
+++ b/backend/src/modules/game/game.timer.ts
@@ -147,6 +147,17 @@ async function transitionToRoundStartWait(
     reason: "round start wait transition",
   });
 
+  emitPhaseUpdated(io, {
+    canvasId,
+    phase: GamePhase.ROUND_START_WAIT,
+    roundId: null,
+    roundNumber,
+    roundDurationSec: canvasGameConfig.phases.roundStartWaitSec,
+    totalRounds: canvasGameConfig.rules.totalRounds,
+    phaseStartedAt,
+    phaseEndsAt,
+  });
+
   scheduleTimer(
     canvasId,
     () => {
@@ -194,6 +205,17 @@ async function transitionToGameEnd(
     reason: "game end transition",
   });
 
+  emitPhaseUpdated(io, {
+    canvasId,
+    phase: GamePhase.GAME_END,
+    roundId: null,
+    roundNumber,
+    roundDurationSec: canvasGameConfig.phases.gameEndWaitSec,
+    totalRounds: canvasGameConfig.rules.totalRounds,
+    phaseStartedAt,
+    phaseEndsAt,
+  });
+
   const gameSummary = await summaryService.saveGameSummary(canvasId);
 
   void publicLandingPreviewService.generateForGame(canvasId, gameSummary.id);
@@ -236,6 +258,31 @@ function scheduleGameEnd(
     },
     delayMs,
   );
+}
+
+function emitPhaseUpdated(
+  io: Server,
+  payload: {
+    canvasId: number;
+    phase: GamePhase;
+    roundId: number | null;
+    roundNumber: number | null;
+    roundDurationSec: number | null;
+    totalRounds: number;
+    phaseStartedAt: Date | null;
+    phaseEndsAt: Date | null;
+  },
+): void {
+  io.to(`canvas:${payload.canvasId}`).emit("canvas:phase-updated", {
+    canvasId: payload.canvasId,
+    phase: payload.phase,
+    roundId: payload.roundId,
+    roundNumber: payload.roundNumber,
+    roundDurationSec: payload.roundDurationSec,
+    totalRounds: payload.totalRounds,
+    phaseStartedAt: payload.phaseStartedAt?.toISOString() ?? null,
+    phaseEndsAt: payload.phaseEndsAt?.toISOString() ?? null,
+  });
 }
 
 function startRoundBroadcast(
@@ -412,6 +459,17 @@ async function resumeRoundStartWaitFromBoundary(
     reason: "round start wait resume",
   });
 
+  emitPhaseUpdated(io, {
+    canvasId: canvas.id,
+    phase: GamePhase.ROUND_START_WAIT,
+    roundId: null,
+    roundNumber: nextRoundNumber,
+    roundDurationSec: canvasGameConfig.phases.roundStartWaitSec,
+    totalRounds: canvasGameConfig.rules.totalRounds,
+    phaseStartedAt: waitStartedAt,
+    phaseEndsAt: waitEndsAt,
+  });
+
   const delayMs = Math.max(0, waitEndsAt.getTime() - Date.now());
 
   if (delayMs === 0) {
@@ -456,6 +514,17 @@ async function resumeGameEndFromBoundary(
     phaseStartedAt: gameEndStartedAt,
     phaseEndsAt: gameEndEndsAt,
     reason: "game end resume",
+  });
+
+  emitPhaseUpdated(io, {
+    canvasId: canvas.id,
+    phase: GamePhase.GAME_END,
+    roundId: null,
+    roundNumber,
+    roundDurationSec: canvasGameConfig.phases.gameEndWaitSec,
+    totalRounds: canvasGameConfig.rules.totalRounds,
+    phaseStartedAt: gameEndStartedAt,
+    phaseEndsAt: gameEndEndsAt,
   });
 
   if (gameEndEndsAt.getTime() <= Date.now()) {

--- a/backend/src/modules/game/game.timer.ts
+++ b/backend/src/modules/game/game.timer.ts
@@ -153,6 +153,7 @@ async function transitionToRoundStartWait(
     roundId: null,
     roundNumber,
     roundDurationSec: canvasGameConfig.phases.roundStartWaitSec,
+    remainingSeconds: canvasGameConfig.phases.roundStartWaitSec,
     totalRounds: canvasGameConfig.rules.totalRounds,
     phaseStartedAt,
     phaseEndsAt,
@@ -211,6 +212,7 @@ async function transitionToGameEnd(
     roundId: null,
     roundNumber,
     roundDurationSec: canvasGameConfig.phases.gameEndWaitSec,
+    remainingSeconds: canvasGameConfig.phases.gameEndWaitSec,
     totalRounds: canvasGameConfig.rules.totalRounds,
     phaseStartedAt,
     phaseEndsAt,
@@ -268,6 +270,7 @@ function emitPhaseUpdated(
     roundId: number | null;
     roundNumber: number | null;
     roundDurationSec: number | null;
+    remainingSeconds: number | null;
     totalRounds: number;
     phaseStartedAt: Date | null;
     phaseEndsAt: Date | null;
@@ -279,10 +282,20 @@ function emitPhaseUpdated(
     roundId: payload.roundId,
     roundNumber: payload.roundNumber,
     roundDurationSec: payload.roundDurationSec,
+    remainingSeconds: payload.remainingSeconds,
     totalRounds: payload.totalRounds,
     phaseStartedAt: payload.phaseStartedAt?.toISOString() ?? null,
     phaseEndsAt: payload.phaseEndsAt?.toISOString() ?? null,
   });
+}
+
+function getPhaseRemainingSeconds(phaseEndsAt: Date | null): number | null {
+  if (!phaseEndsAt) {
+    return null;
+  }
+
+  const diffMs = phaseEndsAt.getTime() - Date.now();
+  return diffMs <= 0 ? 0 : Math.max(1, Math.floor(diffMs / 1000));
 }
 
 function startRoundBroadcast(
@@ -319,6 +332,11 @@ function startRoundBroadcast(
       roundNumber: round.roundNumber,
       remainingSeconds,
       isRoundExpired,
+      serverNow: new Date().toISOString(),
+      roundEndsAt: new Date(
+        round.startedAt.getTime() +
+          canvasGameConfig.phases.roundDurationSec * 1000,
+      ).toISOString(),
       roundDurationSec: canvasGameConfig.phases.roundDurationSec,
       totalRounds: canvasGameConfig.rules.totalRounds,
       gameEndAt: gameEndAt.toISOString(),
@@ -465,6 +483,7 @@ async function resumeRoundStartWaitFromBoundary(
     roundId: null,
     roundNumber: nextRoundNumber,
     roundDurationSec: canvasGameConfig.phases.roundStartWaitSec,
+    remainingSeconds: getPhaseRemainingSeconds(waitEndsAt),
     totalRounds: canvasGameConfig.rules.totalRounds,
     phaseStartedAt: waitStartedAt,
     phaseEndsAt: waitEndsAt,
@@ -522,6 +541,7 @@ async function resumeGameEndFromBoundary(
     roundId: null,
     roundNumber,
     roundDurationSec: canvasGameConfig.phases.gameEndWaitSec,
+    remainingSeconds: getPhaseRemainingSeconds(gameEndEndsAt),
     totalRounds: canvasGameConfig.rules.totalRounds,
     phaseStartedAt: gameEndStartedAt,
     phaseEndsAt: gameEndEndsAt,

--- a/backend/src/modules/round/round.service.ts
+++ b/backend/src/modules/round/round.service.ts
@@ -40,6 +40,8 @@ interface RoundStateResponse {
   timer: {
     remainingSeconds: number;
     isRoundExpired: boolean;
+    serverNow: string;
+    roundEndsAt: string;
     roundDurationSec: number;
     totalRounds: number;
     gameEndAt: string;
@@ -79,6 +81,7 @@ function emitPhaseUpdated(
     roundId: number | null;
     roundNumber: number | null;
     roundDurationSec: number | null;
+    remainingSeconds: number | null;
     totalRounds: number;
     phaseStartedAt: Date | null;
     phaseEndsAt: Date | null;
@@ -90,6 +93,7 @@ function emitPhaseUpdated(
     roundId: payload.roundId,
     roundNumber: payload.roundNumber,
     roundDurationSec: payload.roundDurationSec,
+    remainingSeconds: payload.remainingSeconds,
     totalRounds: payload.totalRounds,
     phaseStartedAt: payload.phaseStartedAt?.toISOString() ?? null,
     phaseEndsAt: payload.phaseEndsAt?.toISOString() ?? null,
@@ -236,6 +240,8 @@ export const roundService = {
         roundId: round.id,
         roundNumber: round.roundNumber,
         startedAt: round.startedAt,
+        serverNow: new Date().toISOString(),
+        roundEndsAt: roundEndsAt.toISOString(),
         roundDurationSec: canvasGameConfig.phases.roundDurationSec,
         totalRounds: canvasGameConfig.rules.totalRounds,
         gameEndAt: gameEndAt.toISOString(),
@@ -246,6 +252,7 @@ export const roundService = {
         roundId: round.id,
         roundNumber: round.roundNumber,
         roundDurationSec: canvasGameConfig.phases.roundDurationSec,
+        remainingSeconds: canvasGameConfig.phases.roundDurationSec,
         totalRounds: canvasGameConfig.rules.totalRounds,
         phaseStartedAt: round.startedAt,
         phaseEndsAt: roundEndsAt,
@@ -462,6 +469,7 @@ export const roundService = {
         roundId: round.id,
         roundNumber: round.roundNumber,
         roundDurationSec: canvasGameConfig.phases.roundResultDelaySec,
+        remainingSeconds: canvasGameConfig.phases.roundResultDelaySec,
         totalRounds: canvasGameConfig.rules.totalRounds,
         phaseStartedAt: round.endedAt,
         phaseEndsAt: roundResultEndsAt,
@@ -535,6 +543,11 @@ export const roundService = {
         timer: {
           remainingSeconds,
           isRoundExpired: remainingSeconds === 0,
+          serverNow: now.toISOString(),
+          roundEndsAt: new Date(
+            activeRound.startedAt.getTime() +
+              canvasGameConfig.phases.roundDurationSec * 1000,
+          ).toISOString(),
           roundDurationSec: canvasGameConfig.phases.roundDurationSec,
           totalRounds: canvasGameConfig.rules.totalRounds,
           gameEndAt: gameEndAt.toISOString(),
@@ -580,6 +593,8 @@ export const roundService = {
       timer: {
         remainingSeconds: 0,
         isRoundExpired: true,
+        serverNow: now.toISOString(),
+        roundEndsAt: waitingDeadline.toISOString(),
         roundDurationSec: canvasGameConfig.phases.roundDurationSec,
         totalRounds: canvasGameConfig.rules.totalRounds,
         gameEndAt: gameEndAt.toISOString(),

--- a/backend/src/modules/round/round.service.ts
+++ b/backend/src/modules/round/round.service.ts
@@ -82,6 +82,7 @@ function emitPhaseUpdated(
     roundNumber: number | null;
     roundDurationSec: number | null;
     remainingSeconds: number | null;
+    serverNow: Date;
     totalRounds: number;
     phaseStartedAt: Date | null;
     phaseEndsAt: Date | null;
@@ -94,6 +95,7 @@ function emitPhaseUpdated(
     roundNumber: payload.roundNumber,
     roundDurationSec: payload.roundDurationSec,
     remainingSeconds: payload.remainingSeconds,
+    serverNow: payload.serverNow.toISOString(),
     totalRounds: payload.totalRounds,
     phaseStartedAt: payload.phaseStartedAt?.toISOString() ?? null,
     phaseEndsAt: payload.phaseEndsAt?.toISOString() ?? null,
@@ -253,6 +255,7 @@ export const roundService = {
         roundNumber: round.roundNumber,
         roundDurationSec: canvasGameConfig.phases.roundDurationSec,
         remainingSeconds: canvasGameConfig.phases.roundDurationSec,
+        serverNow: roundStartedAt,
         totalRounds: canvasGameConfig.rules.totalRounds,
         phaseStartedAt: round.startedAt,
         phaseEndsAt: roundEndsAt,
@@ -470,6 +473,7 @@ export const roundService = {
         roundNumber: round.roundNumber,
         roundDurationSec: canvasGameConfig.phases.roundResultDelaySec,
         remainingSeconds: canvasGameConfig.phases.roundResultDelaySec,
+        serverNow: round.endedAt,
         totalRounds: canvasGameConfig.rules.totalRounds,
         phaseStartedAt: round.endedAt,
         phaseEndsAt: roundResultEndsAt,

--- a/backend/src/modules/round/round.service.ts
+++ b/backend/src/modules/round/round.service.ts
@@ -71,6 +71,31 @@ function logPhaseChange(params: {
   );
 }
 
+function emitPhaseUpdated(
+  io: Server,
+  payload: {
+    canvasId: number;
+    phase: GamePhase;
+    roundId: number | null;
+    roundNumber: number | null;
+    roundDurationSec: number | null;
+    totalRounds: number;
+    phaseStartedAt: Date | null;
+    phaseEndsAt: Date | null;
+  },
+): void {
+  io.to(`canvas:${payload.canvasId}`).emit("canvas:phase-updated", {
+    canvasId: payload.canvasId,
+    phase: payload.phase,
+    roundId: payload.roundId,
+    roundNumber: payload.roundNumber,
+    roundDurationSec: payload.roundDurationSec,
+    totalRounds: payload.totalRounds,
+    phaseStartedAt: payload.phaseStartedAt?.toISOString() ?? null,
+    phaseEndsAt: payload.phaseEndsAt?.toISOString() ?? null,
+  });
+}
+
 function getActiveGameEndAt(
   config: GameConfigSnapshot,
   roundStartedAt: Date,
@@ -214,6 +239,16 @@ export const roundService = {
         roundDurationSec: canvasGameConfig.phases.roundDurationSec,
         totalRounds: canvasGameConfig.rules.totalRounds,
         gameEndAt: gameEndAt.toISOString(),
+      });
+      emitPhaseUpdated(io, {
+        canvasId,
+        phase: GamePhase.ROUND_ACTIVE,
+        roundId: round.id,
+        roundNumber: round.roundNumber,
+        roundDurationSec: canvasGameConfig.phases.roundDurationSec,
+        totalRounds: canvasGameConfig.rules.totalRounds,
+        phaseStartedAt: round.startedAt,
+        phaseEndsAt: roundEndsAt,
       });
       await participantSessionService.broadcastParticipantsUpdated(io, canvasId);
     }
@@ -421,6 +456,16 @@ export const roundService = {
 
     await redisClient.del(redisKey);
     if (io) {
+      emitPhaseUpdated(io, {
+        canvasId,
+        phase: GamePhase.ROUND_RESULT,
+        roundId: round.id,
+        roundNumber: round.roundNumber,
+        roundDurationSec: canvasGameConfig.phases.roundResultDelaySec,
+        totalRounds: canvasGameConfig.rules.totalRounds,
+        phaseStartedAt: round.endedAt,
+        phaseEndsAt: roundResultEndsAt,
+      });
       io.to(`canvas:${canvasId}`).emit("round:ended", {
         roundId: round.id,
         roundNumber: round.roundNumber,

--- a/frontend/src/features/gameplay/round/hooks/useRoundTimer.ts
+++ b/frontend/src/features/gameplay/round/hooks/useRoundTimer.ts
@@ -20,6 +20,19 @@ function getRemainingSecondsFromPhaseEnd(phaseEndsAt: string): number {
   return Math.max(1, Math.ceil((diffMs - 10) / 1000));
 }
 
+function getRemainingSecondsFromServerPhaseClock(
+  endsAt: string,
+  serverOffsetMs: number,
+): number {
+  const diffMs = new Date(endsAt).getTime() - (Date.now() + serverOffsetMs);
+
+  if (diffMs <= 0) {
+    return 0;
+  }
+
+  return Math.max(1, Math.ceil((diffMs - 10) / 1000));
+}
+
 function getRemainingSecondsFromServerClock(
   endsAt: string,
   serverOffsetMs: number,
@@ -78,7 +91,11 @@ export default function useRoundTimer() {
   );
 
   const setPhaseTimerState = useCallback(
-    (phaseEndsAt: string | null, expired: boolean) => {
+    (
+      phaseEndsAt: string | null,
+      serverOffsetMs: number,
+      expired: boolean,
+    ) => {
       if (!phaseEndsAt) {
         setRoundTimerState({
           remainingSeconds: null,
@@ -88,7 +105,13 @@ export default function useRoundTimer() {
         return;
       }
 
-      const remaining = getRemainingSecondsFromPhaseEnd(phaseEndsAt);
+      const remaining =
+        serverOffsetMs === 0
+          ? getRemainingSecondsFromPhaseEnd(phaseEndsAt)
+          : getRemainingSecondsFromServerPhaseClock(
+              phaseEndsAt,
+              serverOffsetMs,
+            );
 
       setRoundTimerState({
         remainingSeconds: remaining,

--- a/frontend/src/features/gameplay/round/hooks/useRoundTimer.ts
+++ b/frontend/src/features/gameplay/round/hooks/useRoundTimer.ts
@@ -10,6 +10,29 @@ interface RoundTimerStateValue {
   isRoundExpired: boolean;
 }
 
+function getRemainingSecondsFromPhaseEnd(phaseEndsAt: string): number {
+  const diffMs = new Date(phaseEndsAt).getTime() - Date.now();
+
+  if (diffMs <= 0) {
+    return 0;
+  }
+
+  return Math.max(1, Math.ceil((diffMs - 10) / 1000));
+}
+
+function getRemainingSecondsFromServerClock(
+  endsAt: string,
+  serverOffsetMs: number,
+): number {
+  const diffMs = new Date(endsAt).getTime() - (Date.now() + serverOffsetMs);
+
+  if (diffMs <= 0) {
+    return 0;
+  }
+
+  return Math.max(1, Math.ceil((diffMs - 10) / 1000));
+}
+
 export default function useRoundTimer() {
   const [remainingSeconds, setRemainingSeconds] = useState<number | null>(null);
   const [formattedRemainingTime, setFormattedRemainingTime] = useState<
@@ -34,6 +57,26 @@ export default function useRoundTimer() {
     [setRoundTimerState],
   );
 
+  const applyPhaseTimerSnapshot = useCallback(
+    (remainingSeconds: number | null, expired: boolean) => {
+      if (remainingSeconds === null) {
+        setRoundTimerState({
+          remainingSeconds: null,
+          formattedRemainingTime: null,
+          isRoundExpired: expired,
+        });
+        return;
+      }
+
+      setRoundTimerState({
+        remainingSeconds,
+        formattedRemainingTime: formatDuration(remainingSeconds),
+        isRoundExpired: expired,
+      });
+    },
+    [setRoundTimerState],
+  );
+
   const setPhaseTimerState = useCallback(
     (phaseEndsAt: string | null, expired: boolean) => {
       if (!phaseEndsAt) {
@@ -45,9 +88,31 @@ export default function useRoundTimer() {
         return;
       }
 
-      const remaining = Math.max(
-        0,
-        Math.ceil((new Date(phaseEndsAt).getTime() - Date.now()) / 1000),
+      const remaining = getRemainingSecondsFromPhaseEnd(phaseEndsAt);
+
+      setRoundTimerState({
+        remainingSeconds: remaining,
+        formattedRemainingTime: formatDuration(remaining),
+        isRoundExpired: expired || remaining === 0,
+      });
+    },
+    [setRoundTimerState],
+  );
+
+  const setActiveRoundTimerState = useCallback(
+    (roundEndsAt: string | null, serverOffsetMs: number, expired: boolean) => {
+      if (!roundEndsAt) {
+        setRoundTimerState({
+          remainingSeconds: null,
+          formattedRemainingTime: null,
+          isRoundExpired: expired,
+        });
+        return;
+      }
+
+      const remaining = getRemainingSecondsFromServerClock(
+        roundEndsAt,
+        serverOffsetMs,
       );
 
       setRoundTimerState({
@@ -92,7 +157,9 @@ export default function useRoundTimer() {
     isRoundExpired,
     setRoundTimerState,
     applyRoundTimer,
+    applyPhaseTimerSnapshot,
     setPhaseTimerState,
+    setActiveRoundTimerState,
     startRoundTimer,
     expireRoundTimer,
     resetRoundTimer,

--- a/frontend/src/features/gameplay/session/api/session.api.ts
+++ b/frontend/src/features/gameplay/session/api/session.api.ts
@@ -6,6 +6,7 @@ import type { GamePhase } from "../model/game-phase.types";
 
 export interface CanvasCurrentResponse {
   canvas: Canvas;
+  serverNow: string;
   gameConfig: GameConfig;
 }
 

--- a/frontend/src/features/gameplay/session/api/session.api.ts
+++ b/frontend/src/features/gameplay/session/api/session.api.ts
@@ -26,6 +26,8 @@ export interface RoundStateResponse {
   timer: {
     remainingSeconds: number;
     isRoundExpired: boolean;
+    serverNow: string;
+    roundEndsAt: string;
     roundDurationSec: number;
     totalRounds: number;
     gameEndAt: string;

--- a/frontend/src/features/gameplay/session/hooks/useGameplayBootstrap.ts
+++ b/frontend/src/features/gameplay/session/hooks/useGameplayBootstrap.ts
@@ -23,10 +23,13 @@ function getRemainingSeconds(phaseEndsAt: string | null): number | null {
     return null;
   }
 
-  return Math.max(
-    0,
-    Math.ceil((new Date(phaseEndsAt).getTime() - Date.now()) / 1000),
-  );
+  const diffMs = new Date(phaseEndsAt).getTime() - Date.now();
+
+  if (diffMs <= 0) {
+    return 0;
+  }
+
+  return Math.max(1, Math.ceil((diffMs - 10) / 1000));
 }
 
 function getPhaseDurationSeconds(
@@ -317,6 +320,7 @@ export function useGameplayBootstrap() {
           : (roundState?.timer?.isRoundExpired ?? false),
       phaseStartedAt: canvas.phaseStartedAt,
       phaseEndsAt: canvas.phaseEndsAt,
+      timerServerNow: roundState?.timer?.serverNow ?? null,
     };
 
     return {

--- a/frontend/src/features/gameplay/session/hooks/useGameplayBootstrap.ts
+++ b/frontend/src/features/gameplay/session/hooks/useGameplayBootstrap.ts
@@ -238,7 +238,7 @@ function getFallbackPhaseDuration(
 export function useGameplayBootstrap() {
   const bootstrap = useCallback(async (): Promise<SessionBootstrapResult> => {
     const { data } = await sessionApi.getCurrentCanvas();
-    const { canvas, gameConfig } = data;
+    const { canvas, serverNow, gameConfig } = data;
     const { phases, rules } = gameConfig;
 
     let roundState: RoundStateResponse | null = null;
@@ -320,7 +320,7 @@ export function useGameplayBootstrap() {
           : (roundState?.timer?.isRoundExpired ?? false),
       phaseStartedAt: canvas.phaseStartedAt,
       phaseEndsAt: canvas.phaseEndsAt,
-      timerServerNow: roundState?.timer?.serverNow ?? null,
+      timerServerNow: roundState?.timer?.serverNow ?? serverNow,
     };
 
     return {

--- a/frontend/src/features/gameplay/session/hooks/useGameplaySocket.ts
+++ b/frontend/src/features/gameplay/session/hooks/useGameplaySocket.ts
@@ -5,6 +5,7 @@ import {
   CanvasJoinedPayload,
   CanvasUpdatedPayload,
   GameSummaryReadyPayload,
+  PhaseUpdatedPayload,
   ParticipantsUpdatedPayload,
   RoundEndedPayload,
   RoundStartedPayload,
@@ -17,6 +18,7 @@ import {
 interface UseGameplaySocketParams {
   canvasId: number | null;
   onCanvasJoined: (payload: CanvasJoinedPayload) => void;
+  onPhaseUpdated: (payload: PhaseUpdatedPayload) => void;
   onRoundStarted: (payload: RoundStartedPayload) => void;
   onRoundEnded: (payload: RoundEndedPayload) => void;
   onRoundSummaryReady: (payload: RoundSummaryReadyPayload) => void;
@@ -35,6 +37,7 @@ type GameplaySocketHandlers = Omit<UseGameplaySocketParams, "canvasId">;
 export function useGameplaySocket({
   canvasId,
   onCanvasJoined,
+  onPhaseUpdated,
   onRoundStarted,
   onRoundEnded,
   onRoundSummaryReady,
@@ -49,6 +52,7 @@ export function useGameplaySocket({
 }: UseGameplaySocketParams) {
   const handlersRef = useRef<GameplaySocketHandlers>({
     onCanvasJoined,
+    onPhaseUpdated,
     onRoundStarted,
     onRoundEnded,
     onRoundSummaryReady,
@@ -65,6 +69,7 @@ export function useGameplaySocket({
   useEffect(() => {
     handlersRef.current = {
       onCanvasJoined,
+      onPhaseUpdated,
       onRoundStarted,
       onRoundEnded,
       onRoundSummaryReady,
@@ -79,6 +84,7 @@ export function useGameplaySocket({
     };
   }, [
     onCanvasJoined,
+    onPhaseUpdated,
     onRoundStarted,
     onRoundEnded,
     onRoundSummaryReady,
@@ -95,6 +101,9 @@ export function useGameplaySocket({
   useEffect(() => {
     const handleCanvasJoined = (payload: CanvasJoinedPayload) => {
       handlersRef.current.onCanvasJoined(payload);
+    };
+    const handlePhaseUpdated = (payload: PhaseUpdatedPayload) => {
+      handlersRef.current.onPhaseUpdated(payload);
     };
     const handleRoundStarted = (payload: RoundStartedPayload) => {
       handlersRef.current.onRoundStarted(payload);
@@ -131,6 +140,7 @@ export function useGameplaySocket({
     };
 
     socket.on("canvas:joined", handleCanvasJoined);
+    socket.on("canvas:phase-updated", handlePhaseUpdated);
     socket.on("round:started", handleRoundStarted);
     socket.on("round:ended", handleRoundEnded);
     socket.on("round-summary:ready", handleRoundSummaryReady);
@@ -146,6 +156,7 @@ export function useGameplaySocket({
 
     return () => {
       socket.off("canvas:joined", handleCanvasJoined);
+      socket.off("canvas:phase-updated", handlePhaseUpdated);
       socket.off("round:started", handleRoundStarted);
       socket.off("round:ended", handleRoundEnded);
       socket.off("round-summary:ready", handleRoundSummaryReady);

--- a/frontend/src/features/gameplay/session/hooks/useParticipantsState.ts
+++ b/frontend/src/features/gameplay/session/hooks/useParticipantsState.ts
@@ -7,17 +7,6 @@ export default function useParticipantsState() {
   const [participantLoading, setParticipantLoading] = useState(false);
   const [participantError, setParticipantError] = useState<string | null>(null);
 
-  const refreshParticipantCount = useCallback(async () => {
-    try {
-      const { data } = await sessionApi.getCurrentParticipantCount();
-      setParticipantCount(data.count);
-      return data.count;
-    } catch {
-      setParticipantCount(null);
-      return null;
-    }
-  }, []);
-
   const refreshParticipants = useCallback(async () => {
     setParticipantLoading(true);
     setParticipantError(null);
@@ -42,10 +31,6 @@ export default function useParticipantsState() {
     } finally {
       setParticipantLoading(false);
     }
-  }, []);
-
-  const applyParticipantCount = useCallback((count: number) => {
-    setParticipantCount(count);
   }, []);
 
   const applyParticipantsSnapshot = useCallback(
@@ -87,9 +72,7 @@ export default function useParticipantsState() {
     participantLoading,
     participantError,
     participantSummary,
-    refreshParticipantCount,
     refreshParticipants,
-    applyParticipantCount,
     applyParticipantsSnapshot,
     clearParticipants,
   };

--- a/frontend/src/features/gameplay/session/model/session.types.ts
+++ b/frontend/src/features/gameplay/session/model/session.types.ts
@@ -13,6 +13,7 @@ export interface RoundInfoState {
   isRoundExpired: boolean;
   phaseStartedAt: string | null;
   phaseEndsAt: string | null;
+  timerServerNow: string | null;
 }
 
 export interface PhaseTimingState {

--- a/frontend/src/features/gameplay/session/model/socket.types.ts
+++ b/frontend/src/features/gameplay/session/model/socket.types.ts
@@ -13,6 +13,7 @@ export interface PhaseUpdatedPayload {
   roundNumber: number | null;
   roundDurationSec: number | null;
   remainingSeconds: number | null;
+  serverNow: string;
   totalRounds: number;
   phaseStartedAt: string | null;
   phaseEndsAt: string | null;

--- a/frontend/src/features/gameplay/session/model/socket.types.ts
+++ b/frontend/src/features/gameplay/session/model/socket.types.ts
@@ -1,13 +1,29 @@
+import type { GamePhase } from "./game-phase.types";
+
 export interface CanvasJoinedPayload {
   canvasId: number;
   status: "voting" | "waiting";
   restored: boolean;
 }
 
+export interface PhaseUpdatedPayload {
+  canvasId: number;
+  phase: GamePhase;
+  roundId: number | null;
+  roundNumber: number | null;
+  roundDurationSec: number | null;
+  remainingSeconds: number | null;
+  totalRounds: number;
+  phaseStartedAt: string | null;
+  phaseEndsAt: string | null;
+}
+
 export interface RoundStartedPayload {
   roundId: number;
   roundNumber: number;
   startedAt: string;
+  serverNow: string;
+  roundEndsAt: string;
   roundDurationSec: number;
   totalRounds: number;
   gameEndAt: string;
@@ -49,6 +65,8 @@ export interface TimerUpdatePayload {
   roundNumber: number;
   remainingSeconds: number;
   isRoundExpired: boolean;
+  serverNow: string;
+  roundEndsAt: string;
   roundDurationSec: number;
   totalRounds: number;
   gameEndAt: string;

--- a/frontend/src/features/gameplay/vote/hooks/useVoteTickets.ts
+++ b/frontend/src/features/gameplay/vote/hooks/useVoteTickets.ts
@@ -1,27 +1,69 @@
-import { useCallback, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 import { voteApi } from "../api/vote.api";
 
 export default function useVoteTickets() {
   const [remaining, setRemaining] = useState<number | null>(null);
+  const latestTicketRequestKeyRef = useRef<string | null>(null);
+  const inFlightTicketRequestRef = useRef<{
+    key: string;
+    promise: Promise<number | null>;
+  } | null>(null);
+
+  const applyRemainingSnapshot = useCallback(
+    (roundId: number | null, nextRemaining: number | null) => {
+      latestTicketRequestKeyRef.current =
+        roundId === null ? null : `round:${roundId}`;
+      setRemaining(nextRemaining);
+    },
+    [],
+  );
 
   const fetchTickets = useCallback(async (roundId: number) => {
-    try {
-      const { data } = await voteApi.getTickets(roundId);
-      setRemaining(data.remaining);
-      return data.remaining;
-    } catch {
-      setRemaining(null);
-      return null;
+    const requestKey = `round:${roundId}`;
+    latestTicketRequestKeyRef.current = requestKey;
+
+    if (inFlightTicketRequestRef.current?.key === requestKey) {
+      return inFlightTicketRequestRef.current.promise;
     }
+
+    const promise = (async () => {
+      try {
+        const { data } = await voteApi.getTickets(roundId);
+
+        if (latestTicketRequestKeyRef.current === requestKey) {
+          setRemaining(data.remaining);
+        }
+
+        return data.remaining;
+      } catch {
+        if (latestTicketRequestKeyRef.current === requestKey) {
+          setRemaining(null);
+        }
+
+        return null;
+      } finally {
+        if (inFlightTicketRequestRef.current?.key === requestKey) {
+          inFlightTicketRequestRef.current = null;
+        }
+      }
+    })();
+
+    inFlightTicketRequestRef.current = {
+      key: requestKey,
+      promise,
+    };
+
+    return promise;
   }, []);
 
   const clearTickets = useCallback(() => {
+    latestTicketRequestKeyRef.current = null;
     setRemaining(null);
   }, []);
 
   return {
     remaining,
-    setRemaining,
+    applyRemainingSnapshot,
     fetchTickets,
     clearTickets,
   };

--- a/frontend/src/pages/canvas/hooks/useGameplayPhaseSync.ts
+++ b/frontend/src/pages/canvas/hooks/useGameplayPhaseSync.ts
@@ -35,7 +35,11 @@ interface UseGameplayPhaseSyncParams {
     remainingSeconds: number | null,
     expired: boolean,
   ) => void;
-  setPhaseTimerState: (phaseEndsAt: string | null, expired: boolean) => void;
+  setPhaseTimerState: (
+    phaseEndsAt: string | null,
+    serverOffsetMs: number,
+    expired: boolean,
+  ) => void;
   setActiveRoundTimerState: (
     roundEndsAt: string | null,
     serverOffsetMs: number,
@@ -72,9 +76,18 @@ export default function useGameplayPhaseSync({
     serverOffsetMs: number;
     isRoundExpired: boolean;
   } | null>(null);
+  const phaseTimerRef = useRef<{
+    phaseEndsAt: string;
+    serverOffsetMs: number;
+    isRoundExpired: boolean;
+  } | null>(null);
 
   const clearActiveRoundTimer = useCallback(() => {
     activeRoundTimerRef.current = null;
+  }, []);
+
+  const clearPhaseTimer = useCallback(() => {
+    phaseTimerRef.current = null;
   }, []);
 
   const syncActiveRoundTimer = useCallback(
@@ -103,7 +116,8 @@ export default function useGameplayPhaseSync({
   const resetJoinedState = useCallback(() => {
     hasJoinedCanvasRef.current = false;
     clearActiveRoundTimer();
-  }, [clearActiveRoundTimer]);
+    clearPhaseTimer();
+  }, [clearActiveRoundTimer, clearPhaseTimer]);
 
   useEffect(() => {
     if (!isRoundActivePhase(phase)) {
@@ -138,23 +152,65 @@ export default function useGameplayPhaseSync({
       return;
     }
 
-    if (!phaseEndsAt) {
+    const timerState = phaseTimerRef.current;
+
+    if (!phaseEndsAt || !timerState) {
       return;
     }
 
-    const expired =
-      phase === GAME_PHASE.ROUND_RESULT || phase === GAME_PHASE.GAME_END;
-
-    setPhaseTimerState(phaseEndsAt, expired);
+    setPhaseTimerState(
+      timerState.phaseEndsAt,
+      timerState.serverOffsetMs,
+      timerState.isRoundExpired,
+    );
 
     const timer = window.setInterval(() => {
-      setPhaseTimerState(phaseEndsAt, expired);
+      const nextTimerState = phaseTimerRef.current;
+
+      if (!nextTimerState) {
+        return;
+      }
+
+      setPhaseTimerState(
+        nextTimerState.phaseEndsAt,
+        nextTimerState.serverOffsetMs,
+        nextTimerState.isRoundExpired,
+      );
     }, 250);
 
     return () => {
       window.clearInterval(timer);
     };
   }, [phase, phaseEndsAt, setPhaseTimerState]);
+
+  const syncPhaseTimer = useCallback(
+    ({
+      phaseEndsAt,
+      serverNow,
+      isRoundExpired,
+    }: {
+      phaseEndsAt: string | null;
+      serverNow: string;
+      isRoundExpired: boolean;
+    }) => {
+      if (!phaseEndsAt) {
+        clearPhaseTimer();
+        setPhaseTimerState(null, 0, isRoundExpired);
+        return;
+      }
+
+      const serverOffsetMs = new Date(serverNow).getTime() - Date.now();
+
+      phaseTimerRef.current = {
+        phaseEndsAt,
+        serverOffsetMs,
+        isRoundExpired,
+      };
+
+      setPhaseTimerState(phaseEndsAt, serverOffsetMs, isRoundExpired);
+    },
+    [clearPhaseTimer, setPhaseTimerState],
+  );
 
   const handleCanvasJoined = useCallback(
     ({ restored }: CanvasJoinedPayload) => {
@@ -197,6 +253,7 @@ export default function useGameplayPhaseSync({
       roundNumber: nextRoundNumber,
       roundDurationSec: nextRoundDurationSec,
       remainingSeconds: nextRemainingSeconds,
+      serverNow,
       totalRounds: nextTotalRounds,
       phaseStartedAt: nextPhaseStartedAt,
       phaseEndsAt: nextPhaseEndsAt,
@@ -206,6 +263,7 @@ export default function useGameplayPhaseSync({
       }
 
       if (nextPhase === GAME_PHASE.ROUND_ACTIVE) {
+        clearPhaseTimer();
         return;
       }
 
@@ -222,33 +280,36 @@ export default function useGameplayPhaseSync({
         phaseEndsAt: nextPhaseEndsAt,
       });
 
+      const expired = nextPhase === GAME_PHASE.GAME_END && nextRemainingSeconds === 0;
+
       if (nextRemainingSeconds !== null) {
         if (nextPhaseEndsAt) {
-          setPhaseTimerState(
-            nextPhaseEndsAt,
-            nextPhase === GAME_PHASE.GAME_END && nextRemainingSeconds === 0,
-          );
+          syncPhaseTimer({
+            phaseEndsAt: nextPhaseEndsAt,
+            serverNow,
+            isRoundExpired: expired,
+          });
         } else {
-          applyPhaseTimerSnapshot(
-            nextRemainingSeconds,
-            nextPhase === GAME_PHASE.GAME_END && nextRemainingSeconds === 0,
-          );
+          clearPhaseTimer();
+          applyPhaseTimerSnapshot(nextRemainingSeconds, expired);
         }
         return;
       }
 
-      setPhaseTimerState(
-        nextPhaseEndsAt,
-        nextPhase === GAME_PHASE.GAME_END && nextRemainingSeconds === 0,
-      );
+      syncPhaseTimer({
+        phaseEndsAt: nextPhaseEndsAt,
+        serverNow,
+        isRoundExpired: expired,
+      });
     },
     [
       applyPhaseTimerSnapshot,
       canvasId,
       clearActiveRoundTimer,
+      clearPhaseTimer,
       formattedGameEndTime,
-      setPhaseTimerState,
       setRoundState,
+      syncPhaseTimer,
     ],
   );
 
@@ -274,6 +335,7 @@ export default function useGameplayPhaseSync({
   return {
     clearActiveRoundTimer,
     syncActiveRoundTimer,
+    syncPhaseTimer,
     resetJoinedState,
     handleCanvasJoined,
     handleRoundEnded,

--- a/frontend/src/pages/canvas/hooks/useGameplayPhaseSync.ts
+++ b/frontend/src/pages/canvas/hooks/useGameplayPhaseSync.ts
@@ -1,0 +1,283 @@
+import { useCallback, useEffect, useRef } from "react";
+import type {
+  CanvasJoinedPayload,
+  PhaseUpdatedPayload,
+  RoundEndedPayload,
+  TimerUpdatePayload,
+} from "@/features/gameplay/session/model/socket.types";
+import {
+  GAME_PHASE,
+  isRoundActivePhase,
+} from "@/features/gameplay/session/model/game-phase.types";
+import type { GamePhase } from "@/features/gameplay/session/model/game-phase.types";
+
+interface UseGameplayPhaseSyncParams {
+  canvasId: number | null;
+  phase: GamePhase;
+  phaseEndsAt: string | null;
+  formattedGameEndTime: string | null;
+  refreshParticipants: () => Promise<unknown>;
+  resyncSession: () => Promise<unknown>;
+  clearTickets: () => void;
+  resetVoteState: () => void;
+  onRoundEndedCleanup: () => void;
+  setRoundState: (state: {
+    phase: GamePhase;
+    roundId: number | null;
+    roundNumber: number | null;
+    roundDurationSec: number | null;
+    totalRounds: number;
+    formattedGameEndTime: string | null;
+    phaseStartedAt: string | null;
+    phaseEndsAt: string | null;
+  }) => void;
+  applyPhaseTimerSnapshot: (
+    remainingSeconds: number | null,
+    expired: boolean,
+  ) => void;
+  setPhaseTimerState: (phaseEndsAt: string | null, expired: boolean) => void;
+  setActiveRoundTimerState: (
+    roundEndsAt: string | null,
+    serverOffsetMs: number,
+    expired: boolean,
+  ) => void;
+  applyRoundMeta: (timer: {
+    roundDurationSec: number;
+    totalRounds: number;
+    gameEndAt: string;
+  }) => void;
+  beginPendingRoundResult: (roundId: number, roundNumber: number) => void;
+}
+
+export default function useGameplayPhaseSync({
+  canvasId,
+  phase,
+  phaseEndsAt,
+  formattedGameEndTime,
+  refreshParticipants,
+  resyncSession,
+  clearTickets,
+  resetVoteState,
+  onRoundEndedCleanup,
+  setRoundState,
+  applyPhaseTimerSnapshot,
+  setPhaseTimerState,
+  setActiveRoundTimerState,
+  applyRoundMeta,
+  beginPendingRoundResult,
+}: UseGameplayPhaseSyncParams) {
+  const hasJoinedCanvasRef = useRef(false);
+  const activeRoundTimerRef = useRef<{
+    roundEndsAt: string;
+    serverOffsetMs: number;
+    isRoundExpired: boolean;
+  } | null>(null);
+
+  const clearActiveRoundTimer = useCallback(() => {
+    activeRoundTimerRef.current = null;
+  }, []);
+
+  const syncActiveRoundTimer = useCallback(
+    ({
+      roundEndsAt,
+      serverNow,
+      isRoundExpired,
+    }: {
+      roundEndsAt: string;
+      serverNow: string;
+      isRoundExpired: boolean;
+    }) => {
+      const serverOffsetMs = new Date(serverNow).getTime() - Date.now();
+
+      activeRoundTimerRef.current = {
+        roundEndsAt,
+        serverOffsetMs,
+        isRoundExpired,
+      };
+
+      setActiveRoundTimerState(roundEndsAt, serverOffsetMs, isRoundExpired);
+    },
+    [setActiveRoundTimerState],
+  );
+
+  const resetJoinedState = useCallback(() => {
+    hasJoinedCanvasRef.current = false;
+    clearActiveRoundTimer();
+  }, [clearActiveRoundTimer]);
+
+  useEffect(() => {
+    if (!isRoundActivePhase(phase)) {
+      return;
+    }
+
+    const syncTimer = () => {
+      const timerState = activeRoundTimerRef.current;
+
+      if (!timerState) {
+        return;
+      }
+
+      setActiveRoundTimerState(
+        timerState.roundEndsAt,
+        timerState.serverOffsetMs,
+        timerState.isRoundExpired,
+      );
+    };
+
+    syncTimer();
+
+    const timer = window.setInterval(syncTimer, 250);
+
+    return () => {
+      window.clearInterval(timer);
+    };
+  }, [phase, setActiveRoundTimerState]);
+
+  useEffect(() => {
+    if (isRoundActivePhase(phase)) {
+      return;
+    }
+
+    if (!phaseEndsAt) {
+      return;
+    }
+
+    const expired =
+      phase === GAME_PHASE.ROUND_RESULT || phase === GAME_PHASE.GAME_END;
+
+    setPhaseTimerState(phaseEndsAt, expired);
+
+    const timer = window.setInterval(() => {
+      setPhaseTimerState(phaseEndsAt, expired);
+    }, 250);
+
+    return () => {
+      window.clearInterval(timer);
+    };
+  }, [phase, phaseEndsAt, setPhaseTimerState]);
+
+  const handleCanvasJoined = useCallback(
+    ({ restored }: CanvasJoinedPayload) => {
+      const isInitialJoin = !hasJoinedCanvasRef.current;
+
+      hasJoinedCanvasRef.current = true;
+
+      if (!isInitialJoin && !restored) {
+        return;
+      }
+
+      void refreshParticipants();
+      void resyncSession();
+    },
+    [refreshParticipants, resyncSession],
+  );
+
+  const handleRoundEnded = useCallback(
+    ({ roundId, roundNumber }: RoundEndedPayload) => {
+      clearActiveRoundTimer();
+      onRoundEndedCleanup();
+      clearTickets();
+      resetVoteState();
+      beginPendingRoundResult(roundId, roundNumber);
+    },
+    [
+      beginPendingRoundResult,
+      clearActiveRoundTimer,
+      clearTickets,
+      onRoundEndedCleanup,
+      resetVoteState,
+    ],
+  );
+
+  const handlePhaseUpdated = useCallback(
+    ({
+      canvasId: updatedCanvasId,
+      phase: nextPhase,
+      roundId: nextRoundId,
+      roundNumber: nextRoundNumber,
+      roundDurationSec: nextRoundDurationSec,
+      remainingSeconds: nextRemainingSeconds,
+      totalRounds: nextTotalRounds,
+      phaseStartedAt: nextPhaseStartedAt,
+      phaseEndsAt: nextPhaseEndsAt,
+    }: PhaseUpdatedPayload) => {
+      if (!canvasId || canvasId !== updatedCanvasId) {
+        return;
+      }
+
+      if (nextPhase === GAME_PHASE.ROUND_ACTIVE) {
+        return;
+      }
+
+      clearActiveRoundTimer();
+
+      setRoundState({
+        phase: nextPhase,
+        roundId: nextRoundId,
+        roundNumber: nextRoundNumber,
+        roundDurationSec: nextRoundDurationSec,
+        totalRounds: nextTotalRounds,
+        formattedGameEndTime,
+        phaseStartedAt: nextPhaseStartedAt,
+        phaseEndsAt: nextPhaseEndsAt,
+      });
+
+      if (nextRemainingSeconds !== null) {
+        if (nextPhaseEndsAt) {
+          setPhaseTimerState(
+            nextPhaseEndsAt,
+            nextPhase === GAME_PHASE.GAME_END && nextRemainingSeconds === 0,
+          );
+        } else {
+          applyPhaseTimerSnapshot(
+            nextRemainingSeconds,
+            nextPhase === GAME_PHASE.GAME_END && nextRemainingSeconds === 0,
+          );
+        }
+        return;
+      }
+
+      setPhaseTimerState(
+        nextPhaseEndsAt,
+        nextPhase === GAME_PHASE.GAME_END && nextRemainingSeconds === 0,
+      );
+    },
+    [
+      applyPhaseTimerSnapshot,
+      canvasId,
+      clearActiveRoundTimer,
+      formattedGameEndTime,
+      setPhaseTimerState,
+      setRoundState,
+    ],
+  );
+
+  const handleTimerUpdate = useCallback(
+    ({
+      isRoundExpired,
+      serverNow,
+      roundEndsAt,
+      gameEndAt,
+      roundDurationSec,
+      totalRounds,
+    }: TimerUpdatePayload) => {
+      syncActiveRoundTimer({
+        roundEndsAt,
+        serverNow,
+        isRoundExpired,
+      });
+      applyRoundMeta({ roundDurationSec, totalRounds, gameEndAt });
+    },
+    [applyRoundMeta, syncActiveRoundTimer],
+  );
+
+  return {
+    clearActiveRoundTimer,
+    syncActiveRoundTimer,
+    resetJoinedState,
+    handleCanvasJoined,
+    handleRoundEnded,
+    handlePhaseUpdated,
+    handleTimerUpdate,
+  };
+}

--- a/frontend/src/pages/canvas/hooks/useGameplaySessionCleanup.ts
+++ b/frontend/src/pages/canvas/hooks/useGameplaySessionCleanup.ts
@@ -1,0 +1,74 @@
+import { useCallback } from "react";
+
+interface UseGameplaySessionCleanupParams {
+  clearActiveRoundTimer: () => void;
+  clearTickets: () => void;
+  clearParticipants: () => void;
+  resetRoundState: () => void;
+  resetRoundTimer: () => void;
+  resetVoteState: () => void;
+  resetSummaries: () => void;
+  markGameEnded: () => void;
+  onGameEndedCleanup: () => void;
+  onSessionEnded: () => void;
+}
+
+export default function useGameplaySessionCleanup({
+  clearActiveRoundTimer,
+  clearTickets,
+  clearParticipants,
+  resetRoundState,
+  resetRoundTimer,
+  resetVoteState,
+  resetSummaries,
+  markGameEnded,
+  onGameEndedCleanup,
+  onSessionEnded,
+}: UseGameplaySessionCleanupParams) {
+  const handleSessionEnded = useCallback(() => {
+    clearActiveRoundTimer();
+    clearTickets();
+    clearParticipants();
+    resetRoundState();
+    resetRoundTimer();
+    resetVoteState();
+    resetSummaries();
+    onSessionEnded();
+  }, [
+    clearActiveRoundTimer,
+    clearParticipants,
+    clearTickets,
+    onSessionEnded,
+    resetRoundState,
+    resetRoundTimer,
+    resetSummaries,
+    resetVoteState,
+  ]);
+
+  const handleGameEnded = useCallback(() => {
+    clearActiveRoundTimer();
+    markGameEnded();
+    clearTickets();
+    clearParticipants();
+    onGameEndedCleanup();
+    resetRoundState();
+    resetRoundTimer();
+    resetVoteState();
+    resetSummaries();
+  }, [
+    clearActiveRoundTimer,
+    clearParticipants,
+    clearTickets,
+    markGameEnded,
+    onGameEndedCleanup,
+    resetRoundState,
+    resetRoundTimer,
+    resetSummaries,
+    resetVoteState,
+  ]);
+
+  return {
+    handleSessionEnded,
+    handleGameEnded,
+  };
+}

--- a/frontend/src/pages/canvas/hooks/useGameplaySummaries.ts
+++ b/frontend/src/pages/canvas/hooks/useGameplaySummaries.ts
@@ -1,0 +1,355 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { sessionApi } from "@/features/gameplay/session";
+import type {
+  GameSummaryData,
+  RoundSummaryData,
+} from "@/features/gameplay/session/api/session.api";
+import type {
+  GameSummaryReadyPayload,
+  RoundSummaryReadyPayload,
+} from "@/features/gameplay/session/model/socket.types";
+import { GAME_PHASE } from "@/features/gameplay/session/model/game-phase.types";
+import type { SessionBootstrapResult } from "@/features/gameplay/session";
+
+interface UseGameplaySummariesParams {
+  canvasId: number | null;
+}
+
+export default function useGameplaySummaries({
+  canvasId,
+}: UseGameplaySummariesParams) {
+  const snapshotDelayTimerRef = useRef<number | null>(null);
+  const latestRoundSummaryRequestKeyRef = useRef<string | null>(null);
+  const inFlightRoundSummaryRequestRef = useRef<{
+    key: string;
+    promise: Promise<RoundSummaryData | null>;
+  } | null>(null);
+  const latestGameSummaryRequestKeyRef = useRef<string | null>(null);
+  const inFlightGameSummaryRequestRef = useRef<{
+    key: string;
+    promise: Promise<GameSummaryData | null>;
+  } | null>(null);
+  const pendingRoundResultRef = useRef<{
+    roundId: number;
+    roundNumber: number;
+    summaryReady: boolean;
+    canvasApplied: boolean;
+    summary: RoundSummaryData | null;
+  } | null>(null);
+  const roundSummaryEventSequenceRef = useRef(0);
+  const gameSummaryEventSequenceRef = useRef(0);
+
+  const [roundSummary, setRoundSummary] = useState<RoundSummaryData | null>(
+    null,
+  );
+  const [gameSummary, setGameSummary] = useState<GameSummaryData | null>(null);
+  const [roundSummaryLoading, setRoundSummaryLoading] = useState(false);
+  const [gameSummaryLoading, setGameSummaryLoading] = useState(false);
+  const [latestRoundSnapshot, setLatestRoundSnapshotState] = useState<
+    string | null
+  >(null);
+  const [roundSummaryEvent, setRoundSummaryEvent] = useState<{
+    sequence: number;
+    summary: RoundSummaryData;
+  } | null>(null);
+  const [gameSummaryEvent, setGameSummaryEvent] = useState<{
+    sequence: number;
+    summary: GameSummaryData;
+  } | null>(null);
+  const [canOpenLatestRoundSummary, setCanOpenLatestRoundSummary] =
+    useState(false);
+
+  const clearSnapshotDelayTimer = useCallback(() => {
+    if (snapshotDelayTimerRef.current === null) {
+      return;
+    }
+
+    window.clearTimeout(snapshotDelayTimerRef.current);
+    snapshotDelayTimerRef.current = null;
+  }, []);
+
+  const publishGameSummary = useCallback((summary: GameSummaryData) => {
+    gameSummaryEventSequenceRef.current += 1;
+    setGameSummaryEvent({
+      sequence: gameSummaryEventSequenceRef.current,
+      summary,
+    });
+  }, []);
+
+  const publishRoundSummary = useCallback((summary: RoundSummaryData) => {
+    roundSummaryEventSequenceRef.current += 1;
+    setRoundSummaryEvent({
+      sequence: roundSummaryEventSequenceRef.current,
+      summary,
+    });
+  }, []);
+
+  const requestGameSummary = useCallback(async (targetCanvasId: number) => {
+    const requestKey = `canvas:${targetCanvasId}`;
+    latestGameSummaryRequestKeyRef.current = requestKey;
+
+    if (inFlightGameSummaryRequestRef.current?.key === requestKey) {
+      return inFlightGameSummaryRequestRef.current.promise;
+    }
+
+    setGameSummaryLoading(true);
+
+    const promise = (async () => {
+      try {
+        const response = await sessionApi.getGameSummary(targetCanvasId);
+        const nextSummary = response.data.data;
+
+        if (latestGameSummaryRequestKeyRef.current === requestKey) {
+          setGameSummary(nextSummary);
+        }
+
+        return nextSummary;
+      } catch (error) {
+        if (latestGameSummaryRequestKeyRef.current === requestKey) {
+          setGameSummary(null);
+        }
+
+        console.error("[summary] failed to load game summary:", error);
+        return null;
+      } finally {
+        if (latestGameSummaryRequestKeyRef.current === requestKey) {
+          setGameSummaryLoading(false);
+        }
+
+        if (inFlightGameSummaryRequestRef.current?.key === requestKey) {
+          inFlightGameSummaryRequestRef.current = null;
+        }
+      }
+    })();
+
+    inFlightGameSummaryRequestRef.current = {
+      key: requestKey,
+      promise,
+    };
+
+    return promise;
+  }, []);
+
+  const requestRoundSummary = useCallback(
+    async (targetCanvasId: number, targetRoundId: number) => {
+      const requestKey = `canvas:${targetCanvasId}:round:${targetRoundId}`;
+      latestRoundSummaryRequestKeyRef.current = requestKey;
+
+      if (inFlightRoundSummaryRequestRef.current?.key === requestKey) {
+        return inFlightRoundSummaryRequestRef.current.promise;
+      }
+
+      setRoundSummaryLoading(true);
+
+      const promise = (async () => {
+        try {
+          const response = await sessionApi.getRoundSummary(
+            targetCanvasId,
+            targetRoundId,
+          );
+
+          const nextSummary = response.data.data;
+
+          if (latestRoundSummaryRequestKeyRef.current === requestKey) {
+            setRoundSummary(nextSummary);
+            setLatestRoundSnapshotState(nextSummary.snapshotUrl);
+          }
+
+          return nextSummary;
+        } catch (error) {
+          if (latestRoundSummaryRequestKeyRef.current === requestKey) {
+            setLatestRoundSnapshotState(null);
+          }
+
+          console.error("[summary] failed to load round summary:", error);
+          return null;
+        } finally {
+          if (latestRoundSummaryRequestKeyRef.current === requestKey) {
+            setRoundSummaryLoading(false);
+          }
+
+          if (inFlightRoundSummaryRequestRef.current?.key === requestKey) {
+            inFlightRoundSummaryRequestRef.current = null;
+          }
+        }
+      })();
+
+      inFlightRoundSummaryRequestRef.current = {
+        key: requestKey,
+        promise,
+      };
+
+      return promise;
+    },
+    [],
+  );
+
+  const completePendingRoundResult = useCallback(() => {
+    const pending = pendingRoundResultRef.current;
+
+    if (!pending || !pending.summaryReady || !pending.canvasApplied) {
+      return;
+    }
+
+    clearSnapshotDelayTimer();
+
+    snapshotDelayTimerRef.current = window.setTimeout(() => {
+      snapshotDelayTimerRef.current = null;
+
+      setLatestRoundSnapshotState(pending.summary?.snapshotUrl ?? null);
+
+      if (pending.summary) {
+        publishRoundSummary(pending.summary);
+      }
+
+      setCanOpenLatestRoundSummary(true);
+      pendingRoundResultRef.current = null;
+    }, 150);
+  }, [clearSnapshotDelayTimer, publishRoundSummary]);
+
+  const beginPendingRoundResult = useCallback(
+    (roundId: number, roundNumber: number) => {
+      clearSnapshotDelayTimer();
+      setRoundSummaryLoading(true);
+      setCanOpenLatestRoundSummary(false);
+      pendingRoundResultRef.current = {
+        roundId,
+        roundNumber,
+        summaryReady: false,
+        canvasApplied: false,
+        summary: null,
+      };
+    },
+    [clearSnapshotDelayTimer],
+  );
+
+  const markPendingRoundResultCanvasApplied = useCallback(() => {
+    if (!pendingRoundResultRef.current) {
+      return;
+    }
+
+    pendingRoundResultRef.current = {
+      ...pendingRoundResultRef.current,
+      canvasApplied: true,
+    };
+
+    window.requestAnimationFrame(() => {
+      completePendingRoundResult();
+    });
+  }, [completePendingRoundResult]);
+
+  const handleRoundSummaryReady = useCallback(
+    (payload: RoundSummaryReadyPayload) => {
+      const readyCanvasId = payload.canvasId;
+      const readyRoundId = payload.roundId;
+
+      if (!canvasId || canvasId !== readyCanvasId) {
+        return;
+      }
+
+      void requestRoundSummary(readyCanvasId, readyRoundId).then((summary) => {
+        if (!summary) {
+          return;
+        }
+
+        if (
+          pendingRoundResultRef.current &&
+          pendingRoundResultRef.current.roundId === readyRoundId
+        ) {
+          pendingRoundResultRef.current = {
+            ...pendingRoundResultRef.current,
+            summaryReady: true,
+            summary,
+          };
+          completePendingRoundResult();
+          return;
+        }
+
+        setCanOpenLatestRoundSummary(true);
+      });
+    },
+    [canvasId, completePendingRoundResult, requestRoundSummary],
+  );
+
+  const handleGameSummaryReady = useCallback(
+    (payload: GameSummaryReadyPayload) => {
+      const readyCanvasId = payload.canvasId;
+
+      if (!canvasId || canvasId !== readyCanvasId) {
+        return;
+      }
+
+      void requestGameSummary(readyCanvasId).then((summary) => {
+        if (summary) {
+          publishGameSummary(summary);
+        }
+      });
+    },
+    [canvasId, publishGameSummary, requestGameSummary],
+  );
+
+  const handleBootstrapSummaryRequests = useCallback(
+    (result: SessionBootstrapResult) => {
+      if (
+        result.round.phase === GAME_PHASE.ROUND_RESULT &&
+        result.round.roundId !== null
+      ) {
+        void requestRoundSummary(result.canvasId, result.round.roundId);
+      }
+
+      if (result.round.phase === GAME_PHASE.GAME_END) {
+        void requestGameSummary(result.canvasId).then((summary) => {
+          if (summary) {
+            publishGameSummary(summary);
+          }
+        });
+      }
+    },
+    [publishGameSummary, requestGameSummary, requestRoundSummary],
+  );
+
+  const resetForRoundStart = useCallback(() => {
+    clearSnapshotDelayTimer();
+    pendingRoundResultRef.current = null;
+    setGameSummary(null);
+    setRoundSummaryLoading(false);
+    setGameSummaryLoading(false);
+  }, [clearSnapshotDelayTimer]);
+
+  const resetAll = useCallback(() => {
+    clearSnapshotDelayTimer();
+    pendingRoundResultRef.current = null;
+    setCanOpenLatestRoundSummary(false);
+    setRoundSummary(null);
+    setGameSummary(null);
+    setRoundSummaryEvent(null);
+    setGameSummaryEvent(null);
+    setRoundSummaryLoading(false);
+    setGameSummaryLoading(false);
+    setLatestRoundSnapshotState(null);
+  }, [clearSnapshotDelayTimer]);
+
+  useEffect(() => {
+    return () => {
+      clearSnapshotDelayTimer();
+    };
+  }, [clearSnapshotDelayTimer]);
+
+  return {
+    roundSummary,
+    latestRoundSnapshot,
+    canOpenLatestRoundSummary,
+    gameSummary,
+    roundSummaryEvent,
+    gameSummaryEvent,
+    roundSummaryLoading,
+    gameSummaryLoading,
+    handleBootstrapSummaryRequests,
+    handleRoundSummaryReady,
+    handleGameSummaryReady,
+    beginPendingRoundResult,
+    markPendingRoundResultCanvasApplied,
+    resetForRoundStart,
+    resetAll,
+  };
+}

--- a/frontend/src/pages/canvas/model/useCanvasGameplay.ts
+++ b/frontend/src/pages/canvas/model/useCanvasGameplay.ts
@@ -136,6 +136,7 @@ export default function useCanvasGameplay({
   const {
     clearActiveRoundTimer,
     syncActiveRoundTimer,
+    syncPhaseTimer,
     resetJoinedState,
     handleCanvasJoined,
     handleRoundEnded,
@@ -177,11 +178,14 @@ export default function useCanvasGameplay({
       } else {
         clearActiveRoundTimer();
 
-        if (result.round.phaseEndsAt) {
-          setPhaseTimerState(
-            result.round.phaseEndsAt,
-            result.round.isRoundExpired,
-          );
+        if (result.round.phaseEndsAt && result.round.timerServerNow) {
+          syncPhaseTimer({
+            phaseEndsAt: result.round.phaseEndsAt,
+            serverNow: result.round.timerServerNow,
+            isRoundExpired: result.round.isRoundExpired,
+          });
+        } else if (result.round.phaseEndsAt) {
+          setPhaseTimerState(result.round.phaseEndsAt, 0, result.round.isRoundExpired);
         } else {
           applyPhaseTimerSnapshot(
             result.round.remainingSeconds,
@@ -205,6 +209,7 @@ export default function useCanvasGameplay({
       setRoundState,
       setRoundTimerState,
       syncActiveRoundTimer,
+      syncPhaseTimer,
     ],
   );
 
@@ -219,7 +224,10 @@ export default function useCanvasGameplay({
     onBootstrap: applyBootstrap,
     onUnauthorized,
   });
-  silentSessionResyncRef.current = () => initializeSession({ silent: true });
+
+  useEffect(() => {
+    silentSessionResyncRef.current = () => initializeSession({ silent: true });
+  }, [initializeSession]);
 
   const sessionCleanup = useGameplaySessionCleanup({
     clearActiveRoundTimer,

--- a/frontend/src/pages/canvas/model/useCanvasGameplay.ts
+++ b/frontend/src/pages/canvas/model/useCanvasGameplay.ts
@@ -98,6 +98,16 @@ export default function useCanvasGameplay({
   const hasJoinedCanvasRef = useRef(false);
   const localPhaseTransitionTimerRef = useRef<number | null>(null);
   const snapshotDelayTimerRef = useRef<number | null>(null);
+  const latestRoundSummaryRequestKeyRef = useRef<string | null>(null);
+  const inFlightRoundSummaryRequestRef = useRef<{
+    key: string;
+    promise: Promise<RoundSummaryData | null>;
+  } | null>(null);
+  const latestGameSummaryRequestKeyRef = useRef<string | null>(null);
+  const inFlightGameSummaryRequestRef = useRef<{
+    key: string;
+    promise: Promise<GameSummaryData | null>;
+  } | null>(null);
   const pendingRoundResultRef = useRef<{
     roundId: number;
     roundNumber: number;
@@ -137,7 +147,7 @@ export default function useCanvasGameplay({
     snapshotDelayTimerRef.current = null;
   }, []);
 
-  const { remaining, setRemaining, fetchTickets, clearTickets } =
+  const { remaining, applyRemainingSnapshot, fetchTickets, clearTickets } =
     useVoteTickets();
 
   const {
@@ -153,21 +163,51 @@ export default function useCanvasGameplay({
 
   const requestGameSummary = useCallback(
     async (targetCanvasId: number) => {
+      const requestKey = `canvas:${targetCanvasId}`;
+      latestGameSummaryRequestKeyRef.current = requestKey;
+
+      if (inFlightGameSummaryRequestRef.current?.key === requestKey) {
+        return inFlightGameSummaryRequestRef.current.promise;
+      }
+
       setGameSummaryLoading(true);
 
-      try {
-        const response = await sessionApi.getGameSummary(targetCanvasId);
-        const nextSummary = response.data.data;
+      const promise = (async () => {
+        try {
+          const response = await sessionApi.getGameSummary(targetCanvasId);
+          const nextSummary = response.data.data;
 
-        setGameSummary(nextSummary);
-        onOpenGameSummaryModal(nextSummary);
-      } catch (error) {
-        console.error("[summary] failed to load game summary:", error);
-      } finally {
-        setGameSummaryLoading(false);
-      }
+          if (latestGameSummaryRequestKeyRef.current === requestKey) {
+            setGameSummary(nextSummary);
+          }
+
+          return nextSummary;
+        } catch (error) {
+          if (latestGameSummaryRequestKeyRef.current === requestKey) {
+            setGameSummary(null);
+          }
+
+          console.error("[summary] failed to load game summary:", error);
+          return null;
+        } finally {
+          if (latestGameSummaryRequestKeyRef.current === requestKey) {
+            setGameSummaryLoading(false);
+          }
+
+          if (inFlightGameSummaryRequestRef.current?.key === requestKey) {
+            inFlightGameSummaryRequestRef.current = null;
+          }
+        }
+      })();
+
+      inFlightGameSummaryRequestRef.current = {
+        key: requestKey,
+        promise,
+      };
+
+      return promise;
     },
-    [onOpenGameSummaryModal],
+    [],
   );
 
   const handleGameSummaryReady = useCallback(
@@ -178,32 +218,65 @@ export default function useCanvasGameplay({
         return;
       }
 
-      void requestGameSummary(readyCanvasId);
+      void requestGameSummary(readyCanvasId).then((summary) => {
+        if (summary) {
+          onOpenGameSummaryModal(summary);
+        }
+      });
     },
-    [canvasId, requestGameSummary],
+    [canvasId, onOpenGameSummaryModal, requestGameSummary],
   );
 
   const requestRoundSummary = useCallback(
     async (targetCanvasId: number, targetRoundId: number) => {
+      const requestKey = `canvas:${targetCanvasId}:round:${targetRoundId}`;
+      latestRoundSummaryRequestKeyRef.current = requestKey;
+
+      if (inFlightRoundSummaryRequestRef.current?.key === requestKey) {
+        return inFlightRoundSummaryRequestRef.current.promise;
+      }
+
       setRoundSummaryLoading(true);
 
-      try {
-        const response = await sessionApi.getRoundSummary(
-          targetCanvasId,
-          targetRoundId,
-        );
+      const promise = (async () => {
+        try {
+          const response = await sessionApi.getRoundSummary(
+            targetCanvasId,
+            targetRoundId,
+          );
 
-        const nextSummary = response.data.data;
-        setRoundSummary(nextSummary);
-        setLatestRoundSnapshotState(nextSummary.snapshotUrl);
-        return nextSummary;
-      } catch (error) {
-        console.error("[summary] failed to load round summary:", error);
-        setLatestRoundSnapshotState(null);
-        return null;
-      } finally {
-        setRoundSummaryLoading(false);
-      }
+          const nextSummary = response.data.data;
+
+          if (latestRoundSummaryRequestKeyRef.current === requestKey) {
+            setRoundSummary(nextSummary);
+            setLatestRoundSnapshotState(nextSummary.snapshotUrl);
+          }
+
+          return nextSummary;
+        } catch (error) {
+          if (latestRoundSummaryRequestKeyRef.current === requestKey) {
+            setLatestRoundSnapshotState(null);
+          }
+
+          console.error("[summary] failed to load round summary:", error);
+          return null;
+        } finally {
+          if (latestRoundSummaryRequestKeyRef.current === requestKey) {
+            setRoundSummaryLoading(false);
+          }
+
+          if (inFlightRoundSummaryRequestRef.current?.key === requestKey) {
+            inFlightRoundSummaryRequestRef.current = null;
+          }
+        }
+      })();
+
+      inFlightRoundSummaryRequestRef.current = {
+        key: requestKey,
+        promise,
+      };
+
+      return promise;
     },
     [],
   );
@@ -263,7 +336,7 @@ export default function useCanvasGameplay({
       }
 
       applyVoteUpdate(result.votes);
-      setRemaining(result.remaining);
+      applyRemainingSnapshot(result.round.roundId, result.remaining);
 
       if (
         result.round.phase === GAME_PHASE.ROUND_RESULT &&
@@ -273,16 +346,21 @@ export default function useCanvasGameplay({
       }
 
       if (result.round.phase === GAME_PHASE.GAME_END) {
-        void requestGameSummary(result.canvasId);
+        void requestGameSummary(result.canvasId).then((summary) => {
+          if (summary) {
+            onOpenGameSummaryModal(summary);
+          }
+        });
       }
     },
     [
+      applyRemainingSnapshot,
       applyVoteUpdate,
       onBootstrapScene,
+      onOpenGameSummaryModal,
       requestGameSummary,
       requestRoundSummary,
       setPhaseTimerState,
-      setRemaining,
       setRoundState,
       setRoundTimerState,
     ],

--- a/frontend/src/pages/canvas/model/useCanvasGameplay.ts
+++ b/frontend/src/pages/canvas/model/useCanvasGameplay.ts
@@ -5,7 +5,6 @@ import {
   useGameSession,
   useGameplaySocket,
   useParticipantsState,
-  type PhaseTimingState,
   type SessionBootstrapResult,
 } from "@/features/gameplay/session";
 import type {
@@ -16,6 +15,7 @@ import type {
 import type {
   CanvasBatchUpdatedPayload,
   GameSummaryReadyPayload,
+  PhaseUpdatedPayload,
   RoundSummaryReadyPayload,
 } from "@/features/gameplay/session/model/socket.types";
 import {
@@ -47,13 +47,6 @@ interface UseCanvasGameplayParams {
   applyVoteUpdate: (votes: Record<string, number>) => void;
   resetVoteState: () => void;
 }
-
-const DEFAULT_PHASE_TIMING: PhaseTimingState = {
-  introPhaseSec: 0,
-  roundStartWaitSec: 0,
-  roundResultDelaySec: 0,
-  gameEndWaitSec: 0,
-};
 
 export default function useCanvasGameplay({
   canvasId,
@@ -88,15 +81,18 @@ export default function useCanvasGameplay({
     formattedRemainingTime,
     isRoundExpired,
     setRoundTimerState,
-    applyRoundTimer,
+    applyPhaseTimerSnapshot,
     setPhaseTimerState,
-    startRoundTimer,
+    setActiveRoundTimerState,
     resetRoundTimer,
   } = useRoundTimer();
 
-  const phaseTimingRef = useRef<PhaseTimingState>(DEFAULT_PHASE_TIMING);
   const hasJoinedCanvasRef = useRef(false);
-  const localPhaseTransitionTimerRef = useRef<number | null>(null);
+  const activeRoundTimerRef = useRef<{
+    roundEndsAt: string;
+    serverOffsetMs: number;
+    isRoundExpired: boolean;
+  } | null>(null);
   const snapshotDelayTimerRef = useRef<number | null>(null);
   const latestRoundSummaryRequestKeyRef = useRef<string | null>(null);
   const inFlightRoundSummaryRequestRef = useRef<{
@@ -129,15 +125,6 @@ export default function useCanvasGameplay({
   const [canOpenLatestRoundSummary, setCanOpenLatestRoundSummary] =
     useState(false);
 
-  const clearLocalPhaseTransitionTimer = useCallback(() => {
-    if (localPhaseTransitionTimerRef.current === null) {
-      return;
-    }
-
-    window.clearTimeout(localPhaseTransitionTimerRef.current);
-    localPhaseTransitionTimerRef.current = null;
-  }, []);
-
   const clearSnapshotDelayTimer = useCallback(() => {
     if (snapshotDelayTimerRef.current === null) {
       return;
@@ -146,6 +133,33 @@ export default function useCanvasGameplay({
     window.clearTimeout(snapshotDelayTimerRef.current);
     snapshotDelayTimerRef.current = null;
   }, []);
+
+  const clearActiveRoundTimer = useCallback(() => {
+    activeRoundTimerRef.current = null;
+  }, []);
+
+  const syncActiveRoundTimer = useCallback(
+    ({
+      roundEndsAt,
+      serverNow,
+      isRoundExpired,
+    }: {
+      roundEndsAt: string;
+      serverNow: string;
+      isRoundExpired: boolean;
+    }) => {
+      const serverOffsetMs = new Date(serverNow).getTime() - Date.now();
+
+      activeRoundTimerRef.current = {
+        roundEndsAt,
+        serverOffsetMs,
+        isRoundExpired,
+      };
+
+      setActiveRoundTimerState(roundEndsAt, serverOffsetMs, isRoundExpired);
+    },
+    [setActiveRoundTimerState],
+  );
 
   const { remaining, applyRemainingSnapshot, fetchTickets, clearTickets } =
     useVoteTickets();
@@ -307,7 +321,6 @@ export default function useCanvasGameplay({
   const applyBootstrap = useCallback(
     (result: SessionBootstrapResult) => {
       setGameConfig(result.gameConfig);
-      phaseTimingRef.current = result.phaseTiming;
       setGameConfigState(result.gameConfig);
       onBootstrapScene(result);
 
@@ -323,16 +336,33 @@ export default function useCanvasGameplay({
       });
 
       if (isRoundActivePhase(result.round.phase)) {
-        setRoundTimerState({
-          remainingSeconds: result.round.remainingSeconds,
-          formattedRemainingTime: result.round.formattedRemainingTime,
-          isRoundExpired: result.round.isRoundExpired,
-        });
+        if (result.round.phaseEndsAt && result.round.timerServerNow) {
+          syncActiveRoundTimer({
+            roundEndsAt: result.round.phaseEndsAt,
+            serverNow: result.round.timerServerNow,
+            isRoundExpired: result.round.isRoundExpired,
+          });
+        } else {
+          setRoundTimerState({
+            remainingSeconds: result.round.remainingSeconds,
+            formattedRemainingTime: result.round.formattedRemainingTime,
+            isRoundExpired: result.round.isRoundExpired,
+          });
+        }
       } else {
-        setPhaseTimerState(
-          result.round.phaseEndsAt,
-          result.round.isRoundExpired,
-        );
+        clearActiveRoundTimer();
+
+        if (result.round.phaseEndsAt) {
+          setPhaseTimerState(
+            result.round.phaseEndsAt,
+            result.round.isRoundExpired,
+          );
+        } else {
+          applyPhaseTimerSnapshot(
+            result.round.remainingSeconds,
+            result.round.isRoundExpired,
+          );
+        }
       }
 
       applyVoteUpdate(result.votes);
@@ -360,6 +390,9 @@ export default function useCanvasGameplay({
       onOpenGameSummaryModal,
       requestGameSummary,
       requestRoundSummary,
+      applyPhaseTimerSnapshot,
+      clearActiveRoundTimer,
+      syncActiveRoundTimer,
       setPhaseTimerState,
       setRoundState,
       setRoundTimerState,
@@ -380,10 +413,9 @@ export default function useCanvasGameplay({
 
   useEffect(() => {
     return () => {
-      clearLocalPhaseTransitionTimer();
       clearSnapshotDelayTimer();
     };
-  }, [clearLocalPhaseTransitionTimer, clearSnapshotDelayTimer]);
+  }, [clearSnapshotDelayTimer]);
 
   useEffect(() => {
     let cancelled = false;
@@ -401,137 +433,60 @@ export default function useCanvasGameplay({
 
   useEffect(() => {
     hasJoinedCanvasRef.current = false;
+    clearActiveRoundTimer();
     clearParticipants();
-  }, [canvasId, clearParticipants]);
+  }, [canvasId, clearActiveRoundTimer, clearParticipants]);
+
+  useEffect(() => {
+    if (!isRoundActivePhase(phase)) {
+      return;
+    }
+
+    const syncTimer = () => {
+      const timerState = activeRoundTimerRef.current;
+
+      if (!timerState) {
+        return;
+      }
+
+      setActiveRoundTimerState(
+        timerState.roundEndsAt,
+        timerState.serverOffsetMs,
+        timerState.isRoundExpired,
+      );
+    };
+
+    syncTimer();
+
+    const timer = window.setInterval(syncTimer, 250);
+
+    return () => {
+      window.clearInterval(timer);
+    };
+  }, [phase, setActiveRoundTimerState]);
 
   useEffect(() => {
     if (isRoundActivePhase(phase)) {
       return;
     }
 
-    setPhaseTimerState(
-      phaseEndsAt,
-      phase === GAME_PHASE.ROUND_RESULT || phase === GAME_PHASE.GAME_END,
-    );
-
     if (!phaseEndsAt) {
       return;
     }
 
+    const expired =
+      phase === GAME_PHASE.ROUND_RESULT || phase === GAME_PHASE.GAME_END;
+
+    setPhaseTimerState(phaseEndsAt, expired);
+
     const timer = window.setInterval(() => {
-      setPhaseTimerState(
-        phaseEndsAt,
-        phase === GAME_PHASE.ROUND_RESULT || phase === GAME_PHASE.GAME_END,
-      );
-    }, 1000);
+      setPhaseTimerState(phaseEndsAt, expired);
+    }, 250);
 
     return () => {
       window.clearInterval(timer);
     };
   }, [phase, phaseEndsAt, setPhaseTimerState]);
-
-  useEffect(() => {
-    clearLocalPhaseTransitionTimer();
-
-    if (!phaseEndsAt || roundNumber === null) {
-      return;
-    }
-
-    if (phase === GAME_PHASE.INTRO) {
-      const delayMs = Math.max(0, new Date(phaseEndsAt).getTime() - Date.now());
-
-      localPhaseTransitionTimerRef.current = window.setTimeout(() => {
-        localPhaseTransitionTimerRef.current = null;
-
-        const waitStartedAt = phaseEndsAt;
-        const waitEndsAt = new Date(
-          new Date(waitStartedAt).getTime() +
-            phaseTimingRef.current.roundStartWaitSec * 1000,
-        ).toISOString();
-
-        setRoundState({
-          phase: GAME_PHASE.ROUND_START_WAIT,
-          roundId: null,
-          roundNumber: 1,
-          roundDurationSec: phaseTimingRef.current.roundStartWaitSec,
-          totalRounds,
-          formattedGameEndTime,
-          phaseStartedAt: waitStartedAt,
-          phaseEndsAt: waitEndsAt,
-        });
-
-        setPhaseTimerState(waitEndsAt, false);
-      }, delayMs);
-
-      return () => {
-        clearLocalPhaseTransitionTimer();
-      };
-    }
-
-    if (phase !== GAME_PHASE.ROUND_RESULT) {
-      return;
-    }
-
-    const delayMs = Math.max(0, new Date(phaseEndsAt).getTime() - Date.now());
-
-    localPhaseTransitionTimerRef.current = window.setTimeout(() => {
-      localPhaseTransitionTimerRef.current = null;
-
-      if (roundNumber >= totalRounds) {
-        const gameEndStartedAt = phaseEndsAt;
-        const gameEndEndsAt = new Date(
-          new Date(gameEndStartedAt).getTime() +
-            phaseTimingRef.current.gameEndWaitSec * 1000,
-        ).toISOString();
-
-        setRoundState({
-          phase: GAME_PHASE.GAME_END,
-          roundId: null,
-          roundNumber,
-          roundDurationSec: phaseTimingRef.current.gameEndWaitSec,
-          totalRounds,
-          formattedGameEndTime,
-          phaseStartedAt: gameEndStartedAt,
-          phaseEndsAt: gameEndEndsAt,
-        });
-
-        setPhaseTimerState(gameEndEndsAt, true);
-        return;
-      }
-
-      const waitStartedAt = phaseEndsAt;
-      const waitEndsAt = new Date(
-        new Date(waitStartedAt).getTime() +
-          phaseTimingRef.current.roundStartWaitSec * 1000,
-      ).toISOString();
-
-      setRoundState({
-        phase: GAME_PHASE.ROUND_START_WAIT,
-        roundId: null,
-        roundNumber: roundNumber + 1,
-        roundDurationSec: phaseTimingRef.current.roundStartWaitSec,
-        totalRounds,
-        formattedGameEndTime,
-        phaseStartedAt: waitStartedAt,
-        phaseEndsAt: waitEndsAt,
-      });
-
-      setPhaseTimerState(waitEndsAt, false);
-    }, delayMs);
-
-    return () => {
-      clearLocalPhaseTransitionTimer();
-    };
-  }, [
-    clearLocalPhaseTransitionTimer,
-    formattedGameEndTime,
-    phase,
-    phaseEndsAt,
-    roundNumber,
-    setPhaseTimerState,
-    setRoundState,
-    totalRounds,
-  ]);
 
   const handleCanvasJoined = useCallback(
     ({ restored }: { restored: boolean }) => {
@@ -556,15 +511,18 @@ export default function useCanvasGameplay({
       gameEndAt,
       roundDurationSec,
       startedAt,
+      roundEndsAt,
+      serverNow,
     }: {
       roundId: number;
       roundNumber: number;
       startedAt: string;
+      roundEndsAt: string;
+      serverNow: string;
       roundDurationSec: number;
       totalRounds: number;
       gameEndAt: string;
     }) => {
-      clearLocalPhaseTransitionTimer();
       clearSnapshotDelayTimer();
       pendingRoundResultRef.current = null;
       setGameSummary(null);
@@ -580,10 +538,14 @@ export default function useCanvasGameplay({
         totalRounds,
         formattedGameEndTime: formatClockTime(new Date(gameEndAt)),
         phaseStartedAt: startedAt,
-        phaseEndsAt: null,
+        phaseEndsAt: roundEndsAt,
       });
 
-      startRoundTimer(roundDurationSec);
+      syncActiveRoundTimer({
+        roundEndsAt,
+        serverNow,
+        isRoundExpired: false,
+      });
       clearSessionError();
       resetVoteState();
       applyParticipantsSnapshot(
@@ -598,7 +560,6 @@ export default function useCanvasGameplay({
     },
     [
       applyParticipantsSnapshot,
-      clearLocalPhaseTransitionTimer,
       clearSessionError,
       clearSnapshotDelayTimer,
       fetchTickets,
@@ -606,7 +567,7 @@ export default function useCanvasGameplay({
       participants,
       resetVoteState,
       setRoundState,
-      startRoundTimer,
+      syncActiveRoundTimer,
     ],
   );
 
@@ -614,13 +575,11 @@ export default function useCanvasGameplay({
     ({
       roundId,
       roundNumber,
-      endedAt,
     }: {
       roundId: number;
       roundNumber: number;
-      endedAt: string;
     }) => {
-      clearLocalPhaseTransitionTimer();
+      clearActiveRoundTimer();
       clearSnapshotDelayTimer();
       onRoundEndedCleanup();
       clearTickets();
@@ -634,35 +593,13 @@ export default function useCanvasGameplay({
         canvasApplied: false,
         summary: null,
       };
-
-      const resultEndsAt = new Date(
-        new Date(endedAt).getTime() +
-          phaseTimingRef.current.roundResultDelaySec * 1000,
-      ).toISOString();
-
-      setRoundState({
-        phase: GAME_PHASE.ROUND_RESULT,
-        roundId,
-        roundNumber,
-        roundDurationSec: phaseTimingRef.current.roundResultDelaySec,
-        totalRounds,
-        formattedGameEndTime,
-        phaseStartedAt: endedAt,
-        phaseEndsAt: resultEndsAt,
-      });
-
-      setPhaseTimerState(resultEndsAt, true);
     },
     [
-      clearLocalPhaseTransitionTimer,
+      clearActiveRoundTimer,
       clearSnapshotDelayTimer,
       onRoundEndedCleanup,
       clearTickets,
-      formattedGameEndTime,
       resetVoteState,
-      setPhaseTimerState,
-      setRoundState,
-      totalRounds,
     ],
   );
 
@@ -699,8 +636,71 @@ export default function useCanvasGameplay({
     [canvasId, completePendingRoundResult, requestRoundSummary],
   );
 
+  const handlePhaseUpdated = useCallback(
+    ({
+      canvasId: updatedCanvasId,
+      phase: nextPhase,
+      roundId: nextRoundId,
+      roundNumber: nextRoundNumber,
+      roundDurationSec: nextRoundDurationSec,
+      remainingSeconds: nextRemainingSeconds,
+      totalRounds: nextTotalRounds,
+      phaseStartedAt: nextPhaseStartedAt,
+      phaseEndsAt: nextPhaseEndsAt,
+    }: PhaseUpdatedPayload) => {
+      if (!canvasId || canvasId !== updatedCanvasId) {
+        return;
+      }
+
+      if (nextPhase === GAME_PHASE.ROUND_ACTIVE) {
+        return;
+      }
+
+      clearActiveRoundTimer();
+
+      setRoundState({
+        phase: nextPhase,
+        roundId: nextRoundId,
+        roundNumber: nextRoundNumber,
+        roundDurationSec: nextRoundDurationSec,
+        totalRounds: nextTotalRounds,
+        formattedGameEndTime,
+        phaseStartedAt: nextPhaseStartedAt,
+        phaseEndsAt: nextPhaseEndsAt,
+      });
+
+      if (nextRemainingSeconds !== null) {
+        if (nextPhaseEndsAt) {
+          setPhaseTimerState(
+            nextPhaseEndsAt,
+            nextPhase === GAME_PHASE.GAME_END && nextRemainingSeconds === 0,
+          );
+        } else {
+          applyPhaseTimerSnapshot(
+            nextRemainingSeconds,
+            nextPhase === GAME_PHASE.GAME_END && nextRemainingSeconds === 0,
+          );
+        }
+        return;
+      }
+
+      setPhaseTimerState(
+        nextPhaseEndsAt,
+        nextPhase === GAME_PHASE.GAME_END && nextRemainingSeconds === 0,
+      );
+    },
+    [
+      applyPhaseTimerSnapshot,
+      canvasId,
+      clearActiveRoundTimer,
+      formattedGameEndTime,
+      setPhaseTimerState,
+      setRoundState,
+    ],
+  );
+
   const handleSessionEnded = useCallback(() => {
-    clearLocalPhaseTransitionTimer();
+    clearActiveRoundTimer();
     clearSnapshotDelayTimer();
     pendingRoundResultRef.current = null;
     setCanOpenLatestRoundSummary(false);
@@ -715,7 +715,7 @@ export default function useCanvasGameplay({
     setGameSummaryLoading(false);
     onSessionEnded();
   }, [
-    clearLocalPhaseTransitionTimer,
+    clearActiveRoundTimer,
     clearParticipants,
     clearSnapshotDelayTimer,
     clearTickets,
@@ -734,22 +734,28 @@ export default function useCanvasGameplay({
 
   const handleTimerUpdate = useCallback(
     ({
-      remainingSeconds,
       isRoundExpired,
+      serverNow,
+      roundEndsAt,
       gameEndAt,
       roundDurationSec,
       totalRounds,
     }: {
-      remainingSeconds: number;
       isRoundExpired: boolean;
+      serverNow: string;
+      roundEndsAt: string;
       gameEndAt: string;
       roundDurationSec: number;
       totalRounds: number;
     }) => {
-      applyRoundTimer({ remainingSeconds, isRoundExpired });
+      syncActiveRoundTimer({
+        roundEndsAt,
+        serverNow,
+        isRoundExpired,
+      });
       applyRoundMeta({ roundDurationSec, totalRounds, gameEndAt });
     },
-    [applyRoundMeta, applyRoundTimer],
+    [applyRoundMeta, syncActiveRoundTimer],
   );
 
   const handleParticipantsUpdated = useCallback(
@@ -767,7 +773,7 @@ export default function useCanvasGameplay({
   );
 
   const handleGameEnded = useCallback(() => {
-    clearLocalPhaseTransitionTimer();
+    clearActiveRoundTimer();
     clearSnapshotDelayTimer();
     pendingRoundResultRef.current = null;
     setCanOpenLatestRoundSummary(false);
@@ -783,7 +789,7 @@ export default function useCanvasGameplay({
     setRoundSummaryLoading(false);
     setGameSummaryLoading(false);
   }, [
-    clearLocalPhaseTransitionTimer,
+    clearActiveRoundTimer,
     clearParticipants,
     clearSnapshotDelayTimer,
     clearTickets,
@@ -824,6 +830,7 @@ export default function useCanvasGameplay({
   useGameplaySocket({
     canvasId,
     onCanvasJoined: handleCanvasJoined,
+    onPhaseUpdated: handlePhaseUpdated,
     onRoundStarted: handleRoundStarted,
     onRoundEnded: handleRoundEnded,
     onRoundSummaryReady: handleRoundSummaryReady,

--- a/frontend/src/pages/canvas/model/useCanvasGameplay.ts
+++ b/frontend/src/pages/canvas/model/useCanvasGameplay.ts
@@ -37,8 +37,6 @@ interface UseCanvasGameplayParams {
   onBootstrapScene: (result: SessionBootstrapResult) => void;
   onCanvasUpdated: (payload: { x: number; y: number; color: string }) => void;
   onCanvasBatchUpdated: (payload: CanvasBatchUpdatedPayload) => void;
-  onOpenRoundSummaryModal: (summary: RoundSummaryData) => void;
-  onOpenGameSummaryModal: (summary: GameSummaryData) => void;
   onRoundStartedCleanup: () => void;
   onRoundEndedCleanup: () => void;
   onGameEndedCleanup: () => void;
@@ -53,8 +51,6 @@ export default function useCanvasGameplay({
   onBootstrapScene,
   onCanvasUpdated,
   onCanvasBatchUpdated,
-  onOpenRoundSummaryModal,
-  onOpenGameSummaryModal,
   onRoundStartedCleanup,
   onRoundEndedCleanup,
   onGameEndedCleanup,
@@ -121,9 +117,19 @@ export default function useCanvasGameplay({
   const [latestRoundSnapshot, setLatestRoundSnapshotState] = useState<
     string | null
   >(null);
+  const [roundSummaryEvent, setRoundSummaryEvent] = useState<{
+    sequence: number;
+    summary: RoundSummaryData;
+  } | null>(null);
+  const [gameSummaryEvent, setGameSummaryEvent] = useState<{
+    sequence: number;
+    summary: GameSummaryData;
+  } | null>(null);
 
   const [canOpenLatestRoundSummary, setCanOpenLatestRoundSummary] =
     useState(false);
+  const roundSummaryEventSequenceRef = useRef(0);
+  const gameSummaryEventSequenceRef = useRef(0);
 
   const clearSnapshotDelayTimer = useCallback(() => {
     if (snapshotDelayTimerRef.current === null) {
@@ -224,6 +230,14 @@ export default function useCanvasGameplay({
     [],
   );
 
+  const publishGameSummary = useCallback((summary: GameSummaryData) => {
+    gameSummaryEventSequenceRef.current += 1;
+    setGameSummaryEvent({
+      sequence: gameSummaryEventSequenceRef.current,
+      summary,
+    });
+  }, []);
+
   const handleGameSummaryReady = useCallback(
     (payload: GameSummaryReadyPayload) => {
       const readyCanvasId = payload.canvasId;
@@ -234,11 +248,11 @@ export default function useCanvasGameplay({
 
       void requestGameSummary(readyCanvasId).then((summary) => {
         if (summary) {
-          onOpenGameSummaryModal(summary);
+          publishGameSummary(summary);
         }
       });
     },
-    [canvasId, onOpenGameSummaryModal, requestGameSummary],
+    [canvasId, publishGameSummary, requestGameSummary],
   );
 
   const requestRoundSummary = useCallback(
@@ -295,6 +309,14 @@ export default function useCanvasGameplay({
     [],
   );
 
+  const publishRoundSummary = useCallback((summary: RoundSummaryData) => {
+    roundSummaryEventSequenceRef.current += 1;
+    setRoundSummaryEvent({
+      sequence: roundSummaryEventSequenceRef.current,
+      summary,
+    });
+  }, []);
+
   const completePendingRoundResult = useCallback(() => {
     const pending = pendingRoundResultRef.current;
 
@@ -310,13 +332,13 @@ export default function useCanvasGameplay({
       setLatestRoundSnapshotState(pending.summary?.snapshotUrl ?? null);
 
       if (pending.summary) {
-        onOpenRoundSummaryModal(pending.summary);
+        publishRoundSummary(pending.summary);
       }
 
       setCanOpenLatestRoundSummary(true);
       pendingRoundResultRef.current = null;
     }, 150);
-  }, [clearSnapshotDelayTimer, onOpenRoundSummaryModal]);
+  }, [clearSnapshotDelayTimer, publishRoundSummary]);
 
   const applyBootstrap = useCallback(
     (result: SessionBootstrapResult) => {
@@ -378,7 +400,7 @@ export default function useCanvasGameplay({
       if (result.round.phase === GAME_PHASE.GAME_END) {
         void requestGameSummary(result.canvasId).then((summary) => {
           if (summary) {
-            onOpenGameSummaryModal(summary);
+            publishGameSummary(summary);
           }
         });
       }
@@ -387,11 +409,11 @@ export default function useCanvasGameplay({
       applyRemainingSnapshot,
       applyVoteUpdate,
       onBootstrapScene,
-      onOpenGameSummaryModal,
       requestGameSummary,
       requestRoundSummary,
       applyPhaseTimerSnapshot,
       clearActiveRoundTimer,
+      publishGameSummary,
       syncActiveRoundTimer,
       setPhaseTimerState,
       setRoundState,
@@ -711,6 +733,8 @@ export default function useCanvasGameplay({
     resetVoteState();
     setRoundSummary(null);
     setGameSummary(null);
+    setRoundSummaryEvent(null);
+    setGameSummaryEvent(null);
     setRoundSummaryLoading(false);
     setGameSummaryLoading(false);
     onSessionEnded();
@@ -786,6 +810,8 @@ export default function useCanvasGameplay({
     resetVoteState();
     setRoundSummary(null);
     setGameSummary(null);
+    setRoundSummaryEvent(null);
+    setGameSummaryEvent(null);
     setRoundSummaryLoading(false);
     setGameSummaryLoading(false);
   }, [
@@ -877,6 +903,8 @@ export default function useCanvasGameplay({
     latestRoundSnapshot,
     canOpenLatestRoundSummary,
     gameSummary,
+    roundSummaryEvent,
+    gameSummaryEvent,
     roundSummaryLoading,
     gameSummaryLoading,
     isRoundExpiredRefValue: isRoundExpired,

--- a/frontend/src/pages/canvas/model/useCanvasGameplay.ts
+++ b/frontend/src/pages/canvas/model/useCanvasGameplay.ts
@@ -1,22 +1,15 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useRoundState, useRoundTimer } from "@/features/gameplay/round";
 import {
-  sessionApi,
   useGameSession,
   useGameplaySocket,
   useParticipantsState,
   type SessionBootstrapResult,
 } from "@/features/gameplay/session";
-import type {
-  GameSummaryData,
-  ParticipantItem,
-  RoundSummaryData,
-} from "@/features/gameplay/session/api/session.api";
+import type { ParticipantItem } from "@/features/gameplay/session/api/session.api";
 import type {
   CanvasBatchUpdatedPayload,
-  GameSummaryReadyPayload,
-  PhaseUpdatedPayload,
-  RoundSummaryReadyPayload,
+  RoundStartedPayload,
 } from "@/features/gameplay/session/model/socket.types";
 import {
   GAME_PHASE,
@@ -25,6 +18,9 @@ import {
 import type { GameConfig } from "@/shared/config/game-config";
 import { setGameConfig } from "@/shared/config/game-config";
 import { useVoteTickets } from "@/features/gameplay/vote";
+import useGameplaySummaries from "../hooks/useGameplaySummaries";
+import useGameplayPhaseSync from "../hooks/useGameplayPhaseSync";
+import useGameplaySessionCleanup from "../hooks/useGameplaySessionCleanup";
 
 function formatClockTime(date: Date): string {
   const hours = String(date.getHours()).padStart(2, "0");
@@ -83,89 +79,7 @@ export default function useCanvasGameplay({
     resetRoundTimer,
   } = useRoundTimer();
 
-  const hasJoinedCanvasRef = useRef(false);
-  const activeRoundTimerRef = useRef<{
-    roundEndsAt: string;
-    serverOffsetMs: number;
-    isRoundExpired: boolean;
-  } | null>(null);
-  const snapshotDelayTimerRef = useRef<number | null>(null);
-  const latestRoundSummaryRequestKeyRef = useRef<string | null>(null);
-  const inFlightRoundSummaryRequestRef = useRef<{
-    key: string;
-    promise: Promise<RoundSummaryData | null>;
-  } | null>(null);
-  const latestGameSummaryRequestKeyRef = useRef<string | null>(null);
-  const inFlightGameSummaryRequestRef = useRef<{
-    key: string;
-    promise: Promise<GameSummaryData | null>;
-  } | null>(null);
-  const pendingRoundResultRef = useRef<{
-    roundId: number;
-    roundNumber: number;
-    summaryReady: boolean;
-    canvasApplied: boolean;
-    summary: RoundSummaryData | null;
-  } | null>(null);
   const [gameConfig, setGameConfigState] = useState<GameConfig | null>(null);
-  const [roundSummary, setRoundSummary] = useState<RoundSummaryData | null>(
-    null,
-  );
-  const [gameSummary, setGameSummary] = useState<GameSummaryData | null>(null);
-  const [roundSummaryLoading, setRoundSummaryLoading] = useState(false);
-  const [gameSummaryLoading, setGameSummaryLoading] = useState(false);
-  const [latestRoundSnapshot, setLatestRoundSnapshotState] = useState<
-    string | null
-  >(null);
-  const [roundSummaryEvent, setRoundSummaryEvent] = useState<{
-    sequence: number;
-    summary: RoundSummaryData;
-  } | null>(null);
-  const [gameSummaryEvent, setGameSummaryEvent] = useState<{
-    sequence: number;
-    summary: GameSummaryData;
-  } | null>(null);
-
-  const [canOpenLatestRoundSummary, setCanOpenLatestRoundSummary] =
-    useState(false);
-  const roundSummaryEventSequenceRef = useRef(0);
-  const gameSummaryEventSequenceRef = useRef(0);
-
-  const clearSnapshotDelayTimer = useCallback(() => {
-    if (snapshotDelayTimerRef.current === null) {
-      return;
-    }
-
-    window.clearTimeout(snapshotDelayTimerRef.current);
-    snapshotDelayTimerRef.current = null;
-  }, []);
-
-  const clearActiveRoundTimer = useCallback(() => {
-    activeRoundTimerRef.current = null;
-  }, []);
-
-  const syncActiveRoundTimer = useCallback(
-    ({
-      roundEndsAt,
-      serverNow,
-      isRoundExpired,
-    }: {
-      roundEndsAt: string;
-      serverNow: string;
-      isRoundExpired: boolean;
-    }) => {
-      const serverOffsetMs = new Date(serverNow).getTime() - Date.now();
-
-      activeRoundTimerRef.current = {
-        roundEndsAt,
-        serverOffsetMs,
-        isRoundExpired,
-      };
-
-      setActiveRoundTimerState(roundEndsAt, serverOffsetMs, isRoundExpired);
-    },
-    [setActiveRoundTimerState],
-  );
 
   const { remaining, applyRemainingSnapshot, fetchTickets, clearTickets } =
     useVoteTickets();
@@ -180,165 +94,54 @@ export default function useCanvasGameplay({
     applyParticipantsSnapshot,
     clearParticipants,
   } = useParticipantsState();
-
-  const requestGameSummary = useCallback(
-    async (targetCanvasId: number) => {
-      const requestKey = `canvas:${targetCanvasId}`;
-      latestGameSummaryRequestKeyRef.current = requestKey;
-
-      if (inFlightGameSummaryRequestRef.current?.key === requestKey) {
-        return inFlightGameSummaryRequestRef.current.promise;
-      }
-
-      setGameSummaryLoading(true);
-
-      const promise = (async () => {
-        try {
-          const response = await sessionApi.getGameSummary(targetCanvasId);
-          const nextSummary = response.data.data;
-
-          if (latestGameSummaryRequestKeyRef.current === requestKey) {
-            setGameSummary(nextSummary);
-          }
-
-          return nextSummary;
-        } catch (error) {
-          if (latestGameSummaryRequestKeyRef.current === requestKey) {
-            setGameSummary(null);
-          }
-
-          console.error("[summary] failed to load game summary:", error);
-          return null;
-        } finally {
-          if (latestGameSummaryRequestKeyRef.current === requestKey) {
-            setGameSummaryLoading(false);
-          }
-
-          if (inFlightGameSummaryRequestRef.current?.key === requestKey) {
-            inFlightGameSummaryRequestRef.current = null;
-          }
-        }
-      })();
-
-      inFlightGameSummaryRequestRef.current = {
-        key: requestKey,
-        promise,
-      };
-
-      return promise;
-    },
-    [],
+  const silentSessionResyncRef = useRef<() => Promise<unknown>>(
+    async () => null,
   );
 
-  const publishGameSummary = useCallback((summary: GameSummaryData) => {
-    gameSummaryEventSequenceRef.current += 1;
-    setGameSummaryEvent({
-      sequence: gameSummaryEventSequenceRef.current,
-      summary,
-    });
-  }, []);
-
-  const handleGameSummaryReady = useCallback(
-    (payload: GameSummaryReadyPayload) => {
-      const readyCanvasId = payload.canvasId;
-
-      if (!canvasId || canvasId !== readyCanvasId) {
-        return;
-      }
-
-      void requestGameSummary(readyCanvasId).then((summary) => {
-        if (summary) {
-          publishGameSummary(summary);
-        }
-      });
-    },
-    [canvasId, publishGameSummary, requestGameSummary],
-  );
-
-  const requestRoundSummary = useCallback(
-    async (targetCanvasId: number, targetRoundId: number) => {
-      const requestKey = `canvas:${targetCanvasId}:round:${targetRoundId}`;
-      latestRoundSummaryRequestKeyRef.current = requestKey;
-
-      if (inFlightRoundSummaryRequestRef.current?.key === requestKey) {
-        return inFlightRoundSummaryRequestRef.current.promise;
-      }
-
-      setRoundSummaryLoading(true);
-
-      const promise = (async () => {
-        try {
-          const response = await sessionApi.getRoundSummary(
-            targetCanvasId,
-            targetRoundId,
-          );
-
-          const nextSummary = response.data.data;
-
-          if (latestRoundSummaryRequestKeyRef.current === requestKey) {
-            setRoundSummary(nextSummary);
-            setLatestRoundSnapshotState(nextSummary.snapshotUrl);
-          }
-
-          return nextSummary;
-        } catch (error) {
-          if (latestRoundSummaryRequestKeyRef.current === requestKey) {
-            setLatestRoundSnapshotState(null);
-          }
-
-          console.error("[summary] failed to load round summary:", error);
-          return null;
-        } finally {
-          if (latestRoundSummaryRequestKeyRef.current === requestKey) {
-            setRoundSummaryLoading(false);
-          }
-
-          if (inFlightRoundSummaryRequestRef.current?.key === requestKey) {
-            inFlightRoundSummaryRequestRef.current = null;
-          }
-        }
-      })();
-
-      inFlightRoundSummaryRequestRef.current = {
-        key: requestKey,
-        promise,
-      };
-
-      return promise;
-    },
-    [],
-  );
-
-  const publishRoundSummary = useCallback((summary: RoundSummaryData) => {
-    roundSummaryEventSequenceRef.current += 1;
-    setRoundSummaryEvent({
-      sequence: roundSummaryEventSequenceRef.current,
-      summary,
-    });
-  }, []);
-
-  const completePendingRoundResult = useCallback(() => {
-    const pending = pendingRoundResultRef.current;
-
-    if (!pending || !pending.summaryReady || !pending.canvasApplied) {
-      return;
-    }
-
-    clearSnapshotDelayTimer();
-
-    snapshotDelayTimerRef.current = window.setTimeout(() => {
-      snapshotDelayTimerRef.current = null;
-
-      setLatestRoundSnapshotState(pending.summary?.snapshotUrl ?? null);
-
-      if (pending.summary) {
-        publishRoundSummary(pending.summary);
-      }
-
-      setCanOpenLatestRoundSummary(true);
-      pendingRoundResultRef.current = null;
-    }, 150);
-  }, [clearSnapshotDelayTimer, publishRoundSummary]);
+  const summaries = useGameplaySummaries({ canvasId });
+  const {
+    roundSummary,
+    latestRoundSnapshot,
+    canOpenLatestRoundSummary,
+    gameSummary,
+    roundSummaryEvent,
+    gameSummaryEvent,
+    roundSummaryLoading,
+    gameSummaryLoading,
+    handleBootstrapSummaryRequests,
+    handleRoundSummaryReady,
+    handleGameSummaryReady,
+    beginPendingRoundResult,
+    markPendingRoundResultCanvasApplied,
+    resetForRoundStart,
+    resetAll: resetSummaries,
+  } = summaries;
+  const phaseSync = useGameplayPhaseSync({
+    canvasId,
+    phase,
+    phaseEndsAt,
+    formattedGameEndTime,
+    refreshParticipants,
+    resyncSession: () => silentSessionResyncRef.current(),
+    clearTickets,
+    resetVoteState,
+    onRoundEndedCleanup,
+    setRoundState,
+    applyPhaseTimerSnapshot,
+    setPhaseTimerState,
+    setActiveRoundTimerState,
+    applyRoundMeta,
+    beginPendingRoundResult,
+  });
+  const {
+    clearActiveRoundTimer,
+    syncActiveRoundTimer,
+    resetJoinedState,
+    handleCanvasJoined,
+    handleRoundEnded,
+    handlePhaseUpdated,
+    handleTimerUpdate,
+  } = phaseSync;
 
   const applyBootstrap = useCallback(
     (result: SessionBootstrapResult) => {
@@ -389,35 +192,19 @@ export default function useCanvasGameplay({
 
       applyVoteUpdate(result.votes);
       applyRemainingSnapshot(result.round.roundId, result.remaining);
-
-      if (
-        result.round.phase === GAME_PHASE.ROUND_RESULT &&
-        result.round.roundId !== null
-      ) {
-        void requestRoundSummary(result.canvasId, result.round.roundId);
-      }
-
-      if (result.round.phase === GAME_PHASE.GAME_END) {
-        void requestGameSummary(result.canvasId).then((summary) => {
-          if (summary) {
-            publishGameSummary(summary);
-          }
-        });
-      }
+      handleBootstrapSummaryRequests(result);
     },
     [
       applyRemainingSnapshot,
       applyVoteUpdate,
-      onBootstrapScene,
-      requestGameSummary,
-      requestRoundSummary,
-      applyPhaseTimerSnapshot,
       clearActiveRoundTimer,
-      publishGameSummary,
-      syncActiveRoundTimer,
+      handleBootstrapSummaryRequests,
+      onBootstrapScene,
+      applyPhaseTimerSnapshot,
       setPhaseTimerState,
       setRoundState,
       setRoundTimerState,
+      syncActiveRoundTimer,
     ],
   );
 
@@ -432,12 +219,20 @@ export default function useCanvasGameplay({
     onBootstrap: applyBootstrap,
     onUnauthorized,
   });
+  silentSessionResyncRef.current = () => initializeSession({ silent: true });
 
-  useEffect(() => {
-    return () => {
-      clearSnapshotDelayTimer();
-    };
-  }, [clearSnapshotDelayTimer]);
+  const sessionCleanup = useGameplaySessionCleanup({
+    clearActiveRoundTimer,
+    clearTickets,
+    clearParticipants,
+    resetRoundState,
+    resetRoundTimer,
+    resetVoteState,
+    resetSummaries,
+    markGameEnded,
+    onGameEndedCleanup,
+    onSessionEnded,
+  });
 
   useEffect(() => {
     let cancelled = false;
@@ -454,76 +249,9 @@ export default function useCanvasGameplay({
   }, [initializeSession]);
 
   useEffect(() => {
-    hasJoinedCanvasRef.current = false;
-    clearActiveRoundTimer();
+    resetJoinedState();
     clearParticipants();
-  }, [canvasId, clearActiveRoundTimer, clearParticipants]);
-
-  useEffect(() => {
-    if (!isRoundActivePhase(phase)) {
-      return;
-    }
-
-    const syncTimer = () => {
-      const timerState = activeRoundTimerRef.current;
-
-      if (!timerState) {
-        return;
-      }
-
-      setActiveRoundTimerState(
-        timerState.roundEndsAt,
-        timerState.serverOffsetMs,
-        timerState.isRoundExpired,
-      );
-    };
-
-    syncTimer();
-
-    const timer = window.setInterval(syncTimer, 250);
-
-    return () => {
-      window.clearInterval(timer);
-    };
-  }, [phase, setActiveRoundTimerState]);
-
-  useEffect(() => {
-    if (isRoundActivePhase(phase)) {
-      return;
-    }
-
-    if (!phaseEndsAt) {
-      return;
-    }
-
-    const expired =
-      phase === GAME_PHASE.ROUND_RESULT || phase === GAME_PHASE.GAME_END;
-
-    setPhaseTimerState(phaseEndsAt, expired);
-
-    const timer = window.setInterval(() => {
-      setPhaseTimerState(phaseEndsAt, expired);
-    }, 250);
-
-    return () => {
-      window.clearInterval(timer);
-    };
-  }, [phase, phaseEndsAt, setPhaseTimerState]);
-
-  const handleCanvasJoined = useCallback(
-    ({ restored }: { restored: boolean }) => {
-      const isInitialJoin = !hasJoinedCanvasRef.current;
-
-      hasJoinedCanvasRef.current = true;
-
-      if (!isInitialJoin && !restored) {
-        return;
-      }
-
-      void refreshParticipants();
-    },
-    [refreshParticipants],
-  );
+  }, [canvasId, clearParticipants, resetJoinedState]);
 
   const handleRoundStarted = useCallback(
     async ({
@@ -535,21 +263,8 @@ export default function useCanvasGameplay({
       startedAt,
       roundEndsAt,
       serverNow,
-    }: {
-      roundId: number;
-      roundNumber: number;
-      startedAt: string;
-      roundEndsAt: string;
-      serverNow: string;
-      roundDurationSec: number;
-      totalRounds: number;
-      gameEndAt: string;
-    }) => {
-      clearSnapshotDelayTimer();
-      pendingRoundResultRef.current = null;
-      setGameSummary(null);
-      setRoundSummaryLoading(false);
-      setGameSummaryLoading(false);
+    }: RoundStartedPayload) => {
+      resetForRoundStart();
       onRoundStartedCleanup();
 
       setRoundState({
@@ -583,203 +298,21 @@ export default function useCanvasGameplay({
     [
       applyParticipantsSnapshot,
       clearSessionError,
-      clearSnapshotDelayTimer,
       fetchTickets,
       onRoundStartedCleanup,
       participants,
       resetVoteState,
       setRoundState,
+      resetForRoundStart,
       syncActiveRoundTimer,
     ],
   );
-
-  const handleRoundEnded = useCallback(
-    ({
-      roundId,
-      roundNumber,
-    }: {
-      roundId: number;
-      roundNumber: number;
-    }) => {
-      clearActiveRoundTimer();
-      clearSnapshotDelayTimer();
-      onRoundEndedCleanup();
-      clearTickets();
-      resetVoteState();
-      setRoundSummaryLoading(true);
-      setCanOpenLatestRoundSummary(false);
-      pendingRoundResultRef.current = {
-        roundId,
-        roundNumber,
-        summaryReady: false,
-        canvasApplied: false,
-        summary: null,
-      };
-    },
-    [
-      clearActiveRoundTimer,
-      clearSnapshotDelayTimer,
-      onRoundEndedCleanup,
-      clearTickets,
-      resetVoteState,
-    ],
-  );
-
-  const handleRoundSummaryReady = useCallback(
-    (payload: RoundSummaryReadyPayload) => {
-      const readyCanvasId = payload.canvasId;
-      const readyRoundId = payload.roundId;
-
-      if (!canvasId || canvasId !== readyCanvasId) {
-        return;
-      }
-
-      void requestRoundSummary(readyCanvasId, readyRoundId).then((summary) => {
-        if (!summary) {
-          return;
-        }
-
-        if (
-          pendingRoundResultRef.current &&
-          pendingRoundResultRef.current.roundId === readyRoundId
-        ) {
-          pendingRoundResultRef.current = {
-            ...pendingRoundResultRef.current,
-            summaryReady: true,
-            summary,
-          };
-          completePendingRoundResult();
-          return;
-        }
-
-        setCanOpenLatestRoundSummary(true);
-      });
-    },
-    [canvasId, completePendingRoundResult, requestRoundSummary],
-  );
-
-  const handlePhaseUpdated = useCallback(
-    ({
-      canvasId: updatedCanvasId,
-      phase: nextPhase,
-      roundId: nextRoundId,
-      roundNumber: nextRoundNumber,
-      roundDurationSec: nextRoundDurationSec,
-      remainingSeconds: nextRemainingSeconds,
-      totalRounds: nextTotalRounds,
-      phaseStartedAt: nextPhaseStartedAt,
-      phaseEndsAt: nextPhaseEndsAt,
-    }: PhaseUpdatedPayload) => {
-      if (!canvasId || canvasId !== updatedCanvasId) {
-        return;
-      }
-
-      if (nextPhase === GAME_PHASE.ROUND_ACTIVE) {
-        return;
-      }
-
-      clearActiveRoundTimer();
-
-      setRoundState({
-        phase: nextPhase,
-        roundId: nextRoundId,
-        roundNumber: nextRoundNumber,
-        roundDurationSec: nextRoundDurationSec,
-        totalRounds: nextTotalRounds,
-        formattedGameEndTime,
-        phaseStartedAt: nextPhaseStartedAt,
-        phaseEndsAt: nextPhaseEndsAt,
-      });
-
-      if (nextRemainingSeconds !== null) {
-        if (nextPhaseEndsAt) {
-          setPhaseTimerState(
-            nextPhaseEndsAt,
-            nextPhase === GAME_PHASE.GAME_END && nextRemainingSeconds === 0,
-          );
-        } else {
-          applyPhaseTimerSnapshot(
-            nextRemainingSeconds,
-            nextPhase === GAME_PHASE.GAME_END && nextRemainingSeconds === 0,
-          );
-        }
-        return;
-      }
-
-      setPhaseTimerState(
-        nextPhaseEndsAt,
-        nextPhase === GAME_PHASE.GAME_END && nextRemainingSeconds === 0,
-      );
-    },
-    [
-      applyPhaseTimerSnapshot,
-      canvasId,
-      clearActiveRoundTimer,
-      formattedGameEndTime,
-      setPhaseTimerState,
-      setRoundState,
-    ],
-  );
-
-  const handleSessionEnded = useCallback(() => {
-    clearActiveRoundTimer();
-    clearSnapshotDelayTimer();
-    pendingRoundResultRef.current = null;
-    setCanOpenLatestRoundSummary(false);
-    clearTickets();
-    clearParticipants();
-    resetRoundState();
-    resetRoundTimer();
-    resetVoteState();
-    setRoundSummary(null);
-    setGameSummary(null);
-    setRoundSummaryEvent(null);
-    setGameSummaryEvent(null);
-    setRoundSummaryLoading(false);
-    setGameSummaryLoading(false);
-    onSessionEnded();
-  }, [
-    clearActiveRoundTimer,
-    clearParticipants,
-    clearSnapshotDelayTimer,
-    clearTickets,
-    onSessionEnded,
-    resetRoundState,
-    resetRoundTimer,
-    resetVoteState,
-  ]);
 
   const handleVoteUpdate = useCallback(
     ({ votes }: { votes: Record<string, number> }) => {
       applyVoteUpdate(votes);
     },
     [applyVoteUpdate],
-  );
-
-  const handleTimerUpdate = useCallback(
-    ({
-      isRoundExpired,
-      serverNow,
-      roundEndsAt,
-      gameEndAt,
-      roundDurationSec,
-      totalRounds,
-    }: {
-      isRoundExpired: boolean;
-      serverNow: string;
-      roundEndsAt: string;
-      gameEndAt: string;
-      roundDurationSec: number;
-      totalRounds: number;
-    }) => {
-      syncActiveRoundTimer({
-        roundEndsAt,
-        serverNow,
-        isRoundExpired,
-      });
-      applyRoundMeta({ roundDurationSec, totalRounds, gameEndAt });
-    },
-    [applyRoundMeta, syncActiveRoundTimer],
   );
 
   const handleParticipantsUpdated = useCallback(
@@ -796,36 +329,6 @@ export default function useCanvasGameplay({
     [applyParticipantsSnapshot],
   );
 
-  const handleGameEnded = useCallback(() => {
-    clearActiveRoundTimer();
-    clearSnapshotDelayTimer();
-    pendingRoundResultRef.current = null;
-    setCanOpenLatestRoundSummary(false);
-    markGameEnded();
-    clearTickets();
-    clearParticipants();
-    onGameEndedCleanup();
-    resetRoundState();
-    resetRoundTimer();
-    resetVoteState();
-    setRoundSummary(null);
-    setGameSummary(null);
-    setRoundSummaryEvent(null);
-    setGameSummaryEvent(null);
-    setRoundSummaryLoading(false);
-    setGameSummaryLoading(false);
-  }, [
-    clearActiveRoundTimer,
-    clearParticipants,
-    clearSnapshotDelayTimer,
-    clearTickets,
-    markGameEnded,
-    onGameEndedCleanup,
-    resetRoundState,
-    resetRoundTimer,
-    resetVoteState,
-  ]);
-
   const handleCanvasUpdatedWithSnapshot = useCallback(
     (payload: { x: number; y: number; color: string }) => {
       onCanvasUpdated(payload);
@@ -836,21 +339,9 @@ export default function useCanvasGameplay({
   const handleCanvasBatchUpdatedWithSnapshot = useCallback(
     (payload: CanvasBatchUpdatedPayload) => {
       onCanvasBatchUpdated(payload);
-
-      if (!pendingRoundResultRef.current) {
-        return;
-      }
-
-      pendingRoundResultRef.current = {
-        ...pendingRoundResultRef.current,
-        canvasApplied: true,
-      };
-
-      window.requestAnimationFrame(() => {
-        completePendingRoundResult();
-      });
+      markPendingRoundResultCanvasApplied();
     },
-    [completePendingRoundResult, onCanvasBatchUpdated],
+    [markPendingRoundResultCanvasApplied, onCanvasBatchUpdated],
   );
 
   useGameplaySocket({
@@ -866,8 +357,8 @@ export default function useCanvasGameplay({
     onVoteUpdate: handleVoteUpdate,
     onTimerUpdate: handleTimerUpdate,
     onParticipantsUpdated: handleParticipantsUpdated,
-    onSessionEnded: handleSessionEnded,
-    onGameEnded: handleGameEnded,
+    onSessionEnded: sessionCleanup.handleSessionEnded,
+    onGameEnded: sessionCleanup.handleGameEnded,
   });
 
   const handleVoteSuccess = useCallback(() => {

--- a/frontend/src/pages/canvas/model/useCanvasGameplay.ts
+++ b/frontend/src/pages/canvas/model/useCanvasGameplay.ts
@@ -95,6 +95,7 @@ export default function useCanvasGameplay({
   } = useRoundTimer();
 
   const phaseTimingRef = useRef<PhaseTimingState>(DEFAULT_PHASE_TIMING);
+  const hasJoinedCanvasRef = useRef(false);
   const localPhaseTransitionTimerRef = useRef<number | null>(null);
   const snapshotDelayTimerRef = useRef<number | null>(null);
   const pendingRoundResultRef = useRef<{
@@ -321,13 +322,9 @@ export default function useCanvasGameplay({
   }, [initializeSession]);
 
   useEffect(() => {
-    if (!canvasId) {
-      clearParticipants();
-      return;
-    }
-
-    void refreshParticipants();
-  }, [canvasId, clearParticipants, refreshParticipants]);
+    hasJoinedCanvasRef.current = false;
+    clearParticipants();
+  }, [canvasId, clearParticipants]);
 
   useEffect(() => {
     if (isRoundActivePhase(phase)) {
@@ -458,8 +455,20 @@ export default function useCanvasGameplay({
     totalRounds,
   ]);
 
-  const handleCanvasJoined = useCallback(() => {
-  }, []);
+  const handleCanvasJoined = useCallback(
+    ({ restored }: { restored: boolean }) => {
+      const isInitialJoin = !hasJoinedCanvasRef.current;
+
+      hasJoinedCanvasRef.current = true;
+
+      if (!isInitialJoin && !restored) {
+        return;
+      }
+
+      void refreshParticipants();
+    },
+    [refreshParticipants],
+  );
 
   const handleRoundStarted = useCallback(
     async ({

--- a/frontend/src/pages/canvas/model/useCanvasPage.ts
+++ b/frontend/src/pages/canvas/model/useCanvasPage.ts
@@ -33,6 +33,8 @@ export default function useCanvasPage({
 }: UseCanvasPageParams) {
   const isRoundExpiredRef = useRef(false);
   const lastAutoOpenedRoundIdRef = useRef<number | null>(null);
+  const handledRoundSummaryEventRef = useRef(0);
+  const handledGameSummaryEventRef = useRef(0);
 
   const [roundSummaryModal, setRoundSummaryModal] =
     useState<RoundSummaryData | null>(null);
@@ -290,8 +292,6 @@ export default function useCanvasPage({
     onBootstrapScene: applyBootstrapScene,
     onCanvasUpdated: handleCanvasUpdated,
     onCanvasBatchUpdated: handleCanvasBatchUpdatedForRoundResult,
-    onOpenRoundSummaryModal: handleReceiveRoundSummary,
-    onOpenGameSummaryModal: handleReceiveGameSummary,
     onRoundStartedCleanup: handleRoundStartedCleanup,
     onRoundEndedCleanup: handleRoundEndedCleanup,
     onGameEndedCleanup: handleGameEndedCleanup,
@@ -304,6 +304,32 @@ export default function useCanvasPage({
   useEffect(() => {
     isRoundExpiredRef.current = gameplay.isRoundExpiredRefValue;
   }, [gameplay.isRoundExpiredRefValue]);
+
+  useEffect(() => {
+    if (!gameplay.roundSummaryEvent) {
+      return;
+    }
+
+    if (handledRoundSummaryEventRef.current === gameplay.roundSummaryEvent.sequence) {
+      return;
+    }
+
+    handledRoundSummaryEventRef.current = gameplay.roundSummaryEvent.sequence;
+    handleReceiveRoundSummary(gameplay.roundSummaryEvent.summary);
+  }, [gameplay.roundSummaryEvent, handleReceiveRoundSummary]);
+
+  useEffect(() => {
+    if (!gameplay.gameSummaryEvent) {
+      return;
+    }
+
+    if (handledGameSummaryEventRef.current === gameplay.gameSummaryEvent.sequence) {
+      return;
+    }
+
+    handledGameSummaryEventRef.current = gameplay.gameSummaryEvent.sequence;
+    handleReceiveGameSummary(gameplay.gameSummaryEvent.summary);
+  }, [gameplay.gameSummaryEvent, handleReceiveGameSummary]);
 
   const handleOpenLatestRoundSummary = useCallback(() => {
     if (!gameplay.roundSummary || !gameplay.canOpenLatestRoundSummary) {

--- a/frontend/src/shared/i18n/resources.ts
+++ b/frontend/src/shared/i18n/resources.ts
@@ -8,6 +8,8 @@ export const LOCALE_STORAGE_KEY = "votedots-locale";
 
 export const resources: Record<Locale, Record<string, string>> = {
   ko: {
+    "server.common.networkError":
+      "네트워크 오류가 발생했습니다.",
     "language.switcher": "언어 변경",
     "language.ko": "한국어",
     "language.en": "English",
@@ -265,6 +267,8 @@ export const resources: Record<Locale, Record<string, string>> = {
     "loginBoard.patchType.breaking": "Breaking",
   },
   en: {
+    "server.common.networkError":
+      "We couldn't connect to the server. Please check your network connection.",
     "language.switcher": "Change language",
     "language.ko": "Korean",
     "language.en": "English",

--- a/frontend/src/shared/i18n/server-messages.ts
+++ b/frontend/src/shared/i18n/server-messages.ts
@@ -9,6 +9,7 @@ const EXACT_KEY_MAP: Record<string, string> = {
   AUTH_INVALID_USERNAME: "server.auth.invalidUsername",
   AUTH_INVALID_NICKNAME: "server.auth.invalidNickname",
   AUTH_INVALID_PASSWORD: "server.auth.invalidPassword",
+  "Network Error": "server.common.networkError",
   "No active round was found.": "server.vote.noRound",
   "Canvas was not found.": "server.vote.canvasNotFound",
   "Invalid cell coordinate.": "server.vote.invalidCell",


### PR DESCRIPTION
## 관련 이슈
  - Close #388 
  - Close #389 

## 개요

gameplay 세션 구조에서 진입/bootstrap, 실시간 동기화, phase 전환, timer 표시, summary 처리, UI orchestration 책임이 섞여 있던 부분을 단계적으로 분리했습니다.

이번 변경은 이후 로비/방 확장과 모바일 지원 시 구조 변경 범위를 줄이기 위한 선행 리팩토링입니다.

## 변경사항

- gameplay 세션 진입과 bootstrap 책임 분리
- bootstrap 내부의 `gameConfig` 전역 적용 제거
- participant 실시간 동기화를 `participants:updated` 중심으로 정리
- summary / ticket 요청에 same-key guard와 stale response 방지 추가
- summary UI open 책임을 page 레벨로 이동
- `canvas:phase-updated` 기반 phase 동기화 추가
- `ROUND_ACTIVE` 타이머를 `serverNow + roundEndsAt` 기준으로 보정
- non-active phase(`INTRO`, `ROUND_START_WAIT`, `ROUND_RESULT`, `GAME_END`)도 `serverNow + phaseEndsAt` 기준으로 표시 동기화
- 홈 복귀 후 재진입 시 `canvas:joined` 기준 silent bootstrap 재동기화 추가
- `useCanvasGameplay`의 책임을 페이지 전용 훅으로 분리
  - `useGameplayPhaseSync`
  - `useGameplaySummaries`
  - `useGameplaySessionCleanup`

## 코드 흐름

- `useGameSession`이 인증 확인, bootstrap 실행, restart/retry 흐름을 조합합니다.
- `useGameplayBootstrap`은 현재 gameplay 진입에 필요한 상태를 조회해서 반환합니다.
- `useCanvasGameplay`는 bootstrap 결과를 적용하고, gameplay 전용 훅을 조합하는 coordinator 역할만 담당합니다.
- `useGameplayPhaseSync`가 `canvas:joined`, `canvas:phase-updated`, `round:started`, `round:ended`, `timer:update`를 받아 phase/timer를 동기화합니다.
- `ROUND_ACTIVE`는 `timer:update`의 `serverNow + roundEndsAt`로 남은 시간을 계산합니다.
- non-active phase는 `canvas:phase-updated`와 bootstrap의 `serverNow + phaseEndsAt`로 남은 시간을 계산합니다.
- `useGameplaySummaries`가 round/game summary 요청, in-flight/stale guard, pending round result 흐름을 관리합니다.
- `useGameplaySessionCleanup`가 session ended / game ended 시 reset/cleanup 로직을 정리합니다.
- `useCanvasPage`가 summary event를 받아 history 반영과 modal open 같은 UI orchestration을 담당합니다.

## 검증

- `frontend`: `tsc --noEmit -p tsconfig.app.json` 통과
- `backend`: `tsc --noEmit -p tsconfig.json` 통과
- `frontend` lint 통과
- `frontend` 테스트 통과
- 수동 확인
  - `/play` 정상 진입
  - phase 전환과 active round 타이머 동작 확인
  - non-active phase 표시 시간이 기기 시계 차이에 덜 영향받는지 확인
  - 라운드/게임 summary modal 및 history 반영 확인
  - 홈 복귀 후 재진입 시 현재 라운드 기준 participant / ticket 재동기화 확인

## 결정사항

- canvas 중심 구조는 유지하고, room/로비 확장을 받을 수 있게 책임만 분리했습니다.
- participant 실시간 상태는 `participants:updated`를 기준 진실로 보고, 최초 진입/복구 시점만 fallback 조회를 사용합니다.
- phase 전환 이벤트는 기존처럼 전환 시점에만 push하고, 매초 countdown push는 추가하지 않았습니다.
- non-active phase 정밀도는 `serverNow` payload 추가로 해결하고, 이벤트 빈도는 늘리지 않았습니다.
- 페이지 전용 orchestration 훅은 `features/gameplay/canvas/hooks`가 아니라 `pages/canvas/hooks` 아래에 배치했습니다.

## 리뷰 포인트

- `useCanvasGameplay`가 coordinator 역할만 남도록 경계가 충분히 정리됐는지
- `canvas:joined` 시 silent bootstrap 재동기화가 재진입/복구 흐름에 적절한지
- active round / non-active phase 모두 서버 시간 기준으로 표시가 일관되게 맞는지
