### PR TITLE
feat: 회원가입 약관 고지 및 동의 정보 저장 추가

### DIFF
--- a/backend/src/database/migrations/1784300000000-AddRegisterConsentFieldsToVoter.ts
+++ b/backend/src/database/migrations/1784300000000-AddRegisterConsentFieldsToVoter.ts
@@ -1,0 +1,51 @@
+import type { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddRegisterConsentFieldsToVoter1784300000000
+  implements MigrationInterface
+{
+  name = "AddRegisterConsentFieldsToVoter1784300000000";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "voter"
+      ADD COLUMN "termsAcceptedAt" TIMESTAMP WITH TIME ZONE
+    `);
+
+    await queryRunner.query(`
+      ALTER TABLE "voter"
+      ADD COLUMN "termsAcceptedLocale" character varying(8)
+    `);
+
+    await queryRunner.query(`
+      ALTER TABLE "voter"
+      ADD COLUMN "termsVersion" character varying(32)
+    `);
+
+    await queryRunner.query(`
+      ALTER TABLE "voter"
+      ADD COLUMN "isAge14OrOlderConfirmed" boolean NOT NULL DEFAULT false
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "voter"
+      DROP COLUMN "isAge14OrOlderConfirmed"
+    `);
+
+    await queryRunner.query(`
+      ALTER TABLE "voter"
+      DROP COLUMN "termsVersion"
+    `);
+
+    await queryRunner.query(`
+      ALTER TABLE "voter"
+      DROP COLUMN "termsAcceptedLocale"
+    `);
+
+    await queryRunner.query(`
+      ALTER TABLE "voter"
+      DROP COLUMN "termsAcceptedAt"
+    `);
+  }
+}

--- a/backend/src/entities/voter.entity.ts
+++ b/backend/src/entities/voter.entity.ts
@@ -24,6 +24,18 @@ export class Voter extends BaseEntity {
   @Column({ type: "varchar", length: 32 })
   nickname!: string;
 
+  @Column({ type: "timestamptz", nullable: true })
+  termsAcceptedAt!: Date | null;
+
+  @Column({ type: "varchar", length: 8, nullable: true })
+  termsAcceptedLocale!: string | null;
+
+  @Column({ type: "varchar", length: 32, nullable: true })
+  termsVersion!: string | null;
+
+  @Column({ type: "boolean", default: false })
+  isAge14OrOlderConfirmed!: boolean;
+
   @Column({
     type: "varchar",
     length: 16,

--- a/backend/src/modules/auth/auth.constants.ts
+++ b/backend/src/modules/auth/auth.constants.ts
@@ -1,0 +1,5 @@
+export const CURRENT_TERMS_VERSION = "2026-05-12";
+
+export const SUPPORTED_AUTH_LOCALES = ["ko", "en"] as const;
+
+export type AuthLocale = (typeof SUPPORTED_AUTH_LOCALES)[number];

--- a/backend/src/modules/auth/auth.controller.ts
+++ b/backend/src/modules/auth/auth.controller.ts
@@ -33,18 +33,31 @@ function destroyRequestSession(req: Request): Promise<void> {
 export const authController = {
   async register(req: Request, res: Response) {
     try {
-      const { username, password, nickname } = req.body;
+      const {
+        username,
+        password,
+        nickname,
+        acceptedTerms,
+        isAge14OrOlderConfirmed,
+        termsAcceptedLocale,
+      } = req.body;
       const validationError = validateRegisterInput({
         username,
         password,
         nickname,
+        acceptedTerms,
+        isAge14OrOlderConfirmed,
+        termsAcceptedLocale,
       });
 
       if (validationError) {
         return res.status(400).json({ message: validationError });
       }
 
-      await authService.register(username, password, nickname);
+      await authService.register(username, password, nickname, {
+        termsAcceptedLocale,
+        isAge14OrOlderConfirmed,
+      });
       return res.status(201).json({ message: "REGISTER_SUCCESS" });
     } catch (err) {
       return res.status(400).json({

--- a/backend/src/modules/auth/auth.service.ts
+++ b/backend/src/modules/auth/auth.service.ts
@@ -2,6 +2,7 @@ import bcrypt from "bcrypt";
 import { QueryFailedError } from "typeorm";
 import { AppDataSource } from "../../database/data-source";
 import { Voter, VoterRole } from "../../entities/voter.entity";
+import { CURRENT_TERMS_VERSION } from "./auth.constants";
 import { AUTH_ERROR_MESSAGES } from "./auth.validation";
 
 const voterRepository = AppDataSource.getRepository(Voter);
@@ -19,7 +20,15 @@ function isUsernameUniqueViolation(error: unknown): boolean {
 }
 
 export const authService = {
-  async register(username: string, password: string, nickname: string) {
+  async register(
+    username: string,
+    password: string,
+    nickname: string,
+    params: {
+      termsAcceptedLocale: string;
+      isAge14OrOlderConfirmed: boolean;
+    },
+  ) {
     const existing = await voterRepository.findOne({ where: { username } });
     if (existing) {
       throw new Error(AUTH_ERROR_MESSAGES.USERNAME_TAKEN);
@@ -31,6 +40,10 @@ export const authService = {
       username,
       password: hashedPassword,
       nickname,
+      termsAcceptedAt: new Date(),
+      termsAcceptedLocale: params.termsAcceptedLocale,
+      termsVersion: CURRENT_TERMS_VERSION,
+      isAge14OrOlderConfirmed: params.isAge14OrOlderConfirmed,
       role: VoterRole.USER,
     });
 

--- a/backend/src/modules/auth/auth.validation.ts
+++ b/backend/src/modules/auth/auth.validation.ts
@@ -11,6 +11,7 @@ export const AUTH_ERROR_MESSAGES = {
 const USERNAME_REGEX = /^[a-z0-9]{4,20}$/;
 const NICKNAME_REGEX = /^[A-Za-z0-9가-힣]{2,20}$/;
 const PASSWORD_REGEX = /^(?=.*[A-Za-z])(?=.*\d)\S{8,64}$/;
+const SUPPORTED_REGISTER_LOCALES = new Set(["ko", "en"]);
 
 function isNonEmptyString(value: unknown): value is string {
   return typeof value === "string" && value.length > 0;
@@ -20,13 +21,27 @@ export function validateRegisterInput(params: {
   username: unknown;
   password: unknown;
   nickname: unknown;
+  acceptedTerms: unknown;
+  isAge14OrOlderConfirmed: unknown;
+  termsAcceptedLocale: unknown;
 }): string | null {
-  const { username, password, nickname } = params;
+  const {
+    username,
+    password,
+    nickname,
+    acceptedTerms,
+    isAge14OrOlderConfirmed,
+    termsAcceptedLocale,
+  } = params;
 
   if (
     !isNonEmptyString(username) ||
     !isNonEmptyString(password) ||
-    !isNonEmptyString(nickname)
+    !isNonEmptyString(nickname) ||
+    acceptedTerms !== true ||
+    isAge14OrOlderConfirmed !== true ||
+    !isNonEmptyString(termsAcceptedLocale) ||
+    !SUPPORTED_REGISTER_LOCALES.has(termsAcceptedLocale)
   ) {
     return AUTH_ERROR_MESSAGES.MISSING_FIELDS;
   }

--- a/backend/test/integration/auth.integration.test.ts
+++ b/backend/test/integration/auth.integration.test.ts
@@ -1,17 +1,30 @@
+import { AppDataSource } from "../../src/database/data-source";
+import { Voter } from "../../src/entities/voter.entity";
 import { setupIntegrationSuite } from "./helpers/setup-integration-suite";
 
 describe("auth integration", () => {
   const suite = setupIntegrationSuite();
+  const voterRepository = AppDataSource.getRepository(Voter);
 
   it("registers a voter successfully", async () => {
     const response = await suite.request().post("/auth/register").send({
       username: "user0001",
       password: "password1",
       nickname: "Tester01",
+      acceptedTerms: true,
+      isAge14OrOlderConfirmed: true,
+      termsAcceptedLocale: "ko",
     });
 
     expect(response.status).toBe(201);
     expect(response.body).toEqual({ message: "REGISTER_SUCCESS" });
+
+    const voter = await voterRepository.findOneByOrFail({ username: "user0001" });
+
+    expect(voter.termsAcceptedAt).toBeInstanceOf(Date);
+    expect(voter.termsAcceptedLocale).toBe("ko");
+    expect(voter.termsVersion).toBe("2026-05-12");
+    expect(voter.isAge14OrOlderConfirmed).toBe(true);
   });
 
   it("logs in and returns the current session voter", async () => {
@@ -21,6 +34,9 @@ describe("auth integration", () => {
       username: "user0002",
       password: "password1",
       nickname: "Tester02",
+      acceptedTerms: true,
+      isAge14OrOlderConfirmed: true,
+      termsAcceptedLocale: "en",
     });
 
     const loginResponse = await agent.post("/auth/login").send({

--- a/frontend/src/features/auth/model/auth.types.ts
+++ b/frontend/src/features/auth/model/auth.types.ts
@@ -2,6 +2,9 @@ export interface RegisterRequest {
   username: string;
   password: string;
   nickname: string;
+  acceptedTerms: boolean;
+  isAge14OrOlderConfirmed: boolean;
+  termsAcceptedLocale: string;
 }
 
 export interface LoginRequest {

--- a/frontend/src/features/auth/model/register.validation.ts
+++ b/frontend/src/features/auth/model/register.validation.ts
@@ -2,12 +2,16 @@ export interface RegisterFormValues {
   username: string;
   nickname: string;
   password: string;
+  acceptedTerms: boolean;
+  isAge14OrOlderConfirmed: boolean;
 }
 
 export interface RegisterFormErrorKeys {
   username: string | null;
   nickname: string | null;
   password: string | null;
+  acceptedTerms: string | null;
+  isAge14OrOlderConfirmed: string | null;
 }
 
 const USERNAME_REGEX = /^[a-z0-9]{4,20}$/;
@@ -27,11 +31,23 @@ export function validateRegisterForm(
     password: PASSWORD_REGEX.test(values.password)
       ? null
       : "auth.register.passwordRule",
+    acceptedTerms: values.acceptedTerms
+      ? null
+      : "auth.register.termsAgreementRequired",
+    isAge14OrOlderConfirmed: values.isAge14OrOlderConfirmed
+      ? null
+      : "auth.register.ageConfirmationRequired",
   };
 }
 
 export function isRegisterFormValid(values: RegisterFormValues): boolean {
   const errors = validateRegisterForm(values);
 
-  return !errors.username && !errors.nickname && !errors.password;
+  return (
+    !errors.username &&
+    !errors.nickname &&
+    !errors.password &&
+    !errors.acceptedTerms &&
+    !errors.isAge14OrOlderConfirmed
+  );
 }

--- a/frontend/src/pages/register/RegisterPage.tsx
+++ b/frontend/src/pages/register/RegisterPage.tsx
@@ -1,10 +1,11 @@
-import { useState } from "react";
+import { useState, type FormEvent, type ReactNode } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { authApi } from "@/features/auth";
 import {
   isRegisterFormValid,
   validateRegisterForm,
 } from "@/features/auth/model/register.validation";
+import { getSiteContent } from "@/shared/content/site-content";
 import { useI18n } from "@/shared/i18n";
 import { usePageRootClass } from "@/shared/hooks/use-page-root-class";
 import { translateServerMessage } from "@/shared/i18n/server-messages";
@@ -12,34 +13,149 @@ import { BrandLogo } from "@/shared/ui/brand-logo";
 import { Button } from "@/shared/ui/button";
 import LanguageSwitcher from "@/shared/ui/language-switcher";
 
+const REGISTER_COPY = {
+  ko: {
+    ageCheckboxLabel: "만 14세 이상입니다.",
+    termsCheckboxLabel: "서비스 이용약관에 동의합니다.",
+    termsSectionTitle: "서비스 이용약관",
+    collectionSectionTitle: "개인정보 수집 및 이용 안내",
+    viewDetailsLabel: "내용 보기",
+    closeDetailsLabel: "내용 닫기",
+    collectionItemsLabel: "수집 항목",
+    collectionItemsValue: "아이디, 닉네임, 비밀번호",
+    collectionPurposeLabel: "이용 목적",
+    collectionPurposeValue:
+      "회원가입, 로그인 및 이용자 식별, 만 14세 이상 여부 확인, 서비스 이용약관 동의 이력 확인",
+    collectionRetentionLabel: "보유 기간",
+    collectionRetentionValue:
+      "아이디, 닉네임, 비밀번호 및 서비스 이용약관 동의 이력은 회원 탈퇴 시까지 보관합니다.",
+    privacyGuidePrefix: "자세한 내용은 ",
+    privacyGuideLink: "개인정보처리방침",
+    privacyGuideSuffix: "에서 확인해 주세요.",
+    ageConfirmationRequired: "만 14세 이상 여부를 확인해 주세요.",
+    termsAgreementRequired: "서비스 이용약관에 동의해 주세요.",
+  },
+  en: {
+    ageCheckboxLabel: "I confirm that I am at least 14 years old.",
+    termsCheckboxLabel: "I agree to the Terms of Service.",
+    termsSectionTitle: "Terms of Service",
+    collectionSectionTitle: "Privacy Collection Notice",
+    viewDetailsLabel: "View details",
+    closeDetailsLabel: "Hide details",
+    collectionItemsLabel: "Collected items",
+    collectionItemsValue: "Username, nickname, password",
+    collectionPurposeLabel: "Purpose",
+    collectionPurposeValue:
+      "Account registration, sign-in and user identification, confirming that the user is at least 14 years old, and recording acceptance of the Terms of Service",
+    collectionRetentionLabel: "Retention period",
+    collectionRetentionValue:
+      "Username, nickname, password, and the Terms of Service consent record are retained until account withdrawal.",
+    privacyGuidePrefix: "For more details, please review the ",
+    privacyGuideLink: "Privacy Policy",
+    privacyGuideSuffix: ".",
+    ageConfirmationRequired: "Please confirm that you are at least 14 years old.",
+    termsAgreementRequired: "Please agree to the Terms of Service.",
+  },
+} as const;
+
+type RegisterErrorKey =
+  | "auth.register.usernameRule"
+  | "auth.register.nicknameRule"
+  | "auth.register.passwordRule"
+  | "auth.register.termsAgreementRequired"
+  | "auth.register.ageConfirmationRequired";
+
+function RegisterAccordion({
+  title,
+  openLabel,
+  closeLabel,
+  children,
+}: {
+  title: string;
+  openLabel: string;
+  closeLabel: string;
+  children: ReactNode;
+}) {
+  return (
+    <details className="group rounded border border-gray-200 bg-white">
+      <summary className="flex cursor-pointer list-none items-center justify-between gap-3 px-3 py-2 text-sm [&::-webkit-details-marker]:hidden">
+        <span className="font-medium text-gray-700">{title}</span>
+        <span className="inline-flex items-center rounded-full border border-gray-300 px-3 py-1 text-xs font-medium text-gray-600 transition group-hover:border-gray-400 group-hover:text-gray-800">
+          <span className="group-open:hidden">{openLabel}</span>
+          <span className="hidden group-open:inline">{closeLabel}</span>
+        </span>
+      </summary>
+
+      <div className="border-t border-gray-200 px-3 py-3 text-sm leading-6 text-gray-600">
+        {children}
+      </div>
+    </details>
+  );
+}
+
 export default function RegisterPage() {
   const navigate = useNavigate();
   const { locale, t } = useI18n();
+  const siteContent = getSiteContent(locale);
+  const copy = REGISTER_COPY[locale];
+  const privacyPath = `/${locale}/privacy`;
 
   usePageRootClass("page-shell-root");
 
   const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
   const [nickname, setNickname] = useState("");
+  const [acceptedTerms, setAcceptedTerms] = useState(false);
+  const [isAge14OrOlderConfirmed, setIsAge14OrOlderConfirmed] =
+    useState(false);
   const [error, setError] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [touched, setTouched] = useState({
     username: false,
     nickname: false,
     password: false,
+    acceptedTerms: false,
+    isAge14OrOlderConfirmed: false,
   });
 
-  const formValues = { username, nickname, password };
+  const formValues = {
+    username,
+    nickname,
+    password,
+    acceptedTerms,
+    isAge14OrOlderConfirmed,
+  };
   const fieldErrors = validateRegisterForm(formValues);
   const canSubmit = isRegisterFormValid(formValues) && !submitting;
 
-  const handleSubmit = async (e: React.FormEvent) => {
+  const getFieldErrorMessage = (errorKey: string | null) => {
+    if (!errorKey) {
+      return null;
+    }
+
+    switch (errorKey as RegisterErrorKey) {
+      case "auth.register.usernameRule":
+      case "auth.register.nicknameRule":
+      case "auth.register.passwordRule":
+        return t(errorKey);
+      case "auth.register.termsAgreementRequired":
+        return copy.termsAgreementRequired;
+      case "auth.register.ageConfirmationRequired":
+        return copy.ageConfirmationRequired;
+      default:
+        return null;
+    }
+  };
+
+  const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
     setError("");
     setTouched({
       username: true,
       nickname: true,
       password: true,
+      acceptedTerms: true,
+      isAge14OrOlderConfirmed: true,
     });
 
     if (!isRegisterFormValid(formValues)) {
@@ -49,7 +165,14 @@ export default function RegisterPage() {
     setSubmitting(true);
 
     try {
-      await authApi.register({ username, password, nickname });
+      await authApi.register({
+        username,
+        password,
+        nickname,
+        acceptedTerms,
+        isAge14OrOlderConfirmed,
+        termsAcceptedLocale: locale,
+      });
       navigate("/login");
     } catch (err: unknown) {
       if (err && typeof err === "object" && "response" in err) {
@@ -66,8 +189,8 @@ export default function RegisterPage() {
   };
 
   return (
-    <div className="flex min-h-screen items-center justify-center">
-      <div className="flex w-full max-w-sm flex-col gap-6">
+    <div className="flex min-h-screen items-center justify-center px-4 py-8">
+      <div className="flex w-full max-w-sm flex-col gap-6 pb-8">
         <div className="flex justify-end">
           <LanguageSwitcher />
         </div>
@@ -107,7 +230,7 @@ export default function RegisterPage() {
               }`}
             >
               {touched.username && fieldErrors.username
-                ? t(fieldErrors.username)
+                ? getFieldErrorMessage(fieldErrors.username)
                 : t("auth.register.usernameHint")}
             </p>
           </div>
@@ -144,7 +267,7 @@ export default function RegisterPage() {
               }`}
             >
               {touched.nickname && fieldErrors.nickname
-                ? t(fieldErrors.nickname)
+                ? getFieldErrorMessage(fieldErrors.nickname)
                 : t("auth.register.nicknameHint")}
             </p>
           </div>
@@ -181,9 +304,125 @@ export default function RegisterPage() {
               }`}
             >
               {touched.password && fieldErrors.password
-                ? t(fieldErrors.password)
+                ? getFieldErrorMessage(fieldErrors.password)
                 : t("auth.register.passwordHint")}
             </p>
