### PR TITLE
feat: 랜딩 및 플레이 진입 통계 수집 기능 추가

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -8,6 +8,7 @@ import { sessionMiddleware } from "./config/session";
 import { redisClient } from "./config/redis";
 
 import authRouter from "./modules/auth/auth.router";
+import analyticsRouter from "./modules/analytics/analytics.router";
 import canvasRouter from "./modules/canvas/canvas.router";
 import loginBoardRouter from "./modules/login-board/login-board.router";
 import publicLandingRouter from "./modules/public-landing/public-landing.router";
@@ -85,6 +86,7 @@ export function createApp() {
   });
 
   app.use("/auth", authRouter);
+  app.use("/analytics", analyticsRouter);
   app.use("/canvas", canvasRouter);
   app.use("/public/login-board", loginBoardRouter);
   app.use("/public/landing", publicLandingRouter);

--- a/backend/src/database/data-source.ts
+++ b/backend/src/database/data-source.ts
@@ -13,6 +13,7 @@ import { GameSummary } from "../entities/game-summary.entity";
 import { GamePreview } from "../entities/game-preview.entity";
 import { RoundSummary } from "../entities/round-summary.entity";
 import { RoundSnapshot } from "../entities/round-snapshot.entity";
+import { VisitEvent } from "../entities/visit-event.entity";
 
 loadEnvironment();
 
@@ -42,6 +43,7 @@ export const AppDataSource = new DataSource({
     GamePreview,
     RoundSummary,
     RoundSnapshot,
+    VisitEvent,
   ],
   migrations: [path.join(__dirname, "migrations/*.{js,ts}")],
 });

