### PR TITLE
feat: 통계 원본 보관 배치와 일별 집계 구조를 추가

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -14,6 +14,8 @@
     "test:infra:down": "docker compose -f ../docker-compose.test.yml down -v",
     "test:integration": "vitest run test/integration",
     "test:coverage": "vitest run --coverage",
+    "analytics:rollup": "ts-node src/scripts/analytics-rollup.ts",
+    "analytics:cleanup": "ts-node src/scripts/analytics-cleanup.ts",
     "migration:generate": "ts-node --require tsconfig-paths/register ./node_modules/typeorm/cli.js migration:generate -d src/database/data-source.ts",
     "migration:run": "node ./node_modules/typeorm/cli.js migration:run -d dist/database/data-source.js",
     "migration:revert": "ts-node --require tsconfig-paths/register ./node_modules/typeorm/cli.js migration:revert -d src/database/data-source.ts"

--- a/backend/src/database/data-source.ts
+++ b/backend/src/database/data-source.ts
@@ -14,6 +14,7 @@ import { GamePreview } from "../entities/game-preview.entity";
 import { RoundSummary } from "../entities/round-summary.entity";
 import { RoundSnapshot } from "../entities/round-snapshot.entity";
 import { VisitEvent } from "../entities/visit-event.entity";
+import { VisitEventDailyAggregate } from "../entities/visit-event-daily-aggregate.entity";
 
 loadEnvironment();
 
@@ -44,6 +45,7 @@ export const AppDataSource = new DataSource({
     RoundSummary,
     RoundSnapshot,
     VisitEvent,
+    VisitEventDailyAggregate,
   ],
   migrations: [path.join(__dirname, "migrations/*.{js,ts}")],
 });

--- a/backend/src/database/migrations/1784500000000-AddVisitEventDailyAggregate.ts
+++ b/backend/src/database/migrations/1784500000000-AddVisitEventDailyAggregate.ts
@@ -1,0 +1,54 @@
+import type { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddVisitEventDailyAggregate1784500000000
+  implements MigrationInterface
+{
+  name = "AddVisitEventDailyAggregate1784500000000";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE "visit_event_daily_aggregate" (
+        "id" SERIAL NOT NULL,
+        "bucket_date" DATE NOT NULL,
+        "event_type" character varying(32) NOT NULL,
+        "browser_language" character varying(32) NOT NULL,
+        "time_zone" character varying(64) NOT NULL,
+        "device_type" character varying(16) NOT NULL,
+        "event_count" integer NOT NULL,
+        "created_at" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+        "updated_at" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+        CONSTRAINT "PK_visit_event_daily_aggregate_id" PRIMARY KEY ("id")
+      )
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX "IDX_visit_event_daily_aggregate_bucket_event"
+      ON "visit_event_daily_aggregate" ("bucket_date", "event_type")
+    `);
+
+    await queryRunner.query(`
+      CREATE UNIQUE INDEX "UQ_visit_event_daily_aggregate_bucket_dimensions"
+      ON "visit_event_daily_aggregate" (
+        "bucket_date",
+        "event_type",
+        "browser_language",
+        "time_zone",
+        "device_type"
+      )
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      DROP INDEX "public"."UQ_visit_event_daily_aggregate_bucket_dimensions"
+    `);
+
+    await queryRunner.query(`
+      DROP INDEX "public"."IDX_visit_event_daily_aggregate_bucket_event"
+    `);
+
+    await queryRunner.query(`
+      DROP TABLE "visit_event_daily_aggregate"
+    `);
+  }
+}

--- a/backend/src/database/migrations/1784510000000-AddVisitEventRolledUpAt.ts
+++ b/backend/src/database/migrations/1784510000000-AddVisitEventRolledUpAt.ts
@@ -1,0 +1,28 @@
+import type { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddVisitEventRolledUpAt1784510000000 implements MigrationInterface {
+  name = "AddVisitEventRolledUpAt1784510000000";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "visit_event"
+      ADD COLUMN "rolled_up_at" TIMESTAMP WITH TIME ZONE
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX "IDX_visit_event_rolled_up_at_entered_at"
+      ON "visit_event" ("rolled_up_at", "entered_at")
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      DROP INDEX "public"."IDX_visit_event_rolled_up_at_entered_at"
+    `);
+
+    await queryRunner.query(`
+      ALTER TABLE "visit_event"
+      DROP COLUMN "rolled_up_at"
+    `);
+  }
+}

