### PR TITLE
chore: restrict CI to develop pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,8 @@ name: CI
 
 on:
   pull_request:
+    branches:
+      - develop
 
 jobs:
   test-and-build:


### PR DESCRIPTION
## 관련 이슈
- Close #408 

## 변경 내용

- GitHub Actions CI 워크플로우를 모든 PR 대상에서 develop 대상 PR 전용으로 제한
- develop을 통합 검증 브랜치로 사용하는 현재 머지 정책에 맞춰 CI 실행 범위를 정리
- main push 기반 CD 워크플로우는 유지해 배포 전용 브랜치 역할을 그대로 보존

## 기대 동작

- 작업 브랜치에서 develop으로 향하는 PR에만 CI가 실행된다
- develop에서 main으로 향하는 반영 과정에서는 CI가 중복 실행되지 않는다
- main 반영 이후에는 CD만 실행된다

## 확인 내용

- feature 또는 chore 브랜치에서 develop 대상으로 PR 생성 시 CI 실행 여부 확인
- develop에서 main으로 향하는 PR에서 CI 미실행 여부 확인
- main push 시 CD만 실행되는지 확인