--- a/backend/src/database/migrations/1784400000000-AddVisitEvent.ts
+++ b/backend/src/database/migrations/1784400000000-AddVisitEvent.ts
@@ -1,0 +1,34 @@
+import type { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddVisitEvent1784400000000 implements MigrationInterface {
+  name = "AddVisitEvent1784400000000";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE "visit_event" (
+        "id" SERIAL NOT NULL,
+        "event_type" character varying(32) NOT NULL,
+        "browser_language" character varying(32) NOT NULL,
+        "time_zone" character varying(64) NOT NULL,
+        "device_type" character varying(16) NOT NULL,
+        "entered_at" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+        CONSTRAINT "PK_visit_event_id" PRIMARY KEY ("id")
+      )
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX "IDX_visit_event_type_entered_at"
+      ON "visit_event" ("event_type", "entered_at")
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      DROP INDEX "public"."IDX_visit_event_type_entered_at"
+    `);
+
+    await queryRunner.query(`
+      DROP TABLE "visit_event"
+    `);
+  }
+}

--- a/backend/src/entities/visit-event.entity.ts
+++ b/backend/src/entities/visit-event.entity.ts
@@ -1,0 +1,35 @@
+import { Column, CreateDateColumn, Entity, Index, PrimaryGeneratedColumn } from "typeorm";
+
+export enum VisitEventType {
+  SITE_VISIT = "site_visit",
+  GAME_ENTRY = "game_entry",
+}
+
+export enum VisitDeviceType {
+  DESKTOP = "desktop",
+  MOBILE = "mobile",
+  TABLET = "tablet",
+  OTHER = "other",
+}
+
+@Entity("visit_event")
+@Index("IDX_visit_event_type_entered_at", ["eventType", "enteredAt"])
+export class VisitEvent {
+  @PrimaryGeneratedColumn()
+  id!: number;
+
+  @Column({ type: "varchar", length: 32, name: "event_type" })
+  eventType!: VisitEventType;
+
+  @Column({ type: "varchar", length: 32, name: "browser_language" })
+  browserLanguage!: string;
+
+  @Column({ type: "varchar", length: 64, name: "time_zone" })
+  timeZone!: string;
+
+  @Column({ type: "varchar", length: 16, name: "device_type" })
+  deviceType!: VisitDeviceType;
+
+  @CreateDateColumn({ type: "timestamptz", name: "entered_at" })
+  enteredAt!: Date;
+}

--- a/backend/src/modules/analytics/analytics.controller.ts
+++ b/backend/src/modules/analytics/analytics.controller.ts
@@ -1,0 +1,24 @@
+import { Request, Response } from "express";
+import { analyticsService } from "./analytics.service";
+import { validateTrackVisitEventInput } from "./analytics.validation";
+
+export const analyticsController = {
+  async trackVisitEvent(req: Request, res: Response) {
+    const body =
+      req.body && typeof req.body === "object"
+        ? (req.body as Record<string, unknown>)
+        : {};
+
+    const { error, value } = validateTrackVisitEventInput(body);
+
+    if (error || !value) {
+      return res.status(400).json({
+        message: error ?? "ANALYTICS_INVALID_REQUEST",
+      });
+    }
+
+    await analyticsService.trackVisitEvent(value);
+
+    return res.status(201).json({ message: "TRACK_VISIT_EVENT_SUCCESS" });
+  },
+};

--- a/backend/src/modules/analytics/analytics.router.ts
+++ b/backend/src/modules/analytics/analytics.router.ts
@@ -1,0 +1,15 @@
+import { Router } from "express";
+import { createRateLimitMiddleware } from "../../middlewares/rate-limit.middleware";
+import { analyticsController } from "./analytics.controller";
+
+const router = Router();
+
+const analyticsRateLimit = createRateLimitMiddleware({
+  windowMs: 1000 * 60,
+  max: 120,
+  message: "TOO_MANY_ANALYTICS_REQUESTS",
+});
+
+router.post("/events", analyticsRateLimit, analyticsController.trackVisitEvent);
+
+export default router;

--- a/backend/src/modules/analytics/analytics.service.ts
+++ b/backend/src/modules/analytics/analytics.service.ts
@@ -1,0 +1,18 @@
+import { AppDataSource } from "../../database/data-source";
+import { VisitEvent } from "../../entities/visit-event.entity";
+import type { TrackVisitEventInput } from "./analytics.validation";
+
+const visitEventRepository = AppDataSource.getRepository(VisitEvent);
+
+export const analyticsService = {
+  async trackVisitEvent(input: TrackVisitEventInput) {
+    const event = visitEventRepository.create({
+      eventType: input.eventType,
+      browserLanguage: input.browserLanguage,
+      timeZone: input.timeZone,
+      deviceType: input.deviceType,
+    });
+
+    return visitEventRepository.save(event);
+  },
+};

--- a/backend/src/modules/analytics/analytics.validation.ts
+++ b/backend/src/modules/analytics/analytics.validation.ts
@@ -1,0 +1,80 @@
+import { VisitDeviceType, VisitEventType } from "../../entities/visit-event.entity";
+
+export const ANALYTICS_ERROR_MESSAGES = {
+  INVALID_EVENT_TYPE: "ANALYTICS_INVALID_EVENT_TYPE",
+  INVALID_BROWSER_LANGUAGE: "ANALYTICS_INVALID_BROWSER_LANGUAGE",
+  INVALID_TIME_ZONE: "ANALYTICS_INVALID_TIME_ZONE",
+  INVALID_DEVICE_TYPE: "ANALYTICS_INVALID_DEVICE_TYPE",
+} as const;
+
+const BROWSER_LANGUAGE_REGEX = /^[A-Za-z]{2,3}(?:-[A-Za-z0-9]{2,8})*$/;
+const TIME_ZONE_REGEX = /^[A-Za-z_+-]+(?:\/[A-Za-z0-9_\-+]+)*$/;
+
+const ALLOWED_EVENT_TYPES = new Set<string>(Object.values(VisitEventType));
+const ALLOWED_DEVICE_TYPES = new Set<string>(Object.values(VisitDeviceType));
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+export interface TrackVisitEventInput {
+  eventType: VisitEventType;
+  browserLanguage: string;
+  timeZone: string;
+  deviceType: VisitDeviceType;
+}
+
+export function validateTrackVisitEventInput(
+  input: Record<string, unknown>,
+): { error: string | null; value: TrackVisitEventInput | null } {
+  const eventType = input["eventType"];
+  const browserLanguage = input["browserLanguage"];
+  const timeZone = input["timeZone"];
+  const deviceType = input["deviceType"];
+
+  if (!isNonEmptyString(eventType) || !ALLOWED_EVENT_TYPES.has(eventType)) {
+    return {
+      error: ANALYTICS_ERROR_MESSAGES.INVALID_EVENT_TYPE,
+      value: null,
+    };
+  }
+
+  if (
+    !isNonEmptyString(browserLanguage) ||
+    browserLanguage.length > 32 ||
+    !BROWSER_LANGUAGE_REGEX.test(browserLanguage)
+  ) {
+    return {
+      error: ANALYTICS_ERROR_MESSAGES.INVALID_BROWSER_LANGUAGE,
+      value: null,
+    };
+  }
+
+  if (
+    !isNonEmptyString(timeZone) ||
+    timeZone.length > 64 ||
+    !TIME_ZONE_REGEX.test(timeZone)
+  ) {
+    return {
+      error: ANALYTICS_ERROR_MESSAGES.INVALID_TIME_ZONE,
+      value: null,
+    };
+  }
+
+  if (!isNonEmptyString(deviceType) || !ALLOWED_DEVICE_TYPES.has(deviceType)) {
+    return {
+      error: ANALYTICS_ERROR_MESSAGES.INVALID_DEVICE_TYPE,
+      value: null,
+    };
+  }
+
+  return {
+    error: null,
+    value: {
+      eventType: eventType as VisitEventType,
+      browserLanguage: browserLanguage.trim(),
+      timeZone: timeZone.trim(),
+      deviceType: deviceType as VisitDeviceType,
+    },
+  };
+}

--- a/backend/test/integration/analytics.integration.test.ts
+++ b/backend/test/integration/analytics.integration.test.ts
@@ -1,0 +1,47 @@
+import { AppDataSource } from "../../src/database/data-source";
+import {
+  VisitDeviceType,
+  VisitEvent,
+  VisitEventType,
+} from "../../src/entities/visit-event.entity";
+import { setupIntegrationSuite } from "./helpers/setup-integration-suite";
+
+describe("analytics integration", () => {
+  const suite = setupIntegrationSuite();
+  const visitEventRepository = AppDataSource.getRepository(VisitEvent);
+
+  it("stores a site visit event", async () => {
+    const response = await suite.request().post("/analytics/events").send({
+      eventType: "site_visit",
+      browserLanguage: "ko-KR",
+      timeZone: "Asia/Seoul",
+      deviceType: "desktop",
+    });
+
+    expect(response.status).toBe(201);
+    expect(response.body).toEqual({ message: "TRACK_VISIT_EVENT_SUCCESS" });
+
+    const event = await visitEventRepository.findOneByOrFail({
+      eventType: VisitEventType.SITE_VISIT,
+    });
+
+    expect(event.browserLanguage).toBe("ko-KR");
+    expect(event.timeZone).toBe("Asia/Seoul");
+    expect(event.deviceType).toBe(VisitDeviceType.DESKTOP);
+    expect(event.enteredAt).toBeInstanceOf(Date);
+  });
+
+  it("rejects an invalid analytics event", async () => {
+    const response = await suite.request().post("/analytics/events").send({
+      eventType: "login_page_view",
+      browserLanguage: "ko-KR",
+      timeZone: "Asia/Seoul",
+      deviceType: "desktop",
+    });
+
+    expect(response.status).toBe(400);
+    expect(response.body).toEqual({
+      message: "ANALYTICS_INVALID_EVENT_TYPE",
+    });
+  });
+});

--- a/frontend/src/features/analytics/api/analytics.api.ts
+++ b/frontend/src/features/analytics/api/analytics.api.ts
@@ -1,0 +1,16 @@
+import api from "@/shared/api/client";
+
+export type VisitEventType = "site_visit" | "game_entry";
+export type VisitDeviceType = "desktop" | "mobile" | "tablet" | "other";
+
+export interface TrackVisitEventRequest {
+  eventType: VisitEventType;
+  browserLanguage: string;
+  timeZone: string;
+  deviceType: VisitDeviceType;
+}
+
+export const analyticsApi = {
+  trackVisitEvent: (data: TrackVisitEventRequest) =>
+    api.post<{ message: string }>("/analytics/events", data),
+};

--- a/frontend/src/features/analytics/hooks/use-track-visit-event.ts
+++ b/frontend/src/features/analytics/hooks/use-track-visit-event.ts
@@ -1,0 +1,30 @@
+import { useEffect } from "react";
+import { useLocation } from "react-router-dom";
+import { analyticsApi, type VisitEventType } from "../api/analytics.api";
+import { buildVisitEventPayload } from "../model/visit-event";
+
+function buildPageViewStorageKey(eventType: VisitEventType, locationKey: string) {
+  return `votedots:analytics:${eventType}:${locationKey}`;
+}
+
+export function useTrackVisitEvent(eventType: VisitEventType) {
+  const location = useLocation();
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    const storageKey = buildPageViewStorageKey(eventType, location.key);
+
+    if (window.sessionStorage.getItem(storageKey) === "sent") {
+      return;
+    }
+
+    window.sessionStorage.setItem(storageKey, "sent");
+
+    void analyticsApi.trackVisitEvent(buildVisitEventPayload(eventType)).catch(() => {
+      window.sessionStorage.removeItem(storageKey);
+    });
+  }, [eventType, location.key]);
+}

--- a/frontend/src/features/analytics/model/visit-event.ts
+++ b/frontend/src/features/analytics/model/visit-event.ts
@@ -1,0 +1,51 @@
+import type {
+  TrackVisitEventRequest,
+  VisitDeviceType,
+  VisitEventType,
+} from "../api/analytics.api";
+
+function resolveDeviceType(userAgent: string): VisitDeviceType {
+  const normalizedUserAgent = userAgent.toLowerCase();
+
+  if (/ipad|tablet|playbook|silk/.test(normalizedUserAgent)) {
+    return "tablet";
+  }
+
+  if (/mobi|iphone|ipod|android/.test(normalizedUserAgent)) {
+    return "mobile";
+  }
+
+  if (
+    normalizedUserAgent.includes("windows") ||
+    normalizedUserAgent.includes("macintosh") ||
+    normalizedUserAgent.includes("linux")
+  ) {
+    return "desktop";
+  }
+
+  return "other";
+}
+
+export function buildVisitEventPayload(
+  eventType: VisitEventType,
+): TrackVisitEventRequest {
+  const browserLanguage =
+    typeof navigator !== "undefined" && navigator.language
+      ? navigator.language
+      : "en";
+  const timeZone =
+    typeof Intl !== "undefined"
+      ? Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC"
+      : "UTC";
+  const userAgent =
+    typeof navigator !== "undefined" && navigator.userAgent
+      ? navigator.userAgent
+      : "";
+
+  return {
+    eventType,
+    browserLanguage,
+    timeZone,
+    deviceType: resolveDeviceType(userAgent),
+  };
+}

--- a/frontend/src/pages/canvas/CanvasPage.tsx
+++ b/frontend/src/pages/canvas/CanvasPage.tsx
@@ -8,6 +8,7 @@ import {
   useState,
 } from "react";
 import { useNavigate } from "react-router-dom";
+import { useTrackVisitEvent } from "@/features/analytics/hooks/use-track-visit-event";
 import { authApi } from "@/features/auth";
 import {
   CanvasStage,
@@ -91,6 +92,7 @@ export default function CanvasPage() {
   const { t } = useI18n();
 
   usePageRootClass("page-shell-root");
+  useTrackVisitEvent("game_entry");
   const [currentVoterUuid, setCurrentVoterUuid] = useState<string | null>(null);
   const [selectionGuideState, dispatchSelectionGuide] = useReducer(
     selectionGuideReducer,

--- a/frontend/src/pages/landing/LandingPage.tsx
+++ b/frontend/src/pages/landing/LandingPage.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import { Link } from "react-router-dom";
+import { useTrackVisitEvent } from "@/features/analytics/hooks/use-track-visit-event";
 import { authApi } from "@/features/auth";
 import { landingApi } from "@/features/landing/api/landing.api";
 import FeaturedPreviewSection from "@/features/landing/components/FeaturedPreviewSection";
@@ -93,6 +94,7 @@ export default function LandingPage({ locale }: LandingPageProps) {
   usePageRootClass("page-shell-root");
   usePublicSiteLocale(locale);
   useAdsenseScript();
+  useTrackVisitEvent("site_visit");
 
   useEffect(() => {
     let cancelled = false;


### PR DESCRIPTION
## 관련 이슈
- Close #392 

## 변경 내용

- `/analytics/events` 엔드포인트와 `visit_event` 저장 구조를 추가했습니다.
- `/ko`, `/en` 랜딩 진입 시 `site_visit`, `/play` 진입 시 `game_entry` 이벤트를 전송하도록 연결했습니다.
- 저장 항목은 `eventType`, `browserLanguage`, `timeZone`, `deviceType`, `enteredAt`로 제한했고, `voterId`, IP, raw user-agent는 저장하지 않도록 했습니다.
- 잘못된 `eventType`, `deviceType`, `timeZone`에 대해 400 검증을 추가했습니다.
- 같은 페이지뷰에서 중복 적재되지 않도록 `location.key + sessionStorage` 기준으로 전송을 1회로 제한했습니다.

## 기대 동작

- `/ko`, `/en` 진입 시 `site_visit` 이벤트가 1회 저장됩니다.
- `/play` 진입 시 `game_entry` 이벤트가 1회 저장됩니다.
- 잘못된 `eventType`, `deviceType`, `timeZone` 요청은 400으로 거절됩니다.
- 개발 모드 StrictMode나 같은 페이지뷰 재마운트로 중복 적재되지 않습니다.

## 확인 내용

- 프론트 타입 체크 통과
- 백엔드 타입 체크 통과
- 잘못된 `eventType` 전송 시 `400 / ANALYTICS_INVALID_EVENT_TYPE` 확인
- 잘못된 `deviceType` 전송 시 `400 / ANALYTICS_INVALID_DEVICE_TYPE` 확인
- 잘못된 `timeZone` 전송 시 `400 / ANALYTICS_INVALID_TIME_ZONE` 확인
- 마이그레이션 명령
- `docker compose exec backend sh -lc "rm -rf dist && npm run build && npm run migration:run"`