### PR TITLE
chore: develop에 main 반영

### DIFF
--- a/backend/src/config/game.config.ts
+++ b/backend/src/config/game.config.ts
@@ -313,7 +313,7 @@ export function getCanvasGameConfigSnapshot(
 
 export function getGameConfigProfiles(): GameConfigProfileSummary[] {
   return getGameConfigProfileKeys()
-    .filter((key) => key !== "default")
+    .filter((key) => key !== "default" && key !== "test")
     .map((key) => ({
       key,
       snapshot: getGameConfigSnapshot(key),

--- a/backend/src/modules/canvas/canvas.controller.ts
+++ b/backend/src/modules/canvas/canvas.controller.ts
@@ -131,7 +131,7 @@ export const canvasController = {
 
   async getCurrent(req: Request, res: Response) {
     try {
-      const canvas = await canvasService.getCurrent();
+      const canvas = await canvasService.getCurrentPlaza();
       if (!canvas) {
         return res
           .status(404)
@@ -150,7 +150,7 @@ export const canvasController = {
 
   async getCurrentParticipantCount(_req: Request, res: Response) {
     try {
-      const result = await canvasService.getCurrentParticipantCount();
+      const result = await canvasService.getCurrentPlazaParticipantCount();
       return res.json({ count: result.count });
     } catch (err) {
       if (String(err).includes("진행 중인 캔버스가 없습니다.")) {
@@ -163,7 +163,7 @@ export const canvasController = {
 
   async getCurrentParticipantList(_req: Request, res: Response) {
     try {
-      const result = await canvasService.getCurrentParticipantList();
+      const result = await canvasService.getCurrentPlazaParticipantList();
       return res.json({
         participants: result.participants.map((participant) => ({
           sessionId: participant.sessionId,

--- a/backend/src/modules/canvas/canvas.service.ts
+++ b/backend/src/modules/canvas/canvas.service.ts
@@ -6,6 +6,7 @@ import {
 import { AppDataSource } from "../../database/data-source";
 import { Canvas, CanvasStatus } from "../../entities/canvas.entity";
 import { Cell, CellStatus } from "../../entities/cell.entity";
+import { RoomType } from "../../entities/room.entity";
 import { VoteRound } from "../../entities/vote-round.entity";
 import { GamePhase } from "../game/game-phase.types";
 import { startGameTimer } from "../game/game.timer";
@@ -37,6 +38,33 @@ interface GetChunkCellsParams {
   startChunkY: number;
   endChunkY: number;
   chunkSize?: number;
+}
+
+async function findCurrentPlazaCanvas(): Promise<Canvas | null> {
+  const currentCanvas = await canvasRepository
+    .createQueryBuilder("canvas")
+    .leftJoin("room", "room", "room.canvas_id = canvas.id")
+    .where("canvas.status = :status", { status: CanvasStatus.PLAYING })
+    .andWhere("(room.id IS NULL OR room.type = :plazaType)", {
+      plazaType: RoomType.PLAZA,
+    })
+    .orderBy("canvas.startedAt", "DESC")
+    .getOne();
+
+  if (currentCanvas) {
+    return currentCanvas;
+  }
+
+  return canvasRepository
+    .createQueryBuilder("canvas")
+    .leftJoin("room", "room", "room.canvas_id = canvas.id")
+    .where("canvas.status = :status", { status: CanvasStatus.FINISHED })
+    .andWhere("canvas.phase = :phase", { phase: GamePhase.GAME_END })
+    .andWhere("(room.id IS NULL OR room.type = :plazaType)", {
+      plazaType: RoomType.PLAZA,
+    })
+    .orderBy("canvas.phaseStartedAt", "DESC")
+    .getOne();
 }
 
 function logPhaseChange(params: {
@@ -137,6 +165,10 @@ export const canvasService = {
     });
   },
 
+  async getCurrentPlaza(): Promise<Canvas | null> {
+    return findCurrentPlazaCanvas();
+  },
+
   async getCurrentParticipantCount(): Promise<{
     canvasId: number;
     count: number;
@@ -157,6 +189,26 @@ export const canvasService = {
     };
   },
 
+  async getCurrentPlazaParticipantCount(): Promise<{
+    canvasId: number;
+    count: number;
+  }> {
+    const canvas = await this.getCurrentPlaza();
+
+    if (!canvas) {
+      throw new Error("No plaza canvas is currently in progress.");
+    }
+
+    const count = await participantSessionService.getParticipantCount(
+      canvas.id,
+    );
+
+    return {
+      canvasId: canvas.id,
+      count,
+    };
+  },
+
   async getCurrentParticipantList(): Promise<{
     canvasId: number;
     participants: ParticipantSummary[];
@@ -165,6 +217,26 @@ export const canvasService = {
 
     if (!canvas) {
       throw new Error("No canvas is currently in progress.");
+    }
+
+    const participants = await participantSessionService.getParticipantList(
+      canvas.id,
+    );
+
+    return {
+      canvasId: canvas.id,
+      participants,
+    };
+  },
+
+  async getCurrentPlazaParticipantList(): Promise<{
+    canvasId: number;
+    participants: ParticipantSummary[];
+  }> {
+    const canvas = await this.getCurrentPlaza();
+
+    if (!canvas) {
+      throw new Error("No plaza canvas is currently in progress.");
     }
 
     const participants = await participantSessionService.getParticipantList(

--- a/backend/src/modules/public-landing/public-landing.service.ts
+++ b/backend/src/modules/public-landing/public-landing.service.ts
@@ -197,7 +197,7 @@ async function getFeaturedSummary(
 
 export const publicLandingService = {
   async getLandingPayload(): Promise<PublicLandingPayload> {
-    const currentCanvas = await canvasService.getCurrent();
+    const currentCanvas = await canvasService.getCurrentPlaza();
 
     const [currentGame, featuredGames] = await Promise.all([
       this.getCurrentGame(currentCanvas),

--- a/frontend/src/shared/i18n/resources.ts
+++ b/frontend/src/shared/i18n/resources.ts
@@ -100,7 +100,7 @@ export const resources: Record<Locale, Record<string, string>> = {
     "lobby.error.roomNotFound": "존재하지 않는 방 번호입니다.",
     "lobby.error.activeLimitReached": "동시에 생성할 수 있는 방은 최대 2개입니다.",
     "lobby.error.accessCodeRequired": "입장 코드를 입력해 주세요.",
-    "lobby.error.privateCodePrompt": "프라이빗방은 입장 코드를 입력해야 합니다.",
+    "lobby.error.privateCodePrompt": "비공개방은 입장 코드를 입력해야 합니다.",
     "lobby.error.requestFailed": "요청을 처리하지 못했습니다.",
     "lobby.login.usernamePlaceholder": "아이디",
     "lobby.login.passwordPlaceholder": "비밀번호",
@@ -128,7 +128,7 @@ export const resources: Record<Locale, Record<string, string>> = {
     "lobby.roomList.detailLoading": "방 정보를 불러오는 중...",
     "lobby.roomList.owner": "내 방",
     "lobby.roomList.publicType": "공개방",
-    "lobby.roomList.privateType": "프라이빗방",
+    "lobby.roomList.privateType": "비공개방",
     "lobby.roomList.currentParticipants": "현재 {{count}}명",
     "lobby.roomList.status.active": "진행 중",
     "lobby.roomList.status.gameEndWait": "종료 대기",
@@ -140,7 +140,7 @@ export const resources: Record<Locale, Record<string, string>> = {
     "lobby.roomList.manage.votesPerRound": "라운드당 표수",
     "lobby.roomList.manage.gameEndWait": "게임 종료 대기",
     "lobby.roomList.manage.accessCode": "입장 코드",
-    "lobby.roomList.privateTitle": "프라이빗 방",
+    "lobby.roomList.privateTitle": "비공개방",
     "lobby.roomList.privateDescription": "입장 코드를 입력해주세요.",
     "lobby.roomList.privateAccessCodePlaceholder": "입장 코드 입력",
     "lobby.roomList.enter": "입장",
@@ -351,7 +351,7 @@ export const resources: Record<Locale, Record<string, string>> = {
     "lobby.roomCreate.close": "닫기",
     "lobby.roomCreate.create": "생성",
     "lobby.roomCreate.creating": "생성 중...",
-    "lobby.roomCreate.generatedCodeTitle": "프라이빗 방 입장 코드",
+    "lobby.roomCreate.generatedCodeTitle": "비공개방 입장 코드",
     "lobby.roomCreate.copyCode": "복사",
     "lobby.roomCreate.enterNow": "바로 입장",
     "lobby.roomCreate.noProfiles":
@@ -366,7 +366,7 @@ export const resources: Record<Locale, Record<string, string>> = {
     "lobby.roomCreate.titleHint": "방 제목은 최대 30자까지 입력할 수 있습니다.",
     "lobby.roomCreate.introHint": "인트로 시간은 최대 5분까지, 5초 단위로 설정할 수 있습니다.",
     "lobby.roomCreate.type.public": "공개방",
-    "lobby.roomCreate.type.private": "프라이빗방",
+    "lobby.roomCreate.type.private": "비공개방",
     "lobby.roomCreate.votesPerRoundHint": "투표 수는 최대 120표까지 설정할 수 있습니다.",
     "lobby.roomCreate.defaultPhaseInfoTitle": "기본 라운드 진행 시간",
     "lobby.roomCreate.phase.roundDuration": "라운드 진행 시간",
@@ -761,5 +761,4 @@ export const resources: Record<Locale, Record<string, string>> = {
     "loginBoard.patchType.breaking": "Breaking",
   },
 };
-
 


### PR DESCRIPTION
* refactor: gameplay 세션 진입과 bootstrap 책임 분리 (#390)

* test: 테스트 설정 변경

* refactor: gameplay 세션 bootstrap 책임을 분리

* test: bootstrap 통합 테스트 기대값을 조정

* refactor: gameplay 세션 책임 분리와 phase/timer 동기화  (#391)

* refactor: participant 실시간 동기화 기준을 정리

* refactor: summary와 ticket 요청 가드를 분리

* refactor: phase 전환 이벤트를 서버에서 emit하도록 추가

* refactor: phase 전환과 active round 타이머를 서버 기준으로 정리

* refactor: gameplay summary orchestration을 페이지 레벨로 이동

* refactor: gameplay session 책임을 훅 단위로 분리

* refactor: non-active phase 타이머를 서버 기준으로 동기화

* fix: 네트워크 오류 메시지 번역을 추가

* chore: restrict CI to develop pull requests (#410)

* chore: AdSense 정적 삽입과 랜딩 반응형 레이아웃 조정 (#413)

* chore: update landing page adsense integration and layout

* chore: refine landing hero and current game responsiveness

* feat: 데일리 통계 집계 완료 후 Telegram 알림 전송 추가 (#416)

* feat: 데일리 통계 집계 완료 후 Telegram 알림 전송 추가

* feat: 데일리 통계 Telegram 상세 집계를 디바이스별로 확장

* Revert "feat: 데일리 통계 집계 완료 후 Telegram 알림 전송 추가 (#416)" (#417)

This reverts commit 146d8eadcb0d4e9520c91966133be373152458e5.

* feat: 데일리 통계 Telegram 알림 전송 재적용 (#418)

* feat: 데일리 통계 집계 완료 후 Telegram 알림 전송 추가

* feat: 데일리 통계 Telegram 상세 집계를 디바이스별로 확장

* chore: re-trigger CI

* develop에 main 반영 (#422)

* chore: develop 통합 CI와 main 배포 전용 CD 정책 반영 (#411)

* refactor: gameplay 세션 진입과 bootstrap 책임 분리 (#390)

* test: 테스트 설정 변경

* refactor: gameplay 세션 bootstrap 책임을 분리

* test: bootstrap 통합 테스트 기대값을 조정

* refactor: gameplay 세션 책임 분리와 phase/timer 동기화  (#391)

* refactor: participant 실시간 동기화 기준을 정리

* refactor: summary와 ticket 요청 가드를 분리

* refactor: phase 전환 이벤트를 서버에서 emit하도록 추가

* refactor: phase 전환과 active round 타이머를 서버 기준으로 정리

* refactor: gameplay summary orchestration을 페이지 레벨로 이동

* refactor: gameplay session 책임을 훅 단위로 분리

* refactor: non-active phase 타이머를 서버 기준으로 동기화

* fix: 네트워크 오류 메시지 번역을 추가

* chore: restrict CI to develop pull requests (#410)

---------



* chore: develop 누적 변경사항을 main에 반영 (#414)

* refactor: gameplay 세션 진입과 bootstrap 책임 분리 (#390)

* test: 테스트 설정 변경

* refactor: gameplay 세션 bootstrap 책임을 분리

* test: bootstrap 통합 테스트 기대값을 조정

* refactor: gameplay 세션 책임 분리와 phase/timer 동기화  (#391)

* refactor: participant 실시간 동기화 기준을 정리

* refactor: summary와 ticket 요청 가드를 분리

* refactor: phase 전환 이벤트를 서버에서 emit하도록 추가

* refactor: phase 전환과 active round 타이머를 서버 기준으로 정리

* refactor: gameplay summary orchestration을 페이지 레벨로 이동

* refactor: gameplay session 책임을 훅 단위로 분리

* refactor: non-active phase 타이머를 서버 기준으로 동기화

* fix: 네트워크 오류 메시지 번역을 추가

* chore: restrict CI to develop pull requests (#410)

* chore: AdSense 정적 삽입과 랜딩 반응형 레이아웃 조정 (#413)

* chore: update landing page adsense integration and layout

* chore: refine landing hero and current game responsiveness

---------



* chore: develop 변경사항을 main에 반영 (#419)

* refactor: gameplay 세션 진입과 bootstrap 책임 분리 (#390)

* test: 테스트 설정 변경

* refactor: gameplay 세션 bootstrap 책임을 분리

* test: bootstrap 통합 테스트 기대값을 조정

* refactor: gameplay 세션 책임 분리와 phase/timer 동기화  (#391)

* refactor: participant 실시간 동기화 기준을 정리

* refactor: summary와 ticket 요청 가드를 분리

* refactor: phase 전환 이벤트를 서버에서 emit하도록 추가

* refactor: phase 전환과 active round 타이머를 서버 기준으로 정리

* refactor: gameplay summary orchestration을 페이지 레벨로 이동

* refactor: gameplay session 책임을 훅 단위로 분리

* refactor: non-active phase 타이머를 서버 기준으로 동기화

* fix: 네트워크 오류 메시지 번역을 추가

* chore: restrict CI to develop pull requests (#410)

* chore: AdSense 정적 삽입과 랜딩 반응형 레이아웃 조정 (#413)

* chore: update landing page adsense integration and layout

* chore: refine landing hero and current game responsiveness

* feat: 데일리 통계 집계 완료 후 Telegram 알림 전송 추가 (#416)

* feat: 데일리 통계 집계 완료 후 Telegram 알림 전송 추가

* feat: 데일리 통계 Telegram 상세 집계를 디바이스별로 확장

* Revert "feat: 데일리 통계 집계 완료 후 Telegram 알림 전송 추가 (#416)" (#417)

This reverts commit 146d8eadcb0d4e9520c91966133be373152458e5.

* feat: 데일리 통계 Telegram 알림 전송 재적용 (#418)

* feat: 데일리 통계 집계 완료 후 Telegram 알림 전송 추가

* feat: 데일리 통계 Telegram 상세 집계를 디바이스별로 확장

* chore: re-trigger CI

---------



* fix: 라운드 60초로 변경 (#421)

---------



* feat: 로비와 room 기반 플레이 진입 구조를 추가 (#423)

* feat:

* feat: room 생성과 입장 API를 추가

* feat: 광장과 room 진입 구조를 분리

* chore: develop 통합 CI와 main 배포 전용 CD 정책 반영 (#411)

* refactor: gameplay 세션 진입과 bootstrap 책임 분리 (#390)

* test: 테스트 설정 변경

* refactor: gameplay 세션 bootstrap 책임을 분리

* test: bootstrap 통합 테스트 기대값을 조정

* refactor: gameplay 세션 책임 분리와 phase/timer 동기화  (#391)

* refactor: participant 실시간 동기화 기준을 정리

* refactor: summary와 ticket 요청 가드를 분리

* refactor: phase 전환 이벤트를 서버에서 emit하도록 추가

* refactor: phase 전환과 active round 타이머를 서버 기준으로 정리

* refactor: gameplay summary orchestration을 페이지 레벨로 이동

* refactor: gameplay session 책임을 훅 단위로 분리

* refactor: non-active phase 타이머를 서버 기준으로 동기화

* fix: 네트워크 오류 메시지 번역을 추가

* chore: restrict CI to develop pull requests (#410)

---------



* feat: 로비와 room 진입 흐름을 연결

* feat: room lifecycle와 생성 설정을 정리

* refactor: 게임 설정 정리

* fix: room 프로필 목록에서 default를 제외

* feat: room 종료 흐름과 로비 입장을 정리

* feat: connect lobby completed canvas tab

* refactor: organize lobby UI and translations

* style: 로비 우측 영역 레이아웃을 마무리

* chore: develop 누적 변경사항을 main에 반영 (#414)

* refactor: gameplay 세션 진입과 bootstrap 책임 분리 (#390)

* test: 테스트 설정 변경

* refactor: gameplay 세션 bootstrap 책임을 분리

* test: bootstrap 통합 테스트 기대값을 조정

* refactor: gameplay 세션 책임 분리와 phase/timer 동기화  (#391)

* refactor: participant 실시간 동기화 기준을 정리

* refactor: summary와 ticket 요청 가드를 분리

* refactor: phase 전환 이벤트를 서버에서 emit하도록 추가

* refactor: phase 전환과 active round 타이머를 서버 기준으로 정리

* refactor: gameplay summary orchestration을 페이지 레벨로 이동

* refactor: gameplay session 책임을 훅 단위로 분리

* refactor: non-active phase 타이머를 서버 기준으로 동기화

* fix: 네트워크 오류 메시지 번역을 추가

* chore: restrict CI to develop pull requests (#410)

* chore: AdSense 정적 삽입과 랜딩 반응형 레이아웃 조정 (#413)

* chore: update landing page adsense integration and layout

* chore: refine landing hero and current game responsiveness

---------



* chore: develop 변경사항을 main에 반영 (#419)

* refactor: gameplay 세션 진입과 bootstrap 책임 분리 (#390)

* test: 테스트 설정 변경

* refactor: gameplay 세션 bootstrap 책임을 분리

* test: bootstrap 통합 테스트 기대값을 조정

* refactor: gameplay 세션 책임 분리와 phase/timer 동기화  (#391)

* refactor: participant 실시간 동기화 기준을 정리

* refactor: summary와 ticket 요청 가드를 분리

* refactor: phase 전환 이벤트를 서버에서 emit하도록 추가

* refactor: phase 전환과 active round 타이머를 서버 기준으로 정리

* refactor: gameplay summary orchestration을 페이지 레벨로 이동

* refactor: gameplay session 책임을 훅 단위로 분리

* refactor: non-active phase 타이머를 서버 기준으로 동기화

* fix: 네트워크 오류 메시지 번역을 추가

* chore: restrict CI to develop pull requests (#410)

* chore: AdSense 정적 삽입과 랜딩 반응형 레이아웃 조정 (#413)

* chore: update landing page adsense integration and layout

* chore: refine landing hero and current game responsiveness

* feat: 데일리 통계 집계 완료 후 Telegram 알림 전송 추가 (#416)

* feat: 데일리 통계 집계 완료 후 Telegram 알림 전송 추가

* feat: 데일리 통계 Telegram 상세 집계를 디바이스별로 확장

* Revert "feat: 데일리 통계 집계 완료 후 Telegram 알림 전송 추가 (#416)" (#417)

This reverts commit 146d8eadcb0d4e9520c91966133be373152458e5.

* feat: 데일리 통계 Telegram 알림 전송 재적용 (#418)

* feat: 데일리 통계 집계 완료 후 Telegram 알림 전송 추가

* feat: 데일리 통계 Telegram 상세 집계를 디바이스별로 확장

* chore: re-trigger CI

---------



* fix: 라운드 60초로 변경 (#421)

* fix: 로비 방 상세와 방 생성 모달을 정리

* fix: 로비 완성된 캔버스와 방 목록 레이아웃을 조정

* fix: 방 입장 모달 다국어 문구를 적용

* fix: 방 입장 모달 문구와 방 번호 오류 메시지를 정리

* fix: 방 생성 모달의 effect 기반 상태 동기화를 제거

* test: 변경된 로비 진입 흐름에 맞게 통합 테스트를 수정

---------



* Merge branch 'main' into feat/common/407-lobby-and-room-system (#425)

* feat:

* feat: room 생성과 입장 API를 추가

* feat: 광장과 room 진입 구조를 분리

* chore: develop 통합 CI와 main 배포 전용 CD 정책 반영 (#411)

* refactor: gameplay 세션 진입과 bootstrap 책임 분리 (#390)

* test: 테스트 설정 변경

* refactor: gameplay 세션 bootstrap 책임을 분리

* test: bootstrap 통합 테스트 기대값을 조정

* refactor: gameplay 세션 책임 분리와 phase/timer 동기화  (#391)

* refactor: participant 실시간 동기화 기준을 정리

* refactor: summary와 ticket 요청 가드를 분리

* refactor: phase 전환 이벤트를 서버에서 emit하도록 추가

* refactor: phase 전환과 active round 타이머를 서버 기준으로 정리

* refactor: gameplay summary orchestration을 페이지 레벨로 이동

* refactor: gameplay session 책임을 훅 단위로 분리

* refactor: non-active phase 타이머를 서버 기준으로 동기화

* fix: 네트워크 오류 메시지 번역을 추가

* chore: restrict CI to develop pull requests (#410)

---------



* feat: 로비와 room 진입 흐름을 연결

* feat: room lifecycle와 생성 설정을 정리

* refactor: 게임 설정 정리

* fix: room 프로필 목록에서 default를 제외

* feat: room 종료 흐름과 로비 입장을 정리

* feat: connect lobby completed canvas tab

* refactor: organize lobby UI and translations

* style: 로비 우측 영역 레이아웃을 마무리

* chore: develop 누적 변경사항을 main에 반영 (#414)

* refactor: gameplay 세션 진입과 bootstrap 책임 분리 (#390)

* test: 테스트 설정 변경

* refactor: gameplay 세션 bootstrap 책임을 분리

* test: bootstrap 통합 테스트 기대값을 조정

* refactor: gameplay 세션 책임 분리와 phase/timer 동기화  (#391)

* refactor: participant 실시간 동기화 기준을 정리

* refactor: summary와 ticket 요청 가드를 분리

* refactor: phase 전환 이벤트를 서버에서 emit하도록 추가

* refactor: phase 전환과 active round 타이머를 서버 기준으로 정리

* refactor: gameplay summary orchestration을 페이지 레벨로 이동

* refactor: gameplay session 책임을 훅 단위로 분리

* refactor: non-active phase 타이머를 서버 기준으로 동기화

* fix: 네트워크 오류 메시지 번역을 추가

* chore: restrict CI to develop pull requests (#410)

* chore: AdSense 정적 삽입과 랜딩 반응형 레이아웃 조정 (#413)

* chore: update landing page adsense integration and layout

* chore: refine landing hero and current game responsiveness

---------



* chore: develop 변경사항을 main에 반영 (#419)

* refactor: gameplay 세션 진입과 bootstrap 책임 분리 (#390)

* test: 테스트 설정 변경

* refactor: gameplay 세션 bootstrap 책임을 분리

* test: bootstrap 통합 테스트 기대값을 조정

* refactor: gameplay 세션 책임 분리와 phase/timer 동기화  (#391)

* refactor: participant 실시간 동기화 기준을 정리

* refactor: summary와 ticket 요청 가드를 분리

* refactor: phase 전환 이벤트를 서버에서 emit하도록 추가

* refactor: phase 전환과 active round 타이머를 서버 기준으로 정리

* refactor: gameplay summary orchestration을 페이지 레벨로 이동

* refactor: gameplay session 책임을 훅 단위로 분리

* refactor: non-active phase 타이머를 서버 기준으로 동기화

* fix: 네트워크 오류 메시지 번역을 추가

* chore: restrict CI to develop pull requests (#410)

* chore: AdSense 정적 삽입과 랜딩 반응형 레이아웃 조정 (#413)

* chore: update landing page adsense integration and layout

* chore: refine landing hero and current game responsiveness

* feat: 데일리 통계 집계 완료 후 Telegram 알림 전송 추가 (#416)

* feat: 데일리 통계 집계 완료 후 Telegram 알림 전송 추가

* feat: 데일리 통계 Telegram 상세 집계를 디바이스별로 확장

* Revert "feat: 데일리 통계 집계 완료 후 Telegram 알림 전송 추가 (#416)" (#417)

This reverts commit 146d8eadcb0d4e9520c91966133be373152458e5.

* feat: 데일리 통계 Telegram 알림 전송 재적용 (#418)

* feat: 데일리 통계 집계 완료 후 Telegram 알림 전송 추가

* feat: 데일리 통계 Telegram 상세 집계를 디바이스별로 확장

* chore: re-trigger CI

---------



* fix: 라운드 60초로 변경 (#421)

* fix: 로비 방 상세와 방 생성 모달을 정리

* fix: 로비 완성된 캔버스와 방 목록 레이아웃을 조정

* fix: 방 입장 모달 다국어 문구를 적용

* fix: 방 입장 모달 문구와 방 번호 오류 메시지를 정리

* fix: 방 생성 모달의 effect 기반 상태 동기화를 제거

* test: 변경된 로비 진입 흐름에 맞게 통합 테스트를 수정

---------



* chore: main 랜딩 충돌 정리 (#426)

* chore: develop 통합 CI와 main 배포 전용 CD 정책 반영 (#411)

* refactor: gameplay 세션 진입과 bootstrap 책임 분리 (#390)

* test: 테스트 설정 변경

* refactor: gameplay 세션 bootstrap 책임을 분리

* test: bootstrap 통합 테스트 기대값을 조정

* refactor: gameplay 세션 책임 분리와 phase/timer 동기화  (#391)

* refactor: participant 실시간 동기화 기준을 정리

* refactor: summary와 ticket 요청 가드를 분리

* refactor: phase 전환 이벤트를 서버에서 emit하도록 추가

* refactor: phase 전환과 active round 타이머를 서버 기준으로 정리

* refactor: gameplay summary orchestration을 페이지 레벨로 이동

* refactor: gameplay session 책임을 훅 단위로 분리

* refactor: non-active phase 타이머를 서버 기준으로 동기화

* fix: 네트워크 오류 메시지 번역을 추가

* chore: restrict CI to develop pull requests (#410)

---------



* chore: develop 누적 변경사항을 main에 반영 (#414)

* refactor: gameplay 세션 진입과 bootstrap 책임 분리 (#390)

* test: 테스트 설정 변경

* refactor: gameplay 세션 bootstrap 책임을 분리

* test: bootstrap 통합 테스트 기대값을 조정

* refactor: gameplay 세션 책임 분리와 phase/timer 동기화  (#391)

* refactor: participant 실시간 동기화 기준을 정리

* refactor: summary와 ticket 요청 가드를 분리

* refactor: phase 전환 이벤트를 서버에서 emit하도록 추가

* refactor: phase 전환과 active round 타이머를 서버 기준으로 정리

* refactor: gameplay summary orchestration을 페이지 레벨로 이동

* refactor: gameplay session 책임을 훅 단위로 분리

* refactor: non-active phase 타이머를 서버 기준으로 동기화

* fix: 네트워크 오류 메시지 번역을 추가

* chore: restrict CI to develop pull requests (#410)

* chore: AdSense 정적 삽입과 랜딩 반응형 레이아웃 조정 (#413)

* chore: update landing page adsense integration and layout

* chore: refine landing hero and current game responsiveness

---------



* chore: develop 변경사항을 main에 반영 (#419)

* refactor: gameplay 세션 진입과 bootstrap 책임 분리 (#390)

* test: 테스트 설정 변경

* refactor: gameplay 세션 bootstrap 책임을 분리

* test: bootstrap 통합 테스트 기대값을 조정

* refactor: gameplay 세션 책임 분리와 phase/timer 동기화  (#391)

* refactor: participant 실시간 동기화 기준을 정리

* refactor: summary와 ticket 요청 가드를 분리

* refactor: phase 전환 이벤트를 서버에서 emit하도록 추가

* refactor: phase 전환과 active round 타이머를 서버 기준으로 정리

* refactor: gameplay summary orchestration을 페이지 레벨로 이동

* refactor: gameplay session 책임을 훅 단위로 분리

* refactor: non-active phase 타이머를 서버 기준으로 동기화

* fix: 네트워크 오류 메시지 번역을 추가

* chore: restrict CI to develop pull requests (#410)

* chore: AdSense 정적 삽입과 랜딩 반응형 레이아웃 조정 (#413)

* chore: update landing page adsense integration and layout

* chore: refine landing hero and current game responsiveness

* feat: 데일리 통계 집계 완료 후 Telegram 알림 전송 추가 (#416)

* feat: 데일리 통계 집계 완료 후 Telegram 알림 전송 추가

* feat: 데일리 통계 Telegram 상세 집계를 디바이스별로 확장

* Revert "feat: 데일리 통계 집계 완료 후 Telegram 알림 전송 추가 (#416)" (#417)

This reverts commit 146d8eadcb0d4e9520c91966133be373152458e5.

* feat: 데일리 통계 Telegram 알림 전송 재적용 (#418)

* feat: 데일리 통계 집계 완료 후 Telegram 알림 전송 추가

* feat: 데일리 통계 Telegram 상세 집계를 디바이스별로 확장

* chore: re-trigger CI

---------



* fix: 라운드 60초로 변경 (#421)

---------



* chore: develop에 main 반영 (#430)

* chore: develop 통합 CI와 main 배포 전용 CD 정책 반영 (#411)

* refactor: gameplay 세션 진입과 bootstrap 책임 분리 (#390)

* test: 테스트 설정 변경

* refactor: gameplay 세션 bootstrap 책임을 분리

* test: bootstrap 통합 테스트 기대값을 조정

* refactor: gameplay 세션 책임 분리와 phase/timer 동기화  (#391)

* refactor: participant 실시간 동기화 기준을 정리

* refactor: summary와 ticket 요청 가드를 분리

* refactor: phase 전환 이벤트를 서버에서 emit하도록 추가

* refactor: phase 전환과 active round 타이머를 서버 기준으로 정리

* refactor: gameplay summary orchestration을 페이지 레벨로 이동

* refactor: gameplay session 책임을 훅 단위로 분리

* refactor: non-active phase 타이머를 서버 기준으로 동기화

* fix: 네트워크 오류 메시지 번역을 추가

* chore: restrict CI to develop pull requests (#410)

---------



* chore: develop 누적 변경사항을 main에 반영 (#414)

* refactor: gameplay 세션 진입과 bootstrap 책임 분리 (#390)

* test: 테스트 설정 변경

* refactor: gameplay 세션 bootstrap 책임을 분리

* test: bootstrap 통합 테스트 기대값을 조정

* refactor: gameplay 세션 책임 분리와 phase/timer 동기화  (#391)

* refactor: participant 실시간 동기화 기준을 정리

* refactor: summary와 ticket 요청 가드를 분리

* refactor: phase 전환 이벤트를 서버에서 emit하도록 추가

* refactor: phase 전환과 active round 타이머를 서버 기준으로 정리

* refactor: gameplay summary orchestration을 페이지 레벨로 이동

* refactor: gameplay session 책임을 훅 단위로 분리

* refactor: non-active phase 타이머를 서버 기준으로 동기화

* fix: 네트워크 오류 메시지 번역을 추가

* chore: restrict CI to develop pull requests (#410)

* chore: AdSense 정적 삽입과 랜딩 반응형 레이아웃 조정 (#413)

* chore: update landing page adsense integration and layout

* chore: refine landing hero and current game responsiveness

---------



* chore: develop 변경사항을 main에 반영 (#419)

* refactor: gameplay 세션 진입과 bootstrap 책임 분리 (#390)

* test: 테스트 설정 변경

* refactor: gameplay 세션 bootstrap 책임을 분리

* test: bootstrap 통합 테스트 기대값을 조정

* refactor: gameplay 세션 책임 분리와 phase/timer 동기화  (#391)

* refactor: participant 실시간 동기화 기준을 정리

* refactor: summary와 ticket 요청 가드를 분리

* refactor: phase 전환 이벤트를 서버에서 emit하도록 추가

* refactor: phase 전환과 active round 타이머를 서버 기준으로 정리

* refactor: gameplay summary orchestration을 페이지 레벨로 이동

* refactor: gameplay session 책임을 훅 단위로 분리

* refactor: non-active phase 타이머를 서버 기준으로 동기화

* fix: 네트워크 오류 메시지 번역을 추가

* chore: restrict CI to develop pull requests (#410)

* chore: AdSense 정적 삽입과 랜딩 반응형 레이아웃 조정 (#413)

* chore: update landing page adsense integration and layout

* chore: refine landing hero and current game responsiveness

* feat: 데일리 통계 집계 완료 후 Telegram 알림 전송 추가 (#416)

* feat: 데일리 통계 집계 완료 후 Telegram 알림 전송 추가

* feat: 데일리 통계 Telegram 상세 집계를 디바이스별로 확장

* Revert "feat: 데일리 통계 집계 완료 후 Telegram 알림 전송 추가 (#416)" (#417)

This reverts commit 146d8eadcb0d4e9520c91966133be373152458e5.

* feat: 데일리 통계 Telegram 알림 전송 재적용 (#418)

* feat: 데일리 통계 집계 완료 후 Telegram 알림 전송 추가

* feat: 데일리 통계 Telegram 상세 집계를 디바이스별로 확장

* chore: re-trigger CI

---------



* fix: 라운드 60초로 변경 (#421)

* chore: main 랜딩 충돌 정리 (#429)

* refactor: gameplay 세션 진입과 bootstrap 책임 분리 (#390)

* test: 테스트 설정 변경

* refactor: gameplay 세션 bootstrap 책임을 분리

* test: bootstrap 통합 테스트 기대값을 조정

* refactor: gameplay 세션 책임 분리와 phase/timer 동기화  (#391)

* refactor: participant 실시간 동기화 기준을 정리

* refactor: summary와 ticket 요청 가드를 분리

* refactor: phase 전환 이벤트를 서버에서 emit하도록 추가

* refactor: phase 전환과 active round 타이머를 서버 기준으로 정리

* refactor: gameplay summary orchestration을 페이지 레벨로 이동

* refactor: gameplay session 책임을 훅 단위로 분리

* refactor: non-active phase 타이머를 서버 기준으로 동기화

* fix: 네트워크 오류 메시지 번역을 추가

* chore: restrict CI to develop pull requests (#410)

* chore: AdSense 정적 삽입과 랜딩 반응형 레이아웃 조정 (#413)

* chore: update landing page adsense integration and layout

* chore: refine landing hero and current game responsiveness

* feat: 데일리 통계 집계 완료 후 Telegram 알림 전송 추가 (#416)

* feat: 데일리 통계 집계 완료 후 Telegram 알림 전송 추가

* feat: 데일리 통계 Telegram 상세 집계를 디바이스별로 확장

* Revert "feat: 데일리 통계 집계 완료 후 Telegram 알림 전송 추가 (#416)" (#417)

This reverts commit 146d8eadcb0d4e9520c91966133be373152458e5.

* feat: 데일리 통계 Telegram 알림 전송 재적용 (#418)

* feat: 데일리 통계 집계 완료 후 Telegram 알림 전송 추가

* feat: 데일리 통계 Telegram 상세 집계를 디바이스별로 확장

* chore: re-trigger CI

* develop에 main 반영 (#422)

* chore: develop 통합 CI와 main 배포 전용 CD 정책 반영 (#411)

* refactor: gameplay 세션 진입과 bootstrap 책임 분리 (#390)

* test: 테스트 설정 변경

* refactor: gameplay 세션 bootstrap 책임을 분리

* test: bootstrap 통합 테스트 기대값을 조정

* refactor: gameplay 세션 책임 분리와 phase/timer 동기화  (#391)

* refactor: participant 실시간 동기화 기준을 정리

* refactor: summary와 ticket 요청 가드를 분리

* refactor: phase 전환 이벤트를 서버에서 emit하도록 추가

* refactor: phase 전환과 active round 타이머를 서버 기준으로 정리

* refactor: gameplay summary orchestration을 페이지 레벨로 이동

* refactor: gameplay session 책임을 훅 단위로 분리

* refactor: non-active phase 타이머를 서버 기준으로 동기화

* fix: 네트워크 오류 메시지 번역을 추가

* chore: restrict CI to develop pull requests (#410)

---------



* chore: develop 누적 변경사항을 main에 반영 (#414)

* refactor: gameplay 세션 진입과 bootstrap 책임 분리 (#390)

* test: 테스트 설정 변경

* refactor: gameplay 세션 bootstrap 책임을 분리

* test: bootstrap 통합 테스트 기대값을 조정

* refactor: gameplay 세션 책임 분리와 phase/timer 동기화  (#391)

* refactor: participant 실시간 동기화 기준을 정리

* refactor: summary와 ticket 요청 가드를 분리

* refactor: phase 전환 이벤트를 서버에서 emit하도록 추가

* refactor: phase 전환과 active round 타이머를 서버 기준으로 정리

* refactor: gameplay summary orchestration을 페이지 레벨로 이동

* refactor: gameplay session 책임을 훅 단위로 분리

* refactor: non-active phase 타이머를 서버 기준으로 동기화

* fix: 네트워크 오류 메시지 번역을 추가

* chore: restrict CI to develop pull requests (#410)

* chore: AdSense 정적 삽입과 랜딩 반응형 레이아웃 조정 (#413)

* chore: update landing page adsense integration and layout

* chore: refine landing hero and current game responsiveness

---------



* chore: develop 변경사항을 main에 반영 (#419)

* refactor: gameplay 세션 진입과 bootstrap 책임 분리 (#390)

* test: 테스트 설정 변경

* refactor: gameplay 세션 bootstrap 책임을 분리

* test: bootstrap 통합 테스트 기대값을 조정

* refactor: gameplay 세션 책임 분리와 phase/timer 동기화  (#391)

* refactor: participant 실시간 동기화 기준을 정리

* refactor: summary와 ticket 요청 가드를 분리

* refactor: phase 전환 이벤트를 서버에서 emit하도록 추가

* refactor: phase 전환과 active round 타이머를 서버 기준으로 정리

* refactor: gameplay summary orchestration을 페이지 레벨로 이동

* refactor: gameplay session 책임을 훅 단위로 분리

* refactor: non-active phase 타이머를 서버 기준으로 동기화

* fix: 네트워크 오류 메시지 번역을 추가

* chore: restrict CI to develop pull requests (#410)

* chore: AdSense 정적 삽입과 랜딩 반응형 레이아웃 조정 (#413)

* chore: update landing page adsense integration and layout

* chore: refine landing hero and current game responsiveness

* feat: 데일리 통계 집계 완료 후 Telegram 알림 전송 추가 (#416)

* feat: 데일리 통계 집계 완료 후 Telegram 알림 전송 추가

* feat: 데일리 통계 Telegram 상세 집계를 디바이스별로 확장

* Revert "feat: 데일리 통계 집계 완료 후 Telegram 알림 전송 추가 (#416)" (#417)

This reverts commit 146d8eadcb0d4e9520c91966133be373152458e5.

* feat: 데일리 통계 Telegram 알림 전송 재적용 (#418)

* feat: 데일리 통계 집계 완료 후 Telegram 알림 전송 추가

* feat: 데일리 통계 Telegram 상세 집계를 디바이스별로 확장

* chore: re-trigger CI

---------



* fix: 라운드 60초로 변경 (#421)

---------



* feat: 로비와 room 기반 플레이 진입 구조를 추가 (#423)

* feat:

* feat: room 생성과 입장 API를 추가

* feat: 광장과 room 진입 구조를 분리

* chore: develop 통합 CI와 main 배포 전용 CD 정책 반영 (#411)

* refactor: gameplay 세션 진입과 bootstrap 책임 분리 (#390)

* test: 테스트 설정 변경

* refactor: gameplay 세션 bootstrap 책임을 분리

* test: bootstrap 통합 테스트 기대값을 조정

* refactor: gameplay 세션 책임 분리와 phase/timer 동기화  (#391)

* refactor: participant 실시간 동기화 기준을 정리

* refactor: summary와 ticket 요청 가드를 분리

* refactor: phase 전환 이벤트를 서버에서 emit하도록 추가

* refactor: phase 전환과 active round 타이머를 서버 기준으로 정리

* refactor: gameplay summary orchestration을 페이지 레벨로 이동

* refactor: gameplay session 책임을 훅 단위로 분리

* refactor: non-active phase 타이머를 서버 기준으로 동기화

* fix: 네트워크 오류 메시지 번역을 추가

* chore: restrict CI to develop pull requests (#410)

---------



* feat: 로비와 room 진입 흐름을 연결

* feat: room lifecycle와 생성 설정을 정리

* refactor: 게임 설정 정리

* fix: room 프로필 목록에서 default를 제외

* feat: room 종료 흐름과 로비 입장을 정리

* feat: connect lobby completed canvas tab

* refactor: organize lobby UI and translations

* style: 로비 우측 영역 레이아웃을 마무리

* chore: develop 누적 변경사항을 main에 반영 (#414)

* refactor: gameplay 세션 진입과 bootstrap 책임 분리 (#390)

* test: 테스트 설정 변경

* refactor: gameplay 세션 bootstrap 책임을 분리

* test: bootstrap 통합 테스트 기대값을 조정

* refactor: gameplay 세션 책임 분리와 phase/timer 동기화  (#391)

* refactor: participant 실시간 동기화 기준을 정리

* refactor: summary와 ticket 요청 가드를 분리

* refactor: phase 전환 이벤트를 서버에서 emit하도록 추가

* refactor: phase 전환과 active round 타이머를 서버 기준으로 정리

* refactor: gameplay summary orchestration을 페이지 레벨로 이동

* refactor: gameplay session 책임을 훅 단위로 분리

* refactor: non-active phase 타이머를 서버 기준으로 동기화

* fix: 네트워크 오류 메시지 번역을 추가

* chore: restrict CI to develop pull requests (#410)

* chore: AdSense 정적 삽입과 랜딩 반응형 레이아웃 조정 (#413)

* chore: update landing page adsense integration and layout

* chore: refine landing hero and current game responsiveness

---------



* chore: develop 변경사항을 main에 반영 (#419)

* refactor: gameplay 세션 진입과 bootstrap 책임 분리 (#390)

* test: 테스트 설정 변경

* refactor: gameplay 세션 bootstrap 책임을 분리

* test: bootstrap 통합 테스트 기대값을 조정

* refactor: gameplay 세션 책임 분리와 phase/timer 동기화  (#391)

* refactor: participant 실시간 동기화 기준을 정리

* refactor: summary와 ticket 요청 가드를 분리

* refactor: phase 전환 이벤트를 서버에서 emit하도록 추가

* refactor: phase 전환과 active round 타이머를 서버 기준으로 정리

* refactor: gameplay summary orchestration을 페이지 레벨로 이동

* refactor: gameplay session 책임을 훅 단위로 분리

* refactor: non-active phase 타이머를 서버 기준으로 동기화

* fix: 네트워크 오류 메시지 번역을 추가

* chore: restrict CI to develop pull requests (#410)

* chore: AdSense 정적 삽입과 랜딩 반응형 레이아웃 조정 (#413)

* chore: update landing page adsense integration and layout

* chore: refine landing hero and current game responsiveness

* feat: 데일리 통계 집계 완료 후 Telegram 알림 전송 추가 (#416)

* feat: 데일리 통계 집계 완료 후 Telegram 알림 전송 추가

* feat: 데일리 통계 Telegram 상세 집계를 디바이스별로 확장

* Revert "feat: 데일리 통계 집계 완료 후 Telegram 알림 전송 추가 (#416)" (#417)

This reverts commit 146d8eadcb0d4e9520c91966133be373152458e5.

* feat: 데일리 통계 Telegram 알림 전송 재적용 (#418)

* feat: 데일리 통계 집계 완료 후 Telegram 알림 전송 추가

* feat: 데일리 통계 Telegram 상세 집계를 디바이스별로 확장

* chore: re-trigger CI

---------



* fix: 라운드 60초로 변경 (#421)

* fix: 로비 방 상세와 방 생성 모달을 정리

* fix: 로비 완성된 캔버스와 방 목록 레이아웃을 조정

* fix: 방 입장 모달 다국어 문구를 적용

* fix: 방 입장 모달 문구와 방 번호 오류 메시지를 정리

* fix: 방 생성 모달의 effect 기반 상태 동기화를 제거

* test: 변경된 로비 진입 흐름에 맞게 통합 테스트를 수정

---------



* Merge branch 'main' into feat/common/407-lobby-and-room-system (#425)

* feat:

* feat: room 생성과 입장 API를 추가

* feat: 광장과 room 진입 구조를 분리

* chore: develop 통합 CI와 main 배포 전용 CD 정책 반영 (#411)

* refactor: gameplay 세션 진입과 bootstrap 책임 분리 (#390)

* test: 테스트 설정 변경

* refactor: gameplay 세션 bootstrap 책임을 분리

* test: bootstrap 통합 테스트 기대값을 조정

* refactor: gameplay 세션 책임 분리와 phase/timer 동기화  (#391)

* refactor: participant 실시간 동기화 기준을 정리

* refactor: summary와 ticket 요청 가드를 분리

* refactor: phase 전환 이벤트를 서버에서 emit하도록 추가

* refactor: phase 전환과 active round 타이머를 서버 기준으로 정리

* refactor: gameplay summary orchestration을 페이지 레벨로 이동

* refactor: gameplay session 책임을 훅 단위로 분리

* refactor: non-active phase 타이머를 서버 기준으로 동기화

* fix: 네트워크 오류 메시지 번역을 추가

* chore: restrict CI to develop pull requests (#410)

---------



* feat: 로비와 room 진입 흐름을 연결

* feat: room lifecycle와 생성 설정을 정리

* refactor: 게임 설정 정리

* fix: room 프로필 목록에서 default를 제외

* feat: room 종료 흐름과 로비 입장을 정리

* feat: connect lobby completed canvas tab

* refactor: organize lobby UI and translations

* style: 로비 우측 영역 레이아웃을 마무리

* chore: develop 누적 변경사항을 main에 반영 (#414)

* refactor: gameplay 세션 진입과 bootstrap 책임 분리 (#390)

* test: 테스트 설정 변경

* refactor: gameplay 세션 bootstrap 책임을 분리

* test: bootstrap 통합 테스트 기대값을 조정

* refactor: gameplay 세션 책임 분리와 phase/timer 동기화  (#391)

* refactor: participant 실시간 동기화 기준을 정리

* refactor: summary와 ticket 요청 가드를 분리

* refactor: phase 전환 이벤트를 서버에서 emit하도록 추가

* refactor: phase 전환과 active round 타이머를 서버 기준으로 정리

* refactor: gameplay summary orchestration을 페이지 레벨로 이동

* refactor: gameplay session 책임을 훅 단위로 분리

* refactor: non-active phase 타이머를 서버 기준으로 동기화

* fix: 네트워크 오류 메시지 번역을 추가

* chore: restrict CI to develop pull requests (#410)

* chore: AdSense 정적 삽입과 랜딩 반응형 레이아웃 조정 (#413)

* chore: update landing page adsense integration and layout

* chore: refine landing hero and current game responsiveness

---------



* chore: develop 변경사항을 main에 반영 (#419)

* refactor: gameplay 세션 진입과 bootstrap 책임 분리 (#390)

* test: 테스트 설정 변경

* refactor: gameplay 세션 bootstrap 책임을 분리

* test: bootstrap 통합 테스트 기대값을 조정

* refactor: gameplay 세션 책임 분리와 phase/timer 동기화  (#391)

* refactor: participant 실시간 동기화 기준을 정리

* refactor: summary와 ticket 요청 가드를 분리

* refactor: phase 전환 이벤트를 서버에서 emit하도록 추가

* refactor: phase 전환과 active round 타이머를 서버 기준으로 정리

* refactor: gameplay summary orchestration을 페이지 레벨로 이동

* refactor: gameplay session 책임을 훅 단위로 분리

* refactor: non-active phase 타이머를 서버 기준으로 동기화

* fix: 네트워크 오류 메시지 번역을 추가

* chore: restrict CI to develop pull requests (#410)

* chore: AdSense 정적 삽입과 랜딩 반응형 레이아웃 조정 (#413)

* chore: update landing page adsense integration and layout

* chore: refine landing hero and current game responsiveness

* feat: 데일리 통계 집계 완료 후 Telegram 알림 전송 추가 (#416)

* feat: 데일리 통계 집계 완료 후 Telegram 알림 전송 추가

* feat: 데일리 통계 Telegram 상세 집계를 디바이스별로 확장

* Revert "feat: 데일리 통계 집계 완료 후 Telegram 알림 전송 추가 (#416)" (#417)

This reverts commit 146d8eadcb0d4e9520c91966133be373152458e5.

* feat: 데일리 통계 Telegram 알림 전송 재적용 (#418)

* feat: 데일리 통계 집계 완료 후 Telegram 알림 전송 추가

* feat: 데일리 통계 Telegram 상세 집계를 디바이스별로 확장

* chore: re-trigger CI

---------



* fix: 라운드 60초로 변경 (#421)

* fix: 로비 방 상세와 방 생성 모달을 정리

* fix: 로비 완성된 캔버스와 방 목록 레이아웃을 조정

* fix: 방 입장 모달 다국어 문구를 적용

* fix: 방 입장 모달 문구와 방 번호 오류 메시지를 정리

* fix: 방 생성 모달의 effect 기반 상태 동기화를 제거

* test: 변경된 로비 진입 흐름에 맞게 통합 테스트를 수정

---------



* chore: main 랜딩 충돌 정리 (#426)

* chore: develop 통합 CI와 main 배포 전용 CD 정책 반영 (#411)

* refactor: gameplay 세션 진입과 bootstrap 책임 분리 (#390)

* test: 테스트 설정 변경

* refactor: gameplay 세션 bootstrap 책임을 분리

* test: bootstrap 통합 테스트 기대값을 조정

* refactor: gameplay 세션 책임 분리와 phase/timer 동기화  (#391)

* refactor: participant 실시간 동기화 기준을 정리

* refactor: summary와 ticket 요청 가드를 분리

* refactor: phase 전환 이벤트를 서버에서 emit하도록 추가

* refactor: phase 전환과 active round 타이머를 서버 기준으로 정리

* refactor: gameplay summary orchestration을 페이지 레벨로 이동

* refactor: gameplay session 책임을 훅 단위로 분리

* refactor: non-active phase 타이머를 서버 기준으로 동기화

* fix: 네트워크 오류 메시지 번역을 추가

* chore: restrict CI to develop pull requests (#410)

---------



* chore: develop 누적 변경사항을 main에 반영 (#414)

* refactor: gameplay 세션 진입과 bootstrap 책임 분리 (#390)

* test: 테스트 설정 변경

* refactor: gameplay 세션 bootstrap 책임을 분리

* test: bootstrap 통합 테스트 기대값을 조정

* refactor: gameplay 세션 책임 분리와 phase/timer 동기화  (#391)

* refactor: participant 실시간 동기화 기준을 정리

* refactor: summary와 ticket 요청 가드를 분리

* refactor: phase 전환 이벤트를 서버에서 emit하도록 추가

* refactor: phase 전환과 active round 타이머를 서버 기준으로 정리

* refactor: gameplay summary orchestration을 페이지 레벨로 이동

* refactor: gameplay session 책임을 훅 단위로 분리

* refactor: non-active phase 타이머를 서버 기준으로 동기화

* fix: 네트워크 오류 메시지 번역을 추가

* chore: restrict CI to develop pull requests (#410)

* chore: AdSense 정적 삽입과 랜딩 반응형 레이아웃 조정 (#413)

* chore: update landing page adsense integration and layout

* chore: refine landing hero and current game responsiveness

---------



* chore: develop 변경사항을 main에 반영 (#419)

* refactor: gameplay 세션 진입과 bootstrap 책임 분리 (#390)

* test: 테스트 설정 변경

* refactor: gameplay 세션 bootstrap 책임을 분리

* test: bootstrap 통합 테스트 기대값을 조정

* refactor: gameplay 세션 책임 분리와 phase/timer 동기화  (#391)

* refactor: participant 실시간 동기화 기준을 정리

* refactor: summary와 ticket 요청 가드를 분리

* refactor: phase 전환 이벤트를 서버에서 emit하도록 추가

* refactor: phase 전환과 active round 타이머를 서버 기준으로 정리

* refactor: gameplay summary orchestration을 페이지 레벨로 이동

* refactor: gameplay session 책임을 훅 단위로 분리

* refactor: non-active phase 타이머를 서버 기준으로 동기화

* fix: 네트워크 오류 메시지 번역을 추가

* chore: restrict CI to develop pull requests (#410)

* chore: AdSense 정적 삽입과 랜딩 반응형 레이아웃 조정 (#413)

* chore: update landing page adsense integration and layout

* chore: refine landing hero and current game responsiveness

* feat: 데일리 통계 집계 완료 후 Telegram 알림 전송 추가 (#416)

* feat: 데일리 통계 집계 완료 후 Telegram 알림 전송 추가

* feat: 데일리 통계 Telegram 상세 집계를 디바이스별로 확장

* Revert "feat: 데일리 통계 집계 완료 후 Telegram 알림 전송 추가 (#416)" (#417)

This reverts commit 146d8eadcb0d4e9520c91966133be373152458e5.

* feat: 데일리 통계 Telegram 알림 전송 재적용 (#418)

* feat: 데일리 통계 집계 완료 후 Telegram 알림 전송 추가

* feat: 데일리 통계 Telegram 상세 집계를 디바이스별로 확장

* chore: re-trigger CI

---------



* fix: 라운드 60초로 변경 (#421)

---------



---------



---------



* fix: 광장 current 조회와 비공개방 문구를 정리

* fix: 광장 current 조회와 비공개방 문구를 정리 (#432)

---------


## 관련 이슈
- Close #

## 개요
<!-- 이 PR에서 변경한 내용을 간략히 설명한다. -->


## 작업 범위 및 내용
### 신규 파일
<!-- 경로와 파일 명, 간략한 구현 내용 -->
-

### 수정 파일
<!-- 경로와 파일 명, 간략한 구현 내용 -->
-

## 테스트 항목
- 