+          </div>
+
+          <label className="flex items-start gap-3 rounded border border-gray-200 px-3 py-3 text-sm">
+            <input
+              type="checkbox"
+              checked={isAge14OrOlderConfirmed}
+              onChange={(e) => {
+                setIsAge14OrOlderConfirmed(e.target.checked);
+                setError("");
+              }}
+              onBlur={() =>
+                setTouched((prev) => ({
+                  ...prev,
+                  isAge14OrOlderConfirmed: true,
+                }))
+              }
+              className="mt-0.5 h-4 w-4"
+              required
+            />
+            <span className="flex-1 text-gray-700">{copy.ageCheckboxLabel}</span>
+          </label>
+          {touched.isAge14OrOlderConfirmed &&
+          fieldErrors.isAge14OrOlderConfirmed ? (
+            <p className="text-xs text-red-500">
+              {getFieldErrorMessage(fieldErrors.isAge14OrOlderConfirmed)}
+            </p>
+          ) : null}
+
+          <label className="flex items-start gap-3 rounded border border-gray-200 px-3 py-3 text-sm">
+            <input
+              type="checkbox"
+              checked={acceptedTerms}
+              onChange={(e) => {
+                setAcceptedTerms(e.target.checked);
+                setError("");
+              }}
+              onBlur={() =>
+                setTouched((prev) => ({
+                  ...prev,
+                  acceptedTerms: true,
+                }))
+              }
+              className="mt-0.5 h-4 w-4"
+              required
+            />
+            <span className="flex-1 text-gray-700">
+              {copy.termsCheckboxLabel}
+            </span>
+          </label>
+          {touched.acceptedTerms && fieldErrors.acceptedTerms ? (
+            <p className="text-xs text-red-500">
+              {getFieldErrorMessage(fieldErrors.acceptedTerms)}
+            </p>
+          ) : null}
+
+          <div className="flex flex-col gap-3">
+            <RegisterAccordion
+              title={copy.termsSectionTitle}
+              openLabel={copy.viewDetailsLabel}
+              closeLabel={copy.closeDetailsLabel}
+            >
+              <div className="space-y-4">
+                <p className="text-sm font-semibold text-gray-800">
+                  {siteContent.infoPages.terms.lead}
+                </p>
+                {siteContent.infoPages.terms.sections.map((section) => (
+                  <section key={section.heading} className="space-y-2">
+                    <h3 className="text-sm font-semibold text-gray-800">
+                      {section.heading}
+                    </h3>
+                    {section.paragraphs.map((paragraph, index) => (
+                      <p key={`${section.heading}-${index}`}>{paragraph}</p>
+                    ))}
+                  </section>
+                ))}
+              </div>
+            </RegisterAccordion>
+
+            <RegisterAccordion
+              title={copy.collectionSectionTitle}
+              openLabel={copy.viewDetailsLabel}
+              closeLabel={copy.closeDetailsLabel}
+            >
+              <div className="space-y-3">
+                <p>
+                  <span className="font-semibold text-gray-800">
+                    {copy.collectionItemsLabel}:{" "}
+                  </span>
+                  {copy.collectionItemsValue}
+                </p>
+                <p>
+                  <span className="font-semibold text-gray-800">
+                    {copy.collectionPurposeLabel}:{" "}
+                  </span>
+                  {copy.collectionPurposeValue}
+                </p>
+                <p>
+                  <span className="font-semibold text-gray-800">
+                    {copy.collectionRetentionLabel}:{" "}
+                  </span>
+                  {copy.collectionRetentionValue}
+                </p>
+                <p>
+                  {copy.privacyGuidePrefix}
+                  <Link
+                    to={privacyPath}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="underline"
+                  >
+                    {copy.privacyGuideLink}
+                  </Link>
+                  {copy.privacyGuideSuffix}
+                </p>
+              </div>
+            </RegisterAccordion>
           </div>
 
           {error && <p className="text-sm text-red-500">{error}</p>}