--- a/backend/src/entities/visit-event-daily-aggregate.entity.ts
+++ b/backend/src/entities/visit-event-daily-aggregate.entity.ts
@@ -1,0 +1,45 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from "typeorm";
+import { VisitDeviceType, VisitEventType } from "./visit-event.entity";
+
+@Entity("visit_event_daily_aggregate")
+@Index("IDX_visit_event_daily_aggregate_bucket_event", ["bucketDate", "eventType"])
+@Index(
+  "UQ_visit_event_daily_aggregate_bucket_dimensions",
+  ["bucketDate", "eventType", "browserLanguage", "timeZone", "deviceType"],
+  { unique: true },
+)
+export class VisitEventDailyAggregate {
+  @PrimaryGeneratedColumn()
+  id!: number;
+
+  @Column({ type: "date", name: "bucket_date" })
+  bucketDate!: string;
+
+  @Column({ type: "varchar", length: 32, name: "event_type" })
+  eventType!: VisitEventType;
+
+  @Column({ type: "varchar", length: 32, name: "browser_language" })
+  browserLanguage!: string;
+
+  @Column({ type: "varchar", length: 64, name: "time_zone" })
+  timeZone!: string;
+
+  @Column({ type: "varchar", length: 16, name: "device_type" })
+  deviceType!: VisitDeviceType;
+
+  @Column({ type: "integer", name: "event_count" })
+  eventCount!: number;
+
+  @CreateDateColumn({ type: "timestamptz", name: "created_at" })
+  createdAt!: Date;
+
+  @UpdateDateColumn({ type: "timestamptz", name: "updated_at" })
+  updatedAt!: Date;
+}

--- a/backend/src/entities/visit-event.entity.ts
+++ b/backend/src/entities/visit-event.entity.ts
@@ -14,6 +14,7 @@ export enum VisitDeviceType {
 
 @Entity("visit_event")
 @Index("IDX_visit_event_type_entered_at", ["eventType", "enteredAt"])
+@Index("IDX_visit_event_rolled_up_at_entered_at", ["rolledUpAt", "enteredAt"])
 export class VisitEvent {
   @PrimaryGeneratedColumn()
   id!: number;
@@ -32,4 +33,7 @@ export class VisitEvent {
 
   @CreateDateColumn({ type: "timestamptz", name: "entered_at" })
   enteredAt!: Date;
+
+  @Column({ type: "timestamptz", name: "rolled_up_at", nullable: true })
+  rolledUpAt!: Date | null;
 }

--- a/backend/src/modules/analytics/analytics-retention.service.ts
+++ b/backend/src/modules/analytics/analytics-retention.service.ts
@@ -1,0 +1,314 @@
+import { AppDataSource } from "../../database/data-source";
+import { VisitEvent } from "../../entities/visit-event.entity";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const KST_OFFSET_MS = 9 * 60 * 60 * 1000;
+const ROLLUP_TIME_ZONE = "Asia/Seoul";
+
+export interface AnalyticsRollupOptions {
+  apply: boolean;
+  before?: Date;
+}
+
+export interface AnalyticsCleanupOptions {
+  apply: boolean;
+  before?: Date;
+  retentionDays: number;
+}
+
+export interface AnalyticsRetentionEventCount {
+  count: number;
+  eventType: string;
+}
+
+export interface AnalyticsRollupSummary {
+  aggregateGroupCount: number;
+  applied: boolean;
+  eventCounts: AnalyticsRetentionEventCount[];
+  eligibleEventCount: number;
+  markedEventCount: number;
+  oldestEligibleEnteredAt: string | null;
+  rolledUpGroupCount: number;
+  upperBoundIso: string;
+}
+
+export interface AnalyticsCleanupSummary {
+  applied: boolean;
+  cutoffIso: string;
+  deletableEventCount: number;
+  deletedCount: number;
+  eventCounts: AnalyticsRetentionEventCount[];
+  oldestDeletableEnteredAt: string | null;
+  pendingUnrolledEventCount: number;
+}
+
+interface RollupPreviewRow {
+  aggregateGroupCount: string;
+  eligibleEventCount: string;
+  oldestEligibleEnteredAt: Date | null;
+}
+
+interface CleanupPreviewRow {
+  deletableEventCount: string;
+  oldestDeletableEnteredAt: Date | null;
+  pendingUnrolledEventCount: string;
+}
+
+interface EventCountRow {
+  count: string;
+  eventType: string;
+}
+
+function resolveRollupUpperBound(before?: Date): Date {
+  if (before) {
+    return before;
+  }
+
+  const now = Date.now();
+  const kstNow = now + KST_OFFSET_MS;
+  const startOfKstDay = Math.floor(kstNow / DAY_MS) * DAY_MS;
+  return new Date(startOfKstDay - KST_OFFSET_MS);
+}
+
+function resolveCleanupCutoff(options: Pick<AnalyticsCleanupOptions, "before" | "retentionDays">): Date {
+  if (options.before) {
+    return options.before;
+  }
+
+  return new Date(Date.now() - options.retentionDays * DAY_MS);
+}
+
+async function loadEventCounts(
+  whereClause: string,
+  parameters: unknown[],
+): Promise<AnalyticsRetentionEventCount[]> {
+  const rows = (await AppDataSource.query(
+    `
+      SELECT event_type AS "eventType", COUNT(*)::int AS "count"
+      FROM visit_event
+      WHERE ${whereClause}
+      GROUP BY event_type
+      ORDER BY event_type ASC
+    `,
+    parameters,
+  )) as EventCountRow[];
+
+  return rows.map((row) => ({
+    eventType: row.eventType,
+    count: Number(row.count),
+  }));
+}
+
+async function loadRollupPreview(upperBound: Date): Promise<{
+  aggregateGroupCount: number;
+  eligibleEventCount: number;
+  eventCounts: AnalyticsRetentionEventCount[];
+  oldestEligibleEnteredAt: string | null;
+}> {
+  const [previewRow] = (await AppDataSource.query(
+    `
+      SELECT
+        COUNT(*)::int AS "eligibleEventCount",
+        COALESCE(
+          (
+            SELECT COUNT(*)::int
+            FROM (
+              SELECT 1
+              FROM visit_event
+              WHERE rolled_up_at IS NULL
+                AND entered_at < $1
+              GROUP BY
+                DATE(entered_at AT TIME ZONE '${ROLLUP_TIME_ZONE}'),
+                event_type,
+                browser_language,
+                time_zone,
+                device_type
+            ) grouped_events
+          ),
+          0
+        ) AS "aggregateGroupCount",
+        MIN(entered_at) AS "oldestEligibleEnteredAt"
+      FROM visit_event
+      WHERE rolled_up_at IS NULL
+        AND entered_at < $1
+    `,
+    [upperBound.toISOString()],
+  )) as RollupPreviewRow[];
+
+  const eventCounts = await loadEventCounts(
+    "rolled_up_at IS NULL AND entered_at < $1",
+    [upperBound.toISOString()],
+  );
+
+  return {
+    aggregateGroupCount: Number(previewRow?.aggregateGroupCount ?? 0),
+    eligibleEventCount: Number(previewRow?.eligibleEventCount ?? 0),
+    eventCounts,
+    oldestEligibleEnteredAt: previewRow?.oldestEligibleEnteredAt
+      ? new Date(previewRow.oldestEligibleEnteredAt).toISOString()
+      : null,
+  };
+}
+
+async function loadCleanupPreview(cutoff: Date): Promise<{
+  deletableEventCount: number;
+  eventCounts: AnalyticsRetentionEventCount[];
+  oldestDeletableEnteredAt: string | null;
+  pendingUnrolledEventCount: number;
+}> {
+  const [previewRow] = (await AppDataSource.query(
+    `
+      SELECT
+        COUNT(*) FILTER (
+          WHERE rolled_up_at IS NOT NULL AND entered_at < $1
+        )::int AS "deletableEventCount",
+        COUNT(*) FILTER (
+          WHERE rolled_up_at IS NULL AND entered_at < $1
+        )::int AS "pendingUnrolledEventCount",
+        MIN(entered_at) FILTER (
+          WHERE rolled_up_at IS NOT NULL AND entered_at < $1
+        ) AS "oldestDeletableEnteredAt"
+      FROM visit_event
+    `,
+    [cutoff.toISOString()],
+  )) as CleanupPreviewRow[];
+
+  const eventCounts = await loadEventCounts(
+    "rolled_up_at IS NOT NULL AND entered_at < $1",
+    [cutoff.toISOString()],
+  );
+
+  return {
+    deletableEventCount: Number(previewRow?.deletableEventCount ?? 0),
+    eventCounts,
+    oldestDeletableEnteredAt: previewRow?.oldestDeletableEnteredAt
+      ? new Date(previewRow.oldestDeletableEnteredAt).toISOString()
+      : null,
+    pendingUnrolledEventCount: Number(
+      previewRow?.pendingUnrolledEventCount ?? 0,
+    ),
+  };
+}
+
+export const analyticsRetentionService = {
+  async rollupVisitEvents(
+    options: AnalyticsRollupOptions,
+  ): Promise<AnalyticsRollupSummary> {
+    const upperBound = resolveRollupUpperBound(options.before);
+    const preview = await loadRollupPreview(upperBound);
+
+    if (!options.apply || preview.eligibleEventCount === 0) {
+      return {
+        ...preview,
+        applied: false,
+        markedEventCount: 0,
+        rolledUpGroupCount: 0,
+        upperBoundIso: upperBound.toISOString(),
+      };
+    }
+
+    const queryRunner = AppDataSource.createQueryRunner();
+    await queryRunner.connect();
+    await queryRunner.startTransaction();
+
+    try {
+      const rolledUpRows = (await queryRunner.query(
+        `
+          INSERT INTO visit_event_daily_aggregate (
+            bucket_date,
+            event_type,
+            browser_language,
+            time_zone,
+            device_type,
+            event_count
+          )
+          SELECT
+            DATE(entered_at AT TIME ZONE '${ROLLUP_TIME_ZONE}') AS bucket_date,
+            event_type,
+            browser_language,
+            time_zone,
+            device_type,
+            COUNT(*)::int AS event_count
+          FROM visit_event
+          WHERE rolled_up_at IS NULL
+            AND entered_at < $1
+          GROUP BY
+            DATE(entered_at AT TIME ZONE '${ROLLUP_TIME_ZONE}'),
+            event_type,
+            browser_language,
+            time_zone,
+            device_type
+          ON CONFLICT (
+            bucket_date,
+            event_type,
+            browser_language,
+            time_zone,
+            device_type
+          )
+          DO UPDATE SET
+            event_count = visit_event_daily_aggregate.event_count + EXCLUDED.event_count,
+            updated_at = now()
+          RETURNING id
+        `,
+        [upperBound.toISOString()],
+      )) as Array<{ id: number }>;
+
+      const markResult = await queryRunner.manager
+        .createQueryBuilder()
+        .update(VisitEvent)
+        .set({
+          rolledUpAt: () => "now()",
+        })
+        .where("rolled_up_at IS NULL")
+        .andWhere("entered_at < :upperBound", {
+          upperBound: upperBound.toISOString(),
+        })
+        .execute();
+
+      await queryRunner.commitTransaction();
+
+      return {
+        ...preview,
+        applied: true,
+        markedEventCount: markResult.affected ?? 0,
+        rolledUpGroupCount: rolledUpRows.length,
+        upperBoundIso: upperBound.toISOString(),
+      };
+    } catch (error) {
+      await queryRunner.rollbackTransaction();
+      throw error;
+    } finally {
+      await queryRunner.release();
+    }
+  },
+
+  async cleanupVisitEvents(
+    options: AnalyticsCleanupOptions,
+  ): Promise<AnalyticsCleanupSummary> {
+    const cutoff = resolveCleanupCutoff(options);
+    const preview = await loadCleanupPreview(cutoff);
+
+    if (!options.apply || preview.deletableEventCount === 0) {
+      return {
+        ...preview,
+        applied: false,
+        cutoffIso: cutoff.toISOString(),
+        deletedCount: 0,
+      };
+    }
+
+    const deleteResult = await AppDataSource.createQueryBuilder()
+      .delete()
+      .from(VisitEvent)
+      .where("rolled_up_at IS NOT NULL")
+      .andWhere("entered_at < :cutoff", { cutoff: cutoff.toISOString() })
+      .execute();
+
+    return {
+      ...preview,
+      applied: true,
+      cutoffIso: cutoff.toISOString(),
+      deletedCount: deleteResult.affected ?? 0,
+    };
+  },
+};

--- a/backend/src/scripts/analytics-cleanup.ts
+++ b/backend/src/scripts/analytics-cleanup.ts
@@ -1,0 +1,116 @@
+import "reflect-metadata";
+import { loadEnvironment } from "../config/load-env";
+import { AppDataSource } from "../database/data-source";
+import { analyticsRetentionService } from "../modules/analytics/analytics-retention.service";
+
+interface AnalyticsCleanupCliOptions {
+  apply: boolean;
+  before?: Date;
+  retentionDays: number;
+}
+
+function parseBeforeDate(value: string): Date {
+  const parsed = new Date(value);
+
+  if (Number.isNaN(parsed.getTime())) {
+    throw new Error(`Invalid --before value: ${value}`);
+  }
+
+  return parsed;
+}
+
+function parseRetentionDays(value: string): number {
+  const parsed = Number(value);
+
+  if (!Number.isInteger(parsed) || parsed < 0) {
+    throw new Error(`Invalid --retention-days value: ${value}`);
+  }
+
+  return parsed;
+}
+
+function parseArgs(argv: string[]): AnalyticsCleanupCliOptions {
+  let apply = false;
+  let before: Date | undefined;
+  let retentionDays = 90;
+
+  for (const arg of argv) {
+    if (arg === "--apply") {
+      apply = true;
+      continue;
+    }
+
+    if (arg === "--dry-run") {
+      apply = false;
+      continue;
+    }
+
+    if (arg.startsWith("--before=")) {
+      before = parseBeforeDate(arg.slice("--before=".length));
+      continue;
+    }
+
+    if (arg.startsWith("--retention-days=")) {
+      retentionDays = parseRetentionDays(
+        arg.slice("--retention-days=".length),
+      );
+      continue;
+    }
+
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  return {
+    apply,
+    before,
+    retentionDays,
+  };
+}
+
+function printSummary(summary: Awaited<
+  ReturnType<typeof analyticsRetentionService.cleanupVisitEvents>
+>): void {
+  console.log("[analytics:cleanup] mode:", summary.applied ? "apply" : "dry-run");
+  console.log("[analytics:cleanup] cutoff:", summary.cutoffIso);
+  console.log("[analytics:cleanup] deletableEventCount:", summary.deletableEventCount);
+  console.log(
+    "[analytics:cleanup] pendingUnrolledEventCount:",
+    summary.pendingUnrolledEventCount,
+  );
+  console.log(
+    "[analytics:cleanup] oldestDeletableEnteredAt:",
+    summary.oldestDeletableEnteredAt ?? "none",
+  );
+
+  if (summary.eventCounts.length > 0) {
+    console.log("[analytics:cleanup] eventCounts:");
+
+    for (const eventCount of summary.eventCounts) {
+      console.log(`- ${eventCount.eventType}: ${eventCount.count}`);
+    }
+  }
+
+  console.log("[analytics:cleanup] deletedCount:", summary.deletedCount);
+}
+
+async function main() {
+  loadEnvironment();
+
+  const options = parseArgs(process.argv.slice(2));
+
+  await AppDataSource.initialize();
+
+  try {
+    const summary = await analyticsRetentionService.cleanupVisitEvents(options);
+    printSummary(summary);
+  } finally {
+    if (AppDataSource.isInitialized) {
+      await AppDataSource.destroy();
+    }
+  }
+}
+
+main().catch((error) => {
+  console.error("[analytics:cleanup] failed:", error);
+  process.exit(1);
+});

--- a/backend/src/scripts/analytics-rollup.ts
+++ b/backend/src/scripts/analytics-rollup.ts
@@ -1,0 +1,94 @@
+import "reflect-metadata";
+import { loadEnvironment } from "../config/load-env";
+import { AppDataSource } from "../database/data-source";
+import { analyticsRetentionService } from "../modules/analytics/analytics-retention.service";
+
+interface AnalyticsRollupCliOptions {
+  apply: boolean;
+  before?: Date;
+}
+
+function parseBeforeDate(value: string): Date {
+  const parsed = new Date(value);
+
+  if (Number.isNaN(parsed.getTime())) {
+    throw new Error(`Invalid --before value: ${value}`);
+  }
+
+  return parsed;
+}
+
+function parseArgs(argv: string[]): AnalyticsRollupCliOptions {
+  let apply = false;
+  let before: Date | undefined;
+
+  for (const arg of argv) {
+    if (arg === "--apply") {
+      apply = true;
+      continue;
+    }
+
+    if (arg === "--dry-run") {
+      apply = false;
+      continue;
+    }
+
+    if (arg.startsWith("--before=")) {
+      before = parseBeforeDate(arg.slice("--before=".length));
+      continue;
+    }
+
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  return {
+    apply,
+    before,
+  };
+}
+
+function printSummary(summary: Awaited<
+  ReturnType<typeof analyticsRetentionService.rollupVisitEvents>
+>): void {
+  console.log("[analytics:rollup] mode:", summary.applied ? "apply" : "dry-run");
+  console.log("[analytics:rollup] upperBound:", summary.upperBoundIso);
+  console.log("[analytics:rollup] eligibleEventCount:", summary.eligibleEventCount);
+  console.log("[analytics:rollup] aggregateGroupCount:", summary.aggregateGroupCount);
+  console.log(
+    "[analytics:rollup] oldestEligibleEnteredAt:",
+    summary.oldestEligibleEnteredAt ?? "none",
+  );
+
+  if (summary.eventCounts.length > 0) {
+    console.log("[analytics:rollup] eventCounts:");
+
+    for (const eventCount of summary.eventCounts) {
+      console.log(`- ${eventCount.eventType}: ${eventCount.count}`);
+    }
+  }
+
+  console.log("[analytics:rollup] rolledUpGroupCount:", summary.rolledUpGroupCount);
+  console.log("[analytics:rollup] markedEventCount:", summary.markedEventCount);
+}
+
+async function main() {
+  loadEnvironment();
+
+  const options = parseArgs(process.argv.slice(2));
+
+  await AppDataSource.initialize();
+
+  try {
+    const summary = await analyticsRetentionService.rollupVisitEvents(options);
+    printSummary(summary);
+  } finally {
+    if (AppDataSource.isInitialized) {
+      await AppDataSource.destroy();
+    }
+  }
+}
+
+main().catch((error) => {
+  console.error("[analytics:rollup] failed:", error);
+  process.exit(1);
+});

--- a/backend/test/integration/analytics-retention.integration.test.ts
+++ b/backend/test/integration/analytics-retention.integration.test.ts
@@ -1,0 +1,200 @@
+import { AppDataSource } from "../../src/database/data-source";
+import { VisitEventDailyAggregate } from "../../src/entities/visit-event-daily-aggregate.entity";
+import {
+  resetIntegrationState,
+} from "./helpers/integration-runtime";
+import {
+  VisitDeviceType,
+  VisitEvent,
+  VisitEventType,
+} from "../../src/entities/visit-event.entity";
+import { analyticsRetentionService } from "../../src/modules/analytics/analytics-retention.service";
+import { setupIntegrationSuite } from "./helpers/setup-integration-suite";
+
+describe("analytics retention integration", () => {
+  setupIntegrationSuite();
+
+  const visitEventRepository = AppDataSource.getRepository(VisitEvent);
+  const aggregateRepository = AppDataSource.getRepository(VisitEventDailyAggregate);
+
+  beforeEach(async () => {
+    await resetIntegrationState();
+  });
+
+  it("supports dry-run rollup without changing data", async () => {
+    const oldEvent = visitEventRepository.create({
+      eventType: VisitEventType.SITE_VISIT,
+      browserLanguage: "ko-KR",
+      timeZone: "Asia/Seoul",
+      deviceType: VisitDeviceType.DESKTOP,
+      enteredAt: new Date("2025-12-31T16:00:00.000Z"),
+    });
+
+    await visitEventRepository.save(oldEvent);
+
+    const summary = await analyticsRetentionService.rollupVisitEvents({
+      apply: false,
+      before: new Date("2026-02-01T00:00:00.000Z"),
+    });
+
+    expect(summary.applied).toBe(false);
+    expect(summary.eligibleEventCount).toBe(1);
+    expect(summary.aggregateGroupCount).toBe(1);
+    expect(summary.rolledUpGroupCount).toBe(0);
+    expect(summary.markedEventCount).toBe(0);
+
+    expect(await visitEventRepository.count()).toBe(1);
+    expect(await aggregateRepository.count()).toBe(0);
+  });
+
+  it("rolls up eligible raw events and marks them as rolled up", async () => {
+    await visitEventRepository.save([
+      visitEventRepository.create({
+        eventType: VisitEventType.SITE_VISIT,
+        browserLanguage: "ko-KR",
+        timeZone: "Asia/Seoul",
+        deviceType: VisitDeviceType.DESKTOP,
+        enteredAt: new Date("2025-12-31T16:30:00.000Z"),
+      }),
+      visitEventRepository.create({
+        eventType: VisitEventType.SITE_VISIT,
+        browserLanguage: "ko-KR",
+        timeZone: "Asia/Seoul",
+        deviceType: VisitDeviceType.DESKTOP,
+        enteredAt: new Date("2026-01-01T02:00:00.000Z"),
+      }),
+      visitEventRepository.create({
+        eventType: VisitEventType.GAME_ENTRY,
+        browserLanguage: "en-US",
+        timeZone: "UTC",
+        deviceType: VisitDeviceType.MOBILE,
+        enteredAt: new Date("2026-01-02T01:00:00.000Z"),
+      }),
+      visitEventRepository.create({
+        eventType: VisitEventType.GAME_ENTRY,
+        browserLanguage: "ko-KR",
+        timeZone: "Asia/Seoul",
+        deviceType: VisitDeviceType.DESKTOP,
+        enteredAt: new Date("2026-03-01T01:00:00.000Z"),
+      }),
+    ]);
+
+    const summary = await analyticsRetentionService.rollupVisitEvents({
+      apply: true,
+      before: new Date("2026-02-01T00:00:00.000Z"),
+    });
+
+    expect(summary.applied).toBe(true);
+    expect(summary.eligibleEventCount).toBe(3);
+    expect(summary.aggregateGroupCount).toBe(2);
+    expect(summary.rolledUpGroupCount).toBe(2);
+    expect(summary.markedEventCount).toBe(3);
+    expect(summary.eventCounts).toEqual([
+      { eventType: VisitEventType.GAME_ENTRY, count: 1 },
+      { eventType: VisitEventType.SITE_VISIT, count: 2 },
+    ]);
+
+    const events = await visitEventRepository.find({
+      order: { id: "ASC" },
+    });
+
+    expect(events).toHaveLength(4);
+    expect(events.slice(0, 3).every((event) => event.rolledUpAt instanceof Date)).toBe(
+      true,
+    );
+    expect(events[3]?.eventType).toBe(VisitEventType.GAME_ENTRY);
+    expect(events[3]?.browserLanguage).toBe("ko-KR");
+    expect(events[3]?.rolledUpAt).toBeNull();
+
+    const aggregateRows = await aggregateRepository.find({
+      order: {
+        bucketDate: "ASC",
+        eventType: "ASC",
+        browserLanguage: "ASC",
+      },
+    });
+
+    expect(aggregateRows).toHaveLength(2);
+    expect(aggregateRows[0]).toMatchObject({
+      bucketDate: "2026-01-01",
+      eventType: VisitEventType.SITE_VISIT,
+      browserLanguage: "ko-KR",
+      timeZone: "Asia/Seoul",
+      deviceType: VisitDeviceType.DESKTOP,
+      eventCount: 2,
+    });
+    expect(aggregateRows[1]).toMatchObject({
+      bucketDate: "2026-01-02",
+      eventType: VisitEventType.GAME_ENTRY,
+      browserLanguage: "en-US",
+      timeZone: "UTC",
+      deviceType: VisitDeviceType.MOBILE,
+      eventCount: 1,
+    });
+  });
+
+  it("deletes only rolled-up raw events that are older than the retention cutoff", async () => {
+    await visitEventRepository.save([
+      visitEventRepository.create({
+        eventType: VisitEventType.SITE_VISIT,
+        browserLanguage: "ko-KR",
+        timeZone: "Asia/Seoul",
+        deviceType: VisitDeviceType.DESKTOP,
+        enteredAt: new Date("2026-01-01T01:00:00.000Z"),
+        rolledUpAt: new Date("2026-01-02T00:00:00.000Z"),
+      }),
+      visitEventRepository.create({
+        eventType: VisitEventType.GAME_ENTRY,
+        browserLanguage: "en-US",
+        timeZone: "UTC",
+        deviceType: VisitDeviceType.MOBILE,
+        enteredAt: new Date("2026-01-02T01:00:00.000Z"),
+        rolledUpAt: null,
+      }),
+      visitEventRepository.create({
+        eventType: VisitEventType.GAME_ENTRY,
+        browserLanguage: "ko-KR",
+        timeZone: "Asia/Seoul",
+        deviceType: VisitDeviceType.DESKTOP,
+        enteredAt: new Date("2026-03-01T01:00:00.000Z"),
+        rolledUpAt: new Date("2026-03-02T00:00:00.000Z"),
+      }),
+    ]);
+
+    const summary = await analyticsRetentionService.cleanupVisitEvents({
+      apply: true,
+      before: new Date("2026-02-01T00:00:00.000Z"),
+      retentionDays: 90,
+    });
+
+    expect(summary.applied).toBe(true);
+    expect(summary.deletableEventCount).toBe(1);
+    expect(summary.pendingUnrolledEventCount).toBe(1);
+    expect(summary.deletedCount).toBe(1);
+    expect(summary.eventCounts).toEqual([
+      { eventType: VisitEventType.SITE_VISIT, count: 1 },
+    ]);
+
+    const remainingEvents = await visitEventRepository.find({
+      order: { id: "ASC" },
+    });
+
+    expect(remainingEvents).toHaveLength(2);
+    expect(
+      remainingEvents.some(
+        (event) =>
+          event.eventType === VisitEventType.GAME_ENTRY &&
+          event.browserLanguage === "en-US" &&
+          event.rolledUpAt === null,
+      ),
+    ).toBe(true);
+    expect(
+      remainingEvents.some(
+        (event) =>
+          event.eventType === VisitEventType.GAME_ENTRY &&
+          event.browserLanguage === "ko-KR" &&
+          event.rolledUpAt instanceof Date,
+      ),
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## 관련 이슈
- Close #392 

## 변경 내용

- `visit_event_daily_aggregate` 일별 집계 테이블을 추가했습니다.
- `visit_event`에 `rolled_up_at` 컬럼과 인덱스를 추가했습니다.
- `analytics:rollup` 명령을 추가했습니다.
  - raw 이벤트를 일별 집계 테이블에 적재합니다.
  - raw는 삭제하지 않고 `rolled_up_at`만 기록합니다.
- `analytics:cleanup` 명령을 추가했습니다.
  - `rolled_up_at IS NOT NULL` 이고 90일 지난 raw만 삭제합니다.
  - 아직 집계되지 않은 raw는 삭제하지 않습니다.
- 집계 키는 아래 기준으로 저장됩니다.
  - `bucketDate`
  - `eventType`
  - `browserLanguage`
  - `timeZone`
  - `deviceType`
- 수동 실행용 CLI와 관련 테스트 초안을 추가했습니다.

## 기대 동작

- raw 이벤트는 먼저 `visit_event`에 저장됩니다.
- `analytics:rollup` 실행 시 raw를 기준으로 일별 집계가 `visit_event_daily_aggregate`에 적재됩니다.
- 집계된 raw에는 `rolled_up_at`이 기록됩니다.
- `analytics:cleanup` 실행 시 90일 지난 rolled-up raw만 삭제됩니다.
- 집계되지 않은 raw는 삭제되지 않습니다.

## 확인 내용

- 백엔드 타입 체크 통과
- 수동 시나리오 검증 완료
  - old raw 이벤트가 일별 집계 테이블로 적재되는지 확인
  - 집계 후 raw에 `rolled_up_at`이 기록되는지 확인
  - cleanup 실행 시 rolled-up old raw만 삭제되는지 확인
  - recent raw는 그대로 남는지 확인

## 실행 명령어

```bash
### 마이그레이션
docker compose exec backend sh -lc "rm -rf dist && npm run build && npm run migration:run"

### 수동 집계 확인
docker compose exec backend sh -lc "npm run analytics:rollup -- --dry-run"

### 수동 집계 실행
docker compose exec backend sh -lc "npm run analytics:rollup -- --apply"

### 수동 삭제 확인
docker compose exec backend sh -lc "npm run analytics:cleanup -- --dry-run --retention-days=90"

### 수동 삭제 실행
docker compose exec backend sh -lc "npm run analytics:cleanup -- --apply --retention-days=90"

### 테스트용 강제 기준일 실행 예시
docker compose exec backend sh -lc "npm run analytics:rollup -- --apply --before=2099-01-01T00:00:00.000Z"
docker compose exec backend sh -lc "npm run analytics:cleanup -- --apply --before=2099-01-01T00:00:00.000Z --retention-days=90"
```

## 서버 크론 예시

```cron
# 매일 오전 3시 00분: 전날까지 raw 이벤트를 일별 집계로 적재
0 3 * * * cd /path/to/votedots && docker compose exec -T backend sh -lc "npm run analytics:rollup -- --apply"

# 매일 오전 3시 10분: 90일 지난 rolled-up raw 이벤트 삭제
10 3 * * * cd /path/to/votedots && docker compose exec -T backend sh -lc "npm run analytics:cleanup -- --apply --retention-days=90"


CRON_TZ=Asia/Seoul
0 3 * * * cd /path/to/votedots && /usr/bin/flock -n /tmp/votedots-analytics-rollup.lock /usr/bin/docker compose exec -T backend sh -lc "npm run analytics:rollup -- --apply" >> /var/log/votedots-analytics-rollup.log 2>&1
10 3 * * * cd /path/to/votedots && /usr/bin/flock -n /tmp/votedots-analytics-cleanup.lock /usr/bin/docker compose exec -T backend sh -lc "npm run analytics:cleanup -- --apply --retention-days=90" >> /var/log/votedots-analytics-cleanup.log 2>&1
```
<img width="653" height="708" alt="image" src="https://github.com/user-attachments/assets/83c8cb76-1882-4bdc-8e5c-a7051857c864" />