### PR TITLE
chore: develop 기준선에 main 변경과 최신 게임플레이 구조를 선형 반영

### DIFF
--- a/backend/src/modules/canvas/canvas.controller.ts
+++ b/backend/src/modules/canvas/canvas.controller.ts
@@ -13,6 +13,12 @@ interface CreateCanvasRequestBody {
   profileKey?: string;
 }
 
+type RoundVoteExtreme = {
+  roundId: number;
+  roundNumber: number;
+  voteCount: number;
+} | null;
+
 function serializeCanvas(canvas: Canvas) {
   return {
     id: canvas.id,
@@ -67,6 +73,7 @@ function buildRoundHighResolutionDownloadSnapshotUrl(
 function serializeGameSummary(
   summary: GameSummary,
   snapshotUrl: string | null,
+  quietestRound: RoundVoteExtreme,
   downloadSnapshotUrl: string | null,
   highResolutionDownloadSnapshotUrl: string | null,
 ) {
@@ -98,6 +105,9 @@ function serializeGameSummary(
     hottestRoundId: summary.hottestRoundId,
     hottestRoundNumber: summary.hottestRoundNumber,
     hottestRoundVoteCount: summary.hottestRoundVoteCount,
+    quietestRoundId: quietestRound?.roundId ?? null,
+    quietestRoundNumber: quietestRound?.roundNumber ?? null,
+    quietestRoundVoteCount: quietestRound?.voteCount ?? 0,
     topVoters: summary.topVotersJson,
     participants: summary.participantsJson,
     snapshotUrl,
@@ -190,9 +200,10 @@ export const canvasController = {
         return res.status(400).json({ message: "존재하지 않는 캔버스입니다." });
       }
 
-      const [summary, snapshot] = await Promise.all([
+      const [summary, snapshot, quietestRound] = await Promise.all([
         summaryService.getGameSummary(canvasId),
         roundSnapshotService.findLatestRoundSnapshot(canvasId),
+        summaryService.getQuietestRound(canvasId),
       ]);
 
       return res.json({
@@ -201,6 +212,7 @@ export const canvasController = {
           snapshot?.round?.id
             ? buildRoundSnapshotUrl(canvasId, snapshot.round.id)
             : null,
+          quietestRound,
           snapshot?.round?.id
             ? buildRoundDownloadSnapshotUrl(canvasId, snapshot.round.id)
             : null,

--- a/backend/src/modules/history/history.service.ts
+++ b/backend/src/modules/history/history.service.ts
@@ -4,12 +4,19 @@ import { GameSummary } from "../../entities/game-summary.entity";
 import { RoundSnapshot } from "../../entities/round-snapshot.entity";
 import { RoundSummary } from "../../entities/round-summary.entity";
 import { VoteRound } from "../../entities/vote-round.entity";
+import { summaryService } from "../summary/summary.service";
 
 const canvasRepository = AppDataSource.getRepository(Canvas);
 const gameSummaryRepository = AppDataSource.getRepository(GameSummary);
 const roundSummaryRepository = AppDataSource.getRepository(RoundSummary);
 const voteRoundRepository = AppDataSource.getRepository(VoteRound);
 const roundSnapshotRepository = AppDataSource.getRepository(RoundSnapshot);
+
+type RoundVoteExtreme = {
+  roundId: number;
+  roundNumber: number;
+  voteCount: number;
+} | null;
 
 function toRecord(value: unknown): Record<string, unknown> {
   if (value && typeof value === "object") {
@@ -357,6 +364,7 @@ function serializeGameSummary(
   rounds: VoteRound[],
   summary: GameSummary | null,
   snapshotUrl: string | null,
+  quietestRound: RoundVoteExtreme,
   downloadSnapshotUrl: string | null,
   highResolutionDownloadSnapshotUrl: string | null,
 ) {
@@ -397,6 +405,9 @@ function serializeGameSummary(
     hottestRoundId: summary?.hottestRoundId ?? null,
     hottestRoundNumber: summary?.hottestRoundNumber ?? null,
     hottestRoundVoteCount: summary?.hottestRoundVoteCount ?? 0,
+    quietestRoundId: quietestRound?.roundId ?? null,
+    quietestRoundNumber: quietestRound?.roundNumber ?? null,
+    quietestRoundVoteCount: quietestRound?.voteCount ?? 0,
     topVoters: summary?.topVotersJson ?? null,
     participants: summary?.participantsJson ?? null,
     snapshotUrl,
@@ -423,7 +434,8 @@ export const historyService = {
       return null;
     }
 
-    const [rounds, roundSummaries, snapshots, gameSummary] = await Promise.all([
+    const [rounds, roundSummaries, snapshots, gameSummary, quietestRound] =
+      await Promise.all([
       voteRoundRepository.find({
         where: {
           canvas: { id: canvasId },
@@ -453,17 +465,8 @@ export const historyService = {
         where: { canvas: { id: canvasId } },
         relations: ["canvas"],
       }),
+      summaryService.getQuietestRound(canvasId),
     ]);
-
-    const snapshotMap = new Map<string, RoundSnapshot>();
-
-    for (const snapshot of snapshots) {
-      const key = getRoundSnapshotKey(snapshot);
-
-      if (key) {
-        snapshotMap.set(key, snapshot);
-      }
-    }
 
     const roundMap = new Map<string, VoteRound>();
 
@@ -491,28 +494,24 @@ export const historyService = {
     }
 
     const historyRounds = snapshots.map((snapshot) => {
-        const round = getRoundForSnapshot(snapshot, roundMap);
-        const roundSummary = getRoundSummaryForSnapshot(
-          snapshot,
-          round,
-          roundSummaryMap,
-        );
-        const snapshotUrl = getRoundSnapshotUrl(canvasId, snapshot, roundMap);
+      const round = getRoundForSnapshot(snapshot, roundMap);
+      const roundSummary = getRoundSummaryForSnapshot(
+        snapshot,
+        round,
+        roundSummaryMap,
+      );
+      const snapshotUrl = getRoundSnapshotUrl(canvasId, snapshot, roundMap);
 
-        if (roundSummary) {
-          return serializeRoundSummary(roundSummary, round, snapshot, snapshotUrl);
-        }
+      if (roundSummary) {
+        return serializeRoundSummary(roundSummary, round, snapshot, snapshotUrl);
+      }
 
-        if (round) {
-          return serializeRoundSummaryFromRound(round, snapshot, snapshotUrl);
-        }
+      if (round) {
+        return serializeRoundSummaryFromRound(round, snapshot, snapshotUrl);
+      }
 
-        if (!round) {
-          return serializeRoundSummaryFromSnapshot(snapshot, snapshotUrl);
-        }
-
-        return serializeRoundSummaryFromSnapshot(snapshot, snapshotUrl);
-      });
+      return serializeRoundSummaryFromSnapshot(snapshot, snapshotUrl);
+    });
     const latestSnapshotUrl = getRoundSnapshotUrl(
       canvasId,
       snapshots[0] ?? null,
@@ -533,11 +532,12 @@ export const historyService = {
     return {
       rounds: historyRounds,
       gameSummary: getDateStringField(canvas, "endedAt")
-        ? serializeGameSummary(
+          ? serializeGameSummary(
             canvas,
             rounds,
             gameSummary,
             latestSnapshotUrl,
+            quietestRound,
             latestDownloadSnapshotUrl,
             latestHighResolutionDownloadSnapshotUrl,
           )

--- a/backend/src/modules/history/round-snapshot.service.ts
+++ b/backend/src/modules/history/round-snapshot.service.ts
@@ -103,7 +103,6 @@ export const roundSnapshotService = {
       },
     });
   },
-
   async getRoundSnapshot(
     canvasId: number,
     roundId: number,

--- a/backend/src/modules/summary/summary.service.ts
+++ b/backend/src/modules/summary/summary.service.ts
@@ -34,6 +34,18 @@ type TopVoterAggregate = {
   voteCount: number;
 };
 
+type RoundVoteExtreme = {
+  roundId: number;
+  roundNumber: number;
+  voteCount: number;
+} | null;
+
+type RoundVoteExtremeRow = {
+  roundId: number | string;
+  roundNumber: number | string;
+  voteCount: number | string;
+};
+
 function toPercent(numerator: number, denominator: number): string {
   if (denominator <= 0) {
     return "0.00";
@@ -149,6 +161,31 @@ export const summaryService = {
     }
 
     return summary;
+  },
+
+  async getQuietestRound(canvasId: number): Promise<RoundVoteExtreme> {
+    const row = await voteRoundRepository
+      .createQueryBuilder("round")
+      .leftJoin("round.votes", "vote")
+      .select("round.id", "roundId")
+      .addSelect("round.roundNumber", "roundNumber")
+      .addSelect("COUNT(vote.id)", "voteCount")
+      .where("round.canvas_id = :canvasId", { canvasId })
+      .groupBy("round.id")
+      .addGroupBy("round.roundNumber")
+      .orderBy("COUNT(vote.id)", "ASC")
+      .addOrderBy("round.roundNumber", "ASC")
+      .getRawOne<RoundVoteExtremeRow>();
+
+    if (!row) {
+      return null;
+    }
+
+    return {
+      roundId: Number(row.roundId),
+      roundNumber: Number(row.roundNumber),
+      voteCount: Number(row.voteCount),
+    };
   },
 
   async saveRoundSummary(

--- a/frontend/src/features/gameplay/canvas/components/MiniMap.tsx
+++ b/frontend/src/features/gameplay/canvas/components/MiniMap.tsx
@@ -8,6 +8,7 @@ const SELECTED_CELL_STROKE = "#f97316";
 const MINIMAP_STROKE_WIDTH = 2;
 
 interface Props {
+  cells: Cell[];
   snapshotUrl: string | null;
   playBackgroundImageUrl: string | null;
   resultTemplateImageUrl: string | null;
@@ -86,6 +87,7 @@ function getClampedMarkerRect(
 }
 
 export default function MiniMap({
+  cells,
   snapshotUrl,
   playBackgroundImageUrl,
   resultTemplateImageUrl,
@@ -123,6 +125,22 @@ export default function MiniMap({
 
     const cellWidth = canvas.width / Math.max(gridX, 1);
     const cellHeight = canvas.height / Math.max(gridY, 1);
+
+    if (!snapshotUrl && !playBackgroundImageUrl && !resultTemplateImageUrl) {
+      for (const cell of cells) {
+        if (!cell.color) {
+          continue;
+        }
+
+        ctx.fillStyle = cell.color;
+        ctx.fillRect(
+          cell.x * cellWidth,
+          cell.y * cellHeight,
+          Math.max(cellWidth, 1),
+          Math.max(cellHeight, 1),
+        );
+      }
+    }
 
     if (viewport) {
       const viewportRect = getClampedViewportRect(
@@ -213,10 +231,13 @@ export default function MiniMap({
       ctx.restore();
     }
   }, [
+    cells,
     gridX,
     gridY,
     minimapDimensions.width,
     minimapDimensions.height,
+    playBackgroundImageUrl,
+    resultTemplateImageUrl,
     selectedCell,
     snapshotUrl,
     viewport,

--- a/frontend/src/features/gameplay/intro/components/IntroGuideModal.tsx
+++ b/frontend/src/features/gameplay/intro/components/IntroGuideModal.tsx
@@ -246,6 +246,27 @@ export default function IntroGuideModal({
       return;
     }
 
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== "Escape") {
+        return;
+      }
+
+      event.preventDefault();
+      onClose();
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [onClose, open]);
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+
     const handleMouseMove = (event: MouseEvent) => {
       if (!isDraggingRef.current) {
         return;

--- a/frontend/src/features/gameplay/session/api/session.api.ts
+++ b/frontend/src/features/gameplay/session/api/session.api.ts
@@ -1,6 +1,6 @@
-import api from "@/shared/api/client";
 import type { Canvas } from "@/features/gameplay/canvas";
 import { voteApi } from "@/features/gameplay/vote/api/vote.api";
+import api from "@/shared/api/client";
 import type { GameConfig } from "@/shared/config/game-config";
 import type { GamePhase } from "../model/game-phase.types";
 
@@ -116,6 +116,9 @@ export interface GameSummaryData {
   hottestRoundId: number | null;
   hottestRoundNumber: number | null;
   hottestRoundVoteCount: number;
+  quietestRoundId: number | null;
+  quietestRoundNumber: number | null;
+  quietestRoundVoteCount: number;
   topVoters: GameSummaryTopVoter[] | null;
   participants: GameSummaryParticipant[] | null;
   snapshotUrl: string | null;

--- a/frontend/src/features/gameplay/vote/components/VotePanel.tsx
+++ b/frontend/src/features/gameplay/vote/components/VotePanel.tsx
@@ -287,6 +287,7 @@ export default function VotePanel({
 
       <div data-tutorial-id="tutorial-minimap" className="shrink-0">
         <MiniMap
+          cells={cells}
           snapshotUrl={latestRoundSnapshot}
           playBackgroundImageUrl={playBackgroundImageUrl}
           resultTemplateImageUrl={resultTemplateImageUrl}


### PR DESCRIPTION
## 변경 내용

- origin/main 기준 최신 변경을 develop 작업 기준선에 선형 반영
- 머지 커밋 없이 게임플레이 세션/요약/스냅샷 관련 충돌 내용을 정리
- 최신 프론트 구조에 맞춰 CanvasPage, VotePanel, GameSummary/RoundSummary, MiniMap 정합성 보정
- 백엔드 summary/history/canvas 응답에서 quietest round 및 snapshot download URL 필드 유지

## 기대 동작

- develop 기준선에서 최신 main 변경과 기존 게임플레이 요약 기능이 함께 동작한다
- 브랜치 보호 규칙에 맞게 merge commit 없는 PR로 develop에 반영할 수 있다
- 프론트 타입 체크와 백엔드 타입 체크가 통과하는 상태로 기준선이 정리된다

## 확인 내용

- frontend `tsc -b` 확인
- backend `tsc --noEmit` 확인
- frontend 전체 `vite build`는 현재 로컬 Node 21.7.3으로 인해 Vite 요구 버전 조건에서 중단됨
- backend `npm run build`는 dist 쓰기 권한 문제로 출력 단계까지는 확인하지 못함