@@ -193,7 +432,7 @@ export default function RegisterPage() {
           </Button>
         </form>
 
-        <p className="text-center text-sm">
+        <p className="pt-2 text-center text-sm">
           {t("auth.register.hasAccount")}{" "}
           <Link to="/login" className="underline">
             {t("auth.register.login")}

--- a/frontend/test/unit/register.validation.test.ts
+++ b/frontend/test/unit/register.validation.test.ts
@@ -9,12 +9,16 @@ describe("register.validation", () => {
       username: "tester01",
       nickname: "Player01",
       password: "password1",
+      acceptedTerms: true,
+      isAge14OrOlderConfirmed: true,
     };
 
     expect(validateRegisterForm(values)).toEqual({
       username: null,
       nickname: null,
       password: null,
+      acceptedTerms: null,
+      isAge14OrOlderConfirmed: null,
     });
     expect(isRegisterFormValid(values)).toBe(true);
   });
@@ -24,12 +28,16 @@ describe("register.validation", () => {
       username: "Ab",
       nickname: "x",
       password: "short",
+      acceptedTerms: false,
+      isAge14OrOlderConfirmed: false,
     };
 
     expect(validateRegisterForm(values)).toEqual({
       username: "auth.register.usernameRule",
       nickname: "auth.register.nicknameRule",
       password: "auth.register.passwordRule",
+      acceptedTerms: "auth.register.termsAgreementRequired",
+      isAge14OrOlderConfirmed: "auth.register.ageConfirmationRequired",
     });
     expect(isRegisterFormValid(values)).toBe(false);
   });


### PR DESCRIPTION
## 관련 이슈
- Close #392 

## 변경 내용

- 회원가입 화면에 `만 14세 이상` 체크와 `서비스 이용약관 동의` 체크를 추가
- 회원가입 화면에 `서비스 이용약관`, `개인정보 수집 및 이용 안내`를 각각 `내용 보기` 아코디언으로 추가
- 개인정보 수집 및 이용 안내 마지막에 개인정보처리방침 링크를 추가하고 새 탭으로 열리도록 변경
- 회원가입 요청에 `termsAcceptedAt`, `termsAcceptedLocale`, `termsVersion`, `isAge14OrOlderConfirmed` 저장 로직 추가
- `voter` 테이블에 관련 컬럼 추가 마이그레이션 작성
- 회원가입 프론트/백엔드 검증 및 관련 테스트 코드 수정

## 기대 동작

- 회원가입 시 연령 확인과 서비스 이용약관 동의가 필수로 동작한다
- 회원가입 화면에서 약관과 개인정보 수집 안내를 펼쳐 확인할 수 있다
- 개인정보처리방침은 새 탭에서 열어 확인할 수 있다
- 생년월일 입력 없이 결정된 동의/확인 정보만 저장된다

## 확인 내용

- 프론트 타입 체크 통과
- 백엔드 타입 체크 통과
- 회원가입 하단 여백 및 아코디언 UI 반영 확인
- 도커 DB 마이그레이션 시 아래 명령 사용
- `docker compose exec backend sh -lc "rm -rf dist && npm run build && npm run migration:run"`