### PR TITLE
fix: 광장 current 조회와 비공개방 문구를 정리

### DIFF
--- a/backend/src/config/game.config.ts
+++ b/backend/src/config/game.config.ts
@@ -313,7 +313,7 @@ export function getCanvasGameConfigSnapshot(
 
 export function getGameConfigProfiles(): GameConfigProfileSummary[] {
   return getGameConfigProfileKeys()
-    .filter((key) => key !== "default")
+    .filter((key) => key !== "default" && key !== "test")
     .map((key) => ({
       key,
       snapshot: getGameConfigSnapshot(key),

--- a/backend/src/modules/canvas/canvas.controller.ts
+++ b/backend/src/modules/canvas/canvas.controller.ts
@@ -131,7 +131,7 @@ export const canvasController = {
 
   async getCurrent(req: Request, res: Response) {
     try {
-      const canvas = await canvasService.getCurrent();
+      const canvas = await canvasService.getCurrentPlaza();
       if (!canvas) {
         return res
           .status(404)
@@ -150,7 +150,7 @@ export const canvasController = {
 
   async getCurrentParticipantCount(_req: Request, res: Response) {
     try {
-      const result = await canvasService.getCurrentParticipantCount();
+      const result = await canvasService.getCurrentPlazaParticipantCount();
       return res.json({ count: result.count });
     } catch (err) {
       if (String(err).includes("진행 중인 캔버스가 없습니다.")) {
@@ -163,7 +163,7 @@ export const canvasController = {
 
   async getCurrentParticipantList(_req: Request, res: Response) {
     try {
-      const result = await canvasService.getCurrentParticipantList();
+      const result = await canvasService.getCurrentPlazaParticipantList();
       return res.json({
         participants: result.participants.map((participant) => ({
           sessionId: participant.sessionId,

--- a/backend/src/modules/canvas/canvas.service.ts
+++ b/backend/src/modules/canvas/canvas.service.ts
@@ -6,6 +6,7 @@ import {
 import { AppDataSource } from "../../database/data-source";
 import { Canvas, CanvasStatus } from "../../entities/canvas.entity";
 import { Cell, CellStatus } from "../../entities/cell.entity";
+import { RoomType } from "../../entities/room.entity";
 import { VoteRound } from "../../entities/vote-round.entity";
 import { GamePhase } from "../game/game-phase.types";
 import { startGameTimer } from "../game/game.timer";
@@ -37,6 +38,33 @@ interface GetChunkCellsParams {
   startChunkY: number;
   endChunkY: number;
   chunkSize?: number;
+}
+
+async function findCurrentPlazaCanvas(): Promise<Canvas | null> {
+  const currentCanvas = await canvasRepository
+    .createQueryBuilder("canvas")
+    .leftJoin("room", "room", "room.canvas_id = canvas.id")
+    .where("canvas.status = :status", { status: CanvasStatus.PLAYING })
+    .andWhere("(room.id IS NULL OR room.type = :plazaType)", {
+      plazaType: RoomType.PLAZA,
+    })
+    .orderBy("canvas.startedAt", "DESC")
+    .getOne();
+
+  if (currentCanvas) {
+    return currentCanvas;
+  }
+
+  return canvasRepository
+    .createQueryBuilder("canvas")
+    .leftJoin("room", "room", "room.canvas_id = canvas.id")
+    .where("canvas.status = :status", { status: CanvasStatus.FINISHED })
+    .andWhere("canvas.phase = :phase", { phase: GamePhase.GAME_END })
+    .andWhere("(room.id IS NULL OR room.type = :plazaType)", {
+      plazaType: RoomType.PLAZA,
+    })
+    .orderBy("canvas.phaseStartedAt", "DESC")
+    .getOne();
 }
 
 function logPhaseChange(params: {
@@ -137,6 +165,10 @@ export const canvasService = {
     });
   },
 
+  async getCurrentPlaza(): Promise<Canvas | null> {
+    return findCurrentPlazaCanvas();
+  },
+
   async getCurrentParticipantCount(): Promise<{
     canvasId: number;
     count: number;
@@ -157,6 +189,26 @@ export const canvasService = {
     };
   },
 
+  async getCurrentPlazaParticipantCount(): Promise<{
+    canvasId: number;
+    count: number;
+  }> {
+    const canvas = await this.getCurrentPlaza();
+
+    if (!canvas) {
+      throw new Error("No plaza canvas is currently in progress.");
+    }
+
+    const count = await participantSessionService.getParticipantCount(
+      canvas.id,
+    );
+
+    return {
+      canvasId: canvas.id,
+      count,
+    };
+  },
+
   async getCurrentParticipantList(): Promise<{
     canvasId: number;
     participants: ParticipantSummary[];
@@ -165,6 +217,26 @@ export const canvasService = {
 
     if (!canvas) {
       throw new Error("No canvas is currently in progress.");
+    }
+
+    const participants = await participantSessionService.getParticipantList(
+      canvas.id,
+    );
+
+    return {
+      canvasId: canvas.id,
+      participants,
+    };
+  },
+
+  async getCurrentPlazaParticipantList(): Promise<{
+    canvasId: number;
+    participants: ParticipantSummary[];
+  }> {
+    const canvas = await this.getCurrentPlaza();
+
+    if (!canvas) {
+      throw new Error("No plaza canvas is currently in progress.");
     }
 
     const participants = await participantSessionService.getParticipantList(

--- a/backend/src/modules/public-landing/public-landing.service.ts
+++ b/backend/src/modules/public-landing/public-landing.service.ts
@@ -197,7 +197,7 @@ async function getFeaturedSummary(
 
 export const publicLandingService = {
   async getLandingPayload(): Promise<PublicLandingPayload> {
-    const currentCanvas = await canvasService.getCurrent();
+    const currentCanvas = await canvasService.getCurrentPlaza();
 
     const [currentGame, featuredGames] = await Promise.all([
       this.getCurrentGame(currentCanvas),

--- a/frontend/src/shared/i18n/resources.ts
+++ b/frontend/src/shared/i18n/resources.ts
@@ -100,7 +100,7 @@ export const resources: Record<Locale, Record<string, string>> = {
     "lobby.error.roomNotFound": "존재하지 않는 방 번호입니다.",
     "lobby.error.activeLimitReached": "동시에 생성할 수 있는 방은 최대 2개입니다.",
     "lobby.error.accessCodeRequired": "입장 코드를 입력해 주세요.",
-    "lobby.error.privateCodePrompt": "프라이빗방은 입장 코드를 입력해야 합니다.",
+    "lobby.error.privateCodePrompt": "비공개방은 입장 코드를 입력해야 합니다.",
     "lobby.error.requestFailed": "요청을 처리하지 못했습니다.",
     "lobby.login.usernamePlaceholder": "아이디",
     "lobby.login.passwordPlaceholder": "비밀번호",
@@ -128,7 +128,7 @@ export const resources: Record<Locale, Record<string, string>> = {
     "lobby.roomList.detailLoading": "방 정보를 불러오는 중...",
     "lobby.roomList.owner": "내 방",
     "lobby.roomList.publicType": "공개방",
-    "lobby.roomList.privateType": "프라이빗방",
+    "lobby.roomList.privateType": "비공개방",
     "lobby.roomList.currentParticipants": "현재 {{count}}명",
     "lobby.roomList.status.active": "진행 중",
     "lobby.roomList.status.gameEndWait": "종료 대기",
@@ -140,7 +140,7 @@ export const resources: Record<Locale, Record<string, string>> = {
     "lobby.roomList.manage.votesPerRound": "라운드당 표수",
     "lobby.roomList.manage.gameEndWait": "게임 종료 대기",
     "lobby.roomList.manage.accessCode": "입장 코드",
-    "lobby.roomList.privateTitle": "프라이빗 방",
+    "lobby.roomList.privateTitle": "비공개방",
     "lobby.roomList.privateDescription": "입장 코드를 입력해주세요.",
     "lobby.roomList.privateAccessCodePlaceholder": "입장 코드 입력",
     "lobby.roomList.enter": "입장",
@@ -351,7 +351,7 @@ export const resources: Record<Locale, Record<string, string>> = {
     "lobby.roomCreate.close": "닫기",
     "lobby.roomCreate.create": "생성",
     "lobby.roomCreate.creating": "생성 중...",
-    "lobby.roomCreate.generatedCodeTitle": "프라이빗 방 입장 코드",
+    "lobby.roomCreate.generatedCodeTitle": "비공개방 입장 코드",
     "lobby.roomCreate.copyCode": "복사",
     "lobby.roomCreate.enterNow": "바로 입장",
     "lobby.roomCreate.noProfiles":
@@ -366,7 +366,7 @@ export const resources: Record<Locale, Record<string, string>> = {
     "lobby.roomCreate.titleHint": "방 제목은 최대 30자까지 입력할 수 있습니다.",
     "lobby.roomCreate.introHint": "인트로 시간은 최대 5분까지, 5초 단위로 설정할 수 있습니다.",
     "lobby.roomCreate.type.public": "공개방",
-    "lobby.roomCreate.type.private": "프라이빗방",
+    "lobby.roomCreate.type.private": "비공개방",
     "lobby.roomCreate.votesPerRoundHint": "투표 수는 최대 120표까지 설정할 수 있습니다.",
     "lobby.roomCreate.defaultPhaseInfoTitle": "기본 라운드 진행 시간",
     "lobby.roomCreate.phase.roundDuration": "라운드 진행 시간",
@@ -761,5 +761,4 @@ export const resources: Record<Locale, Record<string, string>> = {
     "loginBoard.patchType.breaking": "Breaking",
   },
 };
-
 


### PR DESCRIPTION
## 관련 이슈
- Close #431 

## 개요

로비/방 시스템 후속으로 광장 카드와 `/plaza` 진입이 최신 생성 방을 참조하던 문제를 정리하고, 방 생성 모달/로비 문구를 정리했습니다.

## 변경사항

- `프라이빗방` 표기를 `비공개방`으로 통일
- 방 생성 프로필 목록에서 `default`, `test` 제거
- 광장 current 조회를 사용자 생성 방과 분리
- 로비 광장 카드가 실제 광장 스냅샷만 보도록 수정
- `/plaza` 진입이 최신 생성 방이 아니라 실제 광장 canvas를 사용하도록 수정

## 확인 포인트

- 로비와 방 생성 모달에 `비공개방` 문구가 반영되는지
- 방 생성 모달에 `test` 프로필이 보이지 않는지
- 로비 광장 카드가 실제 광장 이미지를 보여주는지
- `/plaza` 진입 시 사용자 생성 방이 아니라 광장으로 들어가는지

## 검증

- backend 타입 체크 통과
- frontend 타입 체크 통과

