### PR TITLE
fix: 로비 입장코드 흐름과 광장 표시를 정리

### DIFF
--- a/backend/src/modules/canvas/canvas.service.ts
+++ b/backend/src/modules/canvas/canvas.service.ts
@@ -67,6 +67,18 @@ async function findCurrentPlazaCanvas(): Promise<Canvas | null> {
     .getOne();
 }
 
+async function findPlayingPlazaCanvas(): Promise<Canvas | null> {
+  return canvasRepository
+    .createQueryBuilder("canvas")
+    .leftJoin("room", "room", "room.canvas_id = canvas.id")
+    .where("canvas.status = :status", { status: CanvasStatus.PLAYING })
+    .andWhere("(room.id IS NULL OR room.type = :plazaType)", {
+      plazaType: RoomType.PLAZA,
+    })
+    .orderBy("canvas.startedAt", "DESC")
+    .getOne();
+}
+
 function logPhaseChange(params: {
   canvasId: number;
   phase: GamePhase;
@@ -116,9 +128,7 @@ export async function startCanvasGame(io: Server, canvasId: number) {
 
 export const canvasService = {
   async create(io: Server, options: CreateCanvasOptions = {}): Promise<Canvas> {
-    const existing = await canvasRepository.findOne({
-      where: { status: CanvasStatus.PLAYING },
-    });
+    const existing = await findPlayingPlazaCanvas();
 
     if (existing) {
       throw new Error("A canvas is already in progress.");

--- a/backend/src/modules/room/room.controller.ts
+++ b/backend/src/modules/room/room.controller.ts
@@ -14,7 +14,7 @@ import { roundSnapshotService } from "../history/round-snapshot.service";
 import { resolveResultTemplateAssetKey } from "../canvas/template/result-template.service";
 import { roomService, type CreateRoomInput } from "./room.service";
 
-function parsePublicRoomNumber(raw: unknown): number | null {
+function parseRoomId(raw: unknown): number | null {
   const value = Number(raw);
   return Number.isInteger(value) && value > 0 ? value : null;
 }
@@ -26,7 +26,6 @@ function serializeRoomListItem(
 ) {
   return {
     roomId: room.id,
-    publicRoomNumber: room.publicRoomNumber,
     title: room.title,
     type: room.type,
     status: room.status,
@@ -38,17 +37,19 @@ function serializeRoomListItem(
 function serializePrivateRoomDetail(room: Room) {
   return {
     roomId: room.id,
-    publicRoomNumber: room.publicRoomNumber,
     title: room.title,
     type: room.type,
     status: room.status,
   };
 }
 
-function serializeManageInfo(room: Room) {
+function serializeManageInfo(
+  room: Room,
+  options: { includeAccessCode: boolean },
+) {
   return {
     settings: room.settingsSnapshot,
-    accessCode: room.type === RoomType.PRIVATE ? room.accessCode : null,
+    accessCode: options.includeAccessCode ? room.accessCode : null,
   };
 }
 
@@ -90,7 +91,6 @@ function serializeRoomDetail(
 
   return {
     roomId: room.id,
-    publicRoomNumber: room.publicRoomNumber,
     title: room.title,
     type: room.type,
     status: room.status,
@@ -128,7 +128,6 @@ async function applyRoomSessionContext(
   context:
     | {
         roomId: number;
-        publicRoomNumber: number | null;
         canvasId: number;
         type: string;
       }
@@ -168,7 +167,6 @@ export const roomController = {
       return res.status(201).json({
         room: {
           roomId: result.room.id,
-          publicRoomNumber: result.room.publicRoomNumber,
           title: result.room.title,
           type: result.room.type,
         },
@@ -204,15 +202,13 @@ export const roomController = {
 
   async getDetail(req: Request, res: Response) {
     try {
-      const publicRoomNumber = parsePublicRoomNumber(
-        req.params["publicRoomNumber"],
-      );
+      const roomId = parseRoomId(req.params["roomId"]);
 
-      if (!publicRoomNumber) {
-        return res.status(400).json({ message: "ROOM_NUMBER_INVALID" });
+      if (!roomId) {
+        return res.status(400).json({ message: "ROOM_ID_INVALID" });
       }
 
-      const room = await roomService.getPublicDetail(publicRoomNumber);
+      const room = await roomService.getDetailByRoomId(roomId);
       const isOwner =
         req.session.voter?.id !== undefined &&
         room.owner?.id === req.session.voter.id;
@@ -221,7 +217,9 @@ export const roomController = {
         return res.json({
           room: {
             ...serializePrivateRoomDetail(room),
-            manage: isOwner ? serializeManageInfo(room) : null,
+            manage: isOwner
+              ? serializeManageInfo(room, { includeAccessCode: true })
+              : null,
           },
         });
       }
@@ -243,7 +241,9 @@ export const roomController = {
                 )
               : null,
           ),
-          manage: isOwner ? serializeManageInfo(room) : null,
+          manage: isOwner
+            ? serializeManageInfo(room, { includeAccessCode: false })
+            : null,
         },
       });
     } catch (error) {
@@ -256,31 +256,17 @@ export const roomController = {
 
   async enter(req: Request, res: Response) {
     try {
-      const roomType =
-        req.body?.type === RoomType.PUBLIC || req.body?.type === RoomType.PRIVATE
-          ? req.body.type
-          : null;
-      let result;
+      const accessCode = String(req.body?.accessCode ?? "")
+        .trim()
+        .toUpperCase();
 
-      if (roomType === RoomType.PUBLIC) {
-        const publicRoomNumber = parsePublicRoomNumber(req.body?.publicRoomNumber);
+      if (!accessCode) {
+        return res.status(400).json({ message: "ROOM_ACCESS_CODE_REQUIRED" });
+      }
 
-        if (!publicRoomNumber) {
-          return res.status(400).json({ message: "ROOM_NUMBER_INVALID" });
-        }
+      const result = await roomService.enterByAccessCode(accessCode);
 
-        result = await roomService.enterPublic(publicRoomNumber);
-      } else if (roomType === RoomType.PRIVATE) {
-        const accessCode = String(req.body?.accessCode ?? "")
-          .trim()
-          .toUpperCase();
-
-        if (!accessCode) {
-          return res.status(400).json({ message: "ROOM_ACCESS_CODE_REQUIRED" });
-        }
-
-        result = await roomService.enterPrivate(accessCode);
-      } else {
+      if (result.room.type !== RoomType.PUBLIC && result.room.type !== RoomType.PRIVATE) {
         return res.status(400).json({ message: "ROOM_TYPE_INVALID" });
       }
 
@@ -289,7 +275,37 @@ export const roomController = {
       return res.json({
         room: {
           roomId: result.room.id,
-          publicRoomNumber: result.room.publicRoomNumber,
+          type: result.room.type,
+        },
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      const status =
+        message === "ROOM_EXPIRED"
+          ? 410
+          : message === "ROOM_NOT_FOUND"
+            ? 404
+            : 400;
+
+      return res.status(status).json({ message });
+    }
+  },
+
+  async enterPublicByRoomId(req: Request, res: Response) {
+    try {
+      const roomId = parseRoomId(req.params["roomId"]);
+
+      if (!roomId) {
+        return res.status(400).json({ message: "ROOM_ID_INVALID" });
+      }
+
+      const result = await roomService.enterPublicByRoomId(roomId);
+
+      await applyRoomSessionContext(req, result.sessionContext);
+
+      return res.json({
+        room: {
+          roomId: result.room.id,
           type: result.room.type,
         },
       });
@@ -319,7 +335,6 @@ export const roomController = {
       return res.json({
         room: {
           roomId: room.id,
-          publicRoomNumber: room.publicRoomNumber,
           title: room.title,
           type: room.type,
           status: room.status,
@@ -408,11 +423,10 @@ export const roomController = {
       return res.json({
         room: {
           roomId: room.id,
-          publicRoomNumber: room.publicRoomNumber,
           title: room.title,
           type: room.type,
           settings: room.settingsSnapshot,
-          accessCode: room.type === RoomType.PRIVATE ? room.accessCode : null,
+          accessCode: room.accessCode,
         },
       });
     } catch (error) {

--- a/backend/src/modules/room/room.router.ts
+++ b/backend/src/modules/room/room.router.ts
@@ -20,7 +20,8 @@ router.get(
 router.get("/current/manage", authMiddleware, roomController.getCurrentManage);
 router.post("/current/end-game", authMiddleware, roomController.endGameCurrent);
 router.post("/current/terminate", authMiddleware, roomController.terminateCurrent);
-router.get("/:publicRoomNumber", roomController.getDetail);
+router.post("/:roomId/enter-public", authMiddleware, roomController.enterPublicByRoomId);
+router.get("/:roomId", roomController.getDetail);
 router.post("/", authMiddleware, roomController.create);
 router.post("/enter", authMiddleware, roomController.enter);
 

--- a/backend/src/modules/room/room.service.ts
+++ b/backend/src/modules/room/room.service.ts
@@ -33,7 +33,6 @@ export interface CreateRoomInput {
 
 export interface RoomSessionContext {
   roomId: number;
-  publicRoomNumber: number | null;
   canvasId: number;
   type: RoomType;
 }
@@ -190,15 +189,6 @@ async function assertOwnerActiveRoomLimit(ownerId: number): Promise<void> {
   }
 }
 
-async function getNextPublicRoomNumber(): Promise<number> {
-  const row = await roomRepository
-    .createQueryBuilder("room")
-    .select("COALESCE(MAX(room.publicRoomNumber), 0)", "max")
-    .getRawOne<{ max: string | number }>();
-
-  return Number(row?.max ?? 0) + 1;
-}
-
 async function generateUniqueAccessCode(): Promise<string> {
   for (let attempt = 0; attempt < 10; attempt += 1) {
     const accessCode = randomBytes(6).toString("base64url").toUpperCase();
@@ -218,7 +208,6 @@ async function generateUniqueAccessCode(): Promise<string> {
 function buildRoomSessionContext(room: Room): RoomSessionContext {
   return {
     roomId: room.id,
-    publicRoomNumber: room.publicRoomNumber,
     canvasId: room.canvas.id,
     type: room.type,
   };
@@ -275,7 +264,7 @@ export const roomService = {
   ): Promise<{
     room: Room;
     sessionContext: RoomSessionContext | null;
-    accessCode: string | null;
+    accessCode: string;
   }> {
     const profileSnapshot = getGameConfigSnapshot(input.profileKey);
     validateCreateRoomInput(input, profileSnapshot);
@@ -285,9 +274,7 @@ export const roomService = {
       input.profileKey,
       buildRoomConfigUpdate(input),
     );
-    const publicRoomNumber = await getNextPublicRoomNumber();
-    const accessCode =
-      input.type === RoomType.PRIVATE ? await generateUniqueAccessCode() : null;
+    const accessCode = await generateUniqueAccessCode();
 
     const room = await AppDataSource.transaction(async (manager) => {
       const canvasRepository = manager.getRepository(Canvas);
@@ -304,7 +291,7 @@ export const roomService = {
       const createdRoom = txRoomRepository.create({
         type: input.type,
         status: RoomStatus.ACTIVE,
-        publicRoomNumber,
+        publicRoomNumber: null,
         title: normalizeTitle(input.title),
         owner: { id: ownerId } as Voter,
         accessCode,
@@ -353,7 +340,7 @@ export const roomService = {
         { type: RoomType.PRIVATE, status: RoomStatus.GAME_END_WAIT },
       ],
       relations: { canvas: true, owner: true },
-      order: { publicRoomNumber: "DESC" },
+      order: { id: "DESC" },
     });
 
     const reconciledRooms = await Promise.all(rooms.map(reconcileRoomLifecycle));
@@ -382,12 +369,12 @@ export const roomService = {
     return participantSessionService.getParticipantList(room.canvas.id);
   },
 
-  async getPublicDetail(publicRoomNumber: number): Promise<Room> {
+  async getDetailByRoomId(roomId: number): Promise<Room> {
     await expireElapsedRooms();
 
     const foundRoom = await roomRepository.findOne({
       where: {
-        publicRoomNumber,
+        id: roomId,
       },
       relations: { canvas: true, owner: true },
     });
@@ -401,8 +388,25 @@ export const roomService = {
     return room;
   },
 
-  async enterPublic(publicRoomNumber: number) {
-    const room = await this.getPublicDetail(publicRoomNumber);
+  async enterByAccessCode(accessCode: string) {
+    await expireElapsedRooms();
+
+    const foundRoom = await roomRepository.findOne({
+      where: {
+        accessCode,
+      },
+      relations: { canvas: true },
+    });
+
+    if (!foundRoom) {
+      throw new Error("ROOM_NOT_FOUND");
+    }
+
+    const room = await reconcileRoomLifecycle(foundRoom);
+
+    if (room.status === RoomStatus.EXPIRED) {
+      throw new Error("ROOM_EXPIRED");
+    }
 
     return {
       room,
@@ -410,21 +414,11 @@ export const roomService = {
     };
   },
 
-  async enterPrivate(accessCode: string) {
-    await expireElapsedRooms();
+  async enterPublicByRoomId(roomId: number) {
+    const room = await this.getDetailByRoomId(roomId);
 
-    const foundRoom = await roomRepository.findOne({
-      where: {
-        accessCode,
-        type: RoomType.PRIVATE,
-      },
-      relations: { canvas: true },
-    });
-
-    const room = foundRoom ? await reconcileRoomLifecycle(foundRoom) : null;
-
-    if (!room || room.status === RoomStatus.EXPIRED) {
-      throw new Error("ROOM_EXPIRED");
+    if (room.type !== RoomType.PUBLIC) {
+      throw new Error("ROOM_TYPE_INVALID");
     }
 
     return {

--- a/backend/src/types/express-session.d.ts
+++ b/backend/src/types/express-session.d.ts
@@ -11,7 +11,6 @@ declare module "express-session" {
     };
     room?: {
       roomId: number;
-      publicRoomNumber: number | null;
       canvasId: number;
       type: string;
     };

--- a/frontend/src/features/gameplay/vote/components/VotePanel.tsx
+++ b/frontend/src/features/gameplay/vote/components/VotePanel.tsx
@@ -239,14 +239,14 @@ export default function VotePanel({
               type="button"
               disabled={settingsDisabled && !forceSettingsOpen}
               onClick={() => setIsSettingsOpen((prev) => !prev)}
-              className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-[color:var(--page-theme-border-primary)] bg-[color:var(--page-theme-surface-primary)] text-sm font-semibold text-[color:var(--page-theme-text-secondary)] shadow-sm transition hover:bg-[color:var(--page-theme-surface-secondary)] hover:text-[color:var(--page-theme-text-primary)] disabled:cursor-not-allowed disabled:opacity-45 disabled:hover:bg-[color:var(--page-theme-surface-primary)] disabled:hover:text-[color:var(--page-theme-text-secondary)]"
+              className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-transparent bg-[#5A8393] text-sm font-semibold text-white shadow-sm transition hover:bg-[#4B7382] disabled:cursor-not-allowed disabled:opacity-45 disabled:hover:bg-[#5A8393] disabled:hover:text-white"
               aria-label={t("vote.panel.settings")}
               aria-expanded={isSettingsVisible}
             >
               <img
                 src={settingsIcon}
                 alt=""
-                className="h-4.5 w-4.5 object-contain"
+                className="h-4.5 w-4.5 object-contain brightness-0 invert"
                 draggable={false}
               />
             </button>

--- a/frontend/src/features/gameplay/vote/components/VotePanelSettings.tsx
+++ b/frontend/src/features/gameplay/vote/components/VotePanelSettings.tsx
@@ -37,7 +37,6 @@ const VotePanelSettings = forwardRef<HTMLDivElement, Props>(
             language: "언어",
             background: "배경",
             room: "방 상세",
-            roomNumber: "방 번호",
             roomTitle: "방 제목",
             profile: "프로필",
             intro: "인트로",
@@ -55,7 +54,6 @@ const VotePanelSettings = forwardRef<HTMLDivElement, Props>(
             language: "Language",
             background: "Background",
             room: "Room",
-            roomNumber: "Room #",
             roomTitle: "Title",
             profile: "Profile",
             intro: "Intro",
@@ -120,9 +118,6 @@ const VotePanelSettings = forwardRef<HTMLDivElement, Props>(
                 {labels.room}
               </p>
               <div className="mt-2 grid gap-1 text-xs text-[color:var(--page-theme-text-primary)]">
-                <p>
-                  {labels.roomNumber}: #{roomManage.publicRoomNumber}
-                </p>
                 <p>
                   {labels.roomTitle}: {roomManage.title}
                 </p>

--- a/frontend/src/features/landing/components/FeaturedPreviewCard.tsx
+++ b/frontend/src/features/landing/components/FeaturedPreviewCard.tsx
@@ -33,7 +33,7 @@ export default function FeaturedPreviewCard({
   const participantNames = preview?.participants ?? [];
 
   return (
-    <article className="mx-auto w-[300px] overflow-hidden rounded-[30px] bg-white shadow-[0_24px_70px_rgba(39,46,55,0.08)]">
+    <article className="mx-auto w-[332px] overflow-hidden rounded-[30px] bg-white shadow-[0_24px_70px_rgba(39,46,55,0.08)]">
       <div className="px-5 pb-4 pt-4">
         <div className="flex items-center justify-center gap-3">
           <h2
@@ -49,6 +49,8 @@ export default function FeaturedPreviewCard({
             locale={locale}
             webpUrl={item?.webpUrl ?? null}
             alt={`${gridX} x ${gridY}`}
+            gridX={gridX}
+            gridY={gridY}
           />
         </div>
 

--- a/frontend/src/features/landing/components/FeaturedPreviewImage.tsx
+++ b/frontend/src/features/landing/components/FeaturedPreviewImage.tsx
@@ -5,7 +5,11 @@ interface FeaturedPreviewImageProps {
   locale: PublicSiteLocale;
   webpUrl: string | null;
   alt: string;
+  gridX: number;
+  gridY: number;
 }
+
+const MAX_LONGEST_SIDE = 256;
 
 function getFallbackImageUrl(locale: PublicSiteLocale) {
   return locale === "ko"
@@ -13,28 +17,44 @@ function getFallbackImageUrl(locale: PublicSiteLocale) {
     : "/landing/fallback/en/featured-preview-fallback.png";
 }
 
+function getPixelPerfectPreviewSize(gridX: number, gridY: number) {
+  const longestSide = Math.max(gridX, gridY);
+  const scale = Math.max(1, Math.floor(MAX_LONGEST_SIDE / longestSide));
+
+  return {
+    width: gridX * scale,
+    height: gridY * scale,
+  };
+}
+
 export default function FeaturedPreviewImage({
   locale,
   webpUrl,
   alt,
+  gridX,
+  gridY,
 }: FeaturedPreviewImageProps) {
   const fallbackImageUrl = useMemo(() => getFallbackImageUrl(locale), [locale]);
   const [failedWebpUrl, setFailedWebpUrl] = useState<string | null>(null);
   const imageUrl =
     !webpUrl || failedWebpUrl === webpUrl ? fallbackImageUrl : webpUrl;
   const isFallbackImage = imageUrl === fallbackImageUrl;
+  const previewSize = useMemo(
+    () => getPixelPerfectPreviewSize(gridX, gridY),
+    [gridX, gridY],
+  );
 
   return (
     <div className="mx-auto flex w-fit justify-center">
       <div
         className="flex-none overflow-hidden rounded-[24px] bg-white shadow-[0_24px_60px_rgba(39,46,55,0.10)]"
         style={{
-          width: "224px",
-          height: "224px",
-          minWidth: "224px",
-          minHeight: "224px",
-          maxWidth: "224px",
-          maxHeight: "224px",
+          width: `${previewSize.width}px`,
+          height: `${previewSize.height}px`,
+          minWidth: `${previewSize.width}px`,
+          minHeight: `${previewSize.height}px`,
+          maxWidth: `${previewSize.width}px`,
+          maxHeight: `${previewSize.height}px`,
         }}
       >
         <img

--- a/frontend/src/features/lobby/components/CompletedCanvasSection.tsx
+++ b/frontend/src/features/lobby/components/CompletedCanvasSection.tsx
@@ -37,10 +37,7 @@ export default function CompletedCanvasSection({
     <div className="flex h-full min-h-0 flex-col rounded-[28px] bg-[#fbf7f2] p-6">
       <div className="flex flex-wrap items-center justify-between gap-4">
         <div>
-          <h1 className="text-[28px] font-semibold tracking-tight">
-            {t("lobby.completed.title")}
-          </h1>
-          <p className="mt-2 text-sm leading-6 text-[#5f6368]">
+          <p className="text-sm leading-6 text-[#5f6368]">
             {t("lobby.completed.description")}
           </p>
         </div>
@@ -108,7 +105,7 @@ export default function CompletedCanvasSection({
             {t("lobby.completed.empty")}
           </div>
         ) : (
-          <div className="flex flex-wrap gap-6">
+          <div className="grid justify-items-center gap-6 md:grid-cols-2 2xl:grid-cols-4">
             {COMPLETED_PREVIEW_SLOTS.map((slot) => (
               <FeaturedPreviewCard
                 key={slot.size}

--- a/frontend/src/features/room/api/room.api.ts
+++ b/frontend/src/features/room/api/room.api.ts
@@ -27,7 +27,6 @@ export interface RoomConfigProfile {
 
 export interface RoomListItem {
   roomId: number;
-  publicRoomNumber: number;
   title: string;
   type: "public" | "private";
   status: "active" | "game_end_wait" | "expired";
@@ -38,7 +37,6 @@ export interface RoomListItem {
 export interface PublicRoomDetailResponse {
   room: {
     roomId: number;
-    publicRoomNumber: number;
     title: string;
     type: "public";
     status: "active" | "game_end_wait" | "expired";
@@ -70,7 +68,6 @@ export interface PublicRoomDetailResponse {
 export interface PrivateRoomDetailResponse {
   room: {
     roomId: number;
-    publicRoomNumber: number;
     title: string;
     type: "private";
     status: "active" | "game_end_wait" | "expired";
@@ -105,18 +102,16 @@ export interface RoomCreateRequest {
 export interface RoomCreateResponse {
   room: {
     roomId: number;
-    publicRoomNumber: number;
     title: string;
     type: "public" | "private";
   };
-  accessCode: string | null;
+  accessCode: string;
   entered: boolean;
 }
 
 export interface RoomEnterResponse {
   room: {
     roomId: number;
-    publicRoomNumber: number;
     type: "public" | "private";
   };
 }
@@ -124,7 +119,6 @@ export interface RoomEnterResponse {
 export interface RoomCurrentManageResponse {
   room: {
     roomId: number;
-    publicRoomNumber: number;
     title: string;
     type: "public" | "private";
     settings: {
@@ -144,20 +138,16 @@ export const roomApi = {
   getRooms: () => api.get<{ rooms: RoomListItem[] }>("/rooms"),
   getConfigProfiles: () =>
     api.get<{ profiles: RoomConfigProfile[] }>("/rooms/config-profiles"),
-  getRoomDetail: (publicRoomNumber: number) =>
-    api.get<RoomDetailResponse>(`/rooms/${publicRoomNumber}`),
+  getRoomDetail: (roomId: number) =>
+    api.get<RoomDetailResponse>(`/rooms/${roomId}`),
   createRoom: (payload: RoomCreateRequest) =>
     api.post<RoomCreateResponse>("/rooms", payload),
-  enterPublicRoom: (publicRoomNumber: number) =>
+  enterRoom: (accessCode: string) =>
     api.post<RoomEnterResponse>("/rooms/enter", {
-      type: "public",
-      publicRoomNumber,
-    }),
-  enterPrivateRoom: (accessCode: string) =>
-    api.post<RoomEnterResponse>("/rooms/enter", {
-      type: "private",
       accessCode,
     }),
+  enterPublicRoomById: (roomId: number) =>
+    api.post<RoomEnterResponse>(`/rooms/${roomId}/enter-public`),
   getCurrentManage: () =>
     api.get<RoomCurrentManageResponse>("/rooms/current/manage"),
   endGameCurrent: () => api.post<{ ok: true }>("/rooms/current/end-game"),
@@ -169,7 +159,6 @@ export function toRoomSessionContext(
 ): RoomSessionContext {
   return {
     roomId: room.roomId,
-    publicRoomNumber: room.publicRoomNumber,
     type: room.type,
   };
 }

--- a/frontend/src/features/room/components/RoomCreateModal.tsx
+++ b/frontend/src/features/room/components/RoomCreateModal.tsx
@@ -155,7 +155,8 @@ export default function RoomCreateModal({
                   value={title}
                   onChange={(event) => setTitle(event.target.value)}
                   placeholder={t("lobby.roomCreate.placeholder.title")}
-                  className="h-12 rounded-2xl border border-[#d9cdc1] px-4 text-sm outline-none"
+                  className="h-12 rounded-2xl border border-[#d9cdc1] bg-white px-4 text-sm text-[#272E37] outline-none"
+                  style={{ colorScheme: "light" }}
                 />
                 <span className="text-xs text-[#7b6b62]">
                   {t("lobby.roomCreate.titleHint")}
@@ -172,7 +173,8 @@ export default function RoomCreateModal({
                     onChange={(event) =>
                       setType(event.target.value as "public" | "private")
                     }
-                    className="h-12 rounded-2xl border border-[#d9cdc1] px-4 text-sm outline-none"
+                    className="h-12 rounded-2xl border border-[#d9cdc1] bg-white px-4 text-sm text-[#272E37] outline-none"
+                    style={{ colorScheme: "light" }}
                   >
                     <option value="public">{t("lobby.roomCreate.type.public")}</option>
                     <option value="private">
@@ -197,7 +199,8 @@ export default function RoomCreateModal({
                     value={resolvedProfileKey}
                     onChange={(event) => handleProfileChange(event.target.value)}
                     disabled={availableProfiles.length === 0}
-                    className="h-12 rounded-2xl border border-[#d9cdc1] px-4 text-sm outline-none"
+                    className="h-12 rounded-2xl border border-[#d9cdc1] bg-white px-4 text-sm text-[#272E37] outline-none"
+                    style={{ colorScheme: "light" }}
                   >
                     {availableProfiles.map((profile) => (
                       <option key={profile.key} value={profile.key}>
@@ -267,7 +270,8 @@ export default function RoomCreateModal({
                       onChange={(event) =>
                         setIntroPhaseSecOverride(Number(event.target.value))
                       }
-                      className="h-12 rounded-2xl border border-[#d9cdc1] px-4 text-sm outline-none"
+                      className="h-12 rounded-2xl border border-[#d9cdc1] bg-white px-4 text-sm text-[#272E37] outline-none"
+                      style={{ colorScheme: "light" }}
                     />
                     <span className="text-xs text-[#7b6b62]">
                       {t("lobby.roomCreate.introHint")}
@@ -283,7 +287,8 @@ export default function RoomCreateModal({
                       onChange={(event) =>
                         setTotalRoundsOverride(Number(event.target.value))
                       }
-                      className="h-12 rounded-2xl border border-[#d9cdc1] px-4 text-sm outline-none"
+                      className="h-12 rounded-2xl border border-[#d9cdc1] bg-white px-4 text-sm text-[#272E37] outline-none"
+                      style={{ colorScheme: "light" }}
                     >
                       {Array.from({ length: maxRounds }, (_, index) => index + 1).map(
                         (round) => (
@@ -307,7 +312,8 @@ export default function RoomCreateModal({
                       onChange={(event) =>
                         setVotesPerRoundOverride(Number(event.target.value))
                       }
-                      className="h-12 rounded-2xl border border-[#d9cdc1] px-4 text-sm outline-none"
+                      className="h-12 rounded-2xl border border-[#d9cdc1] bg-white px-4 text-sm text-[#272E37] outline-none"
+                      style={{ colorScheme: "light" }}
                     />
                     <span className="text-xs text-[#7b6b62]">
                       {t("lobby.roomCreate.votesPerRoundHint")}

--- a/frontend/src/features/room/components/RoomEnterModal.tsx
+++ b/frontend/src/features/room/components/RoomEnterModal.tsx
@@ -6,8 +6,7 @@ interface RoomEnterModalProps {
   loading: boolean;
   error: string | null;
   onClose: () => void;
-  onResolveRoomNumber: (publicRoomNumber: number) => Promise<void>;
-  onEnterPrivateRoom: (accessCode: string) => Promise<void>;
+  onEnterRoom: (accessCode: string) => Promise<void>;
 }
 
 export default function RoomEnterModal({
@@ -15,8 +14,7 @@ export default function RoomEnterModal({
   loading,
   error,
   onClose,
-  onResolveRoomNumber,
-  onEnterPrivateRoom,
+  onEnterRoom,
 }: RoomEnterModalProps) {
   const { t } = useI18n();
   const [entryValue, setEntryValue] = useState("");
@@ -49,7 +47,8 @@ export default function RoomEnterModal({
           value={entryValue}
           onChange={(event) => setEntryValue(event.target.value.toUpperCase())}
           placeholder={t("lobby.roomEnter.placeholder")}
-          className="mt-5 h-12 w-full rounded-2xl border border-[#d9cdc1] px-4 text-sm outline-none"
+          className="mt-5 h-12 w-full rounded-2xl border border-[#d9cdc1] bg-white px-4 text-sm text-[#272E37] outline-none"
+          style={{ colorScheme: "light" }}
         />
         {error ? <p className="mt-3 text-sm text-[#d14d28]">{error}</p> : null}
         <button
@@ -62,18 +61,7 @@ export default function RoomEnterModal({
               return;
             }
 
-            if (/^\d+$/.test(trimmed)) {
-              const nextRoomNumber = Number(trimmed);
-
-              if (!Number.isInteger(nextRoomNumber) || nextRoomNumber <= 0) {
-                return;
-              }
-
-              await onResolveRoomNumber(nextRoomNumber);
-              return;
-            }
-
-            await onEnterPrivateRoom(trimmed);
+            await onEnterRoom(trimmed);
           }}
           className="mt-6 w-full rounded-2xl bg-[#272E37] px-4 py-3 text-sm font-semibold text-white disabled:opacity-60"
         >
@@ -83,4 +71,3 @@ export default function RoomEnterModal({
     </div>
   );
 }
-

--- a/frontend/src/features/room/components/RoomListSection.tsx
+++ b/frontend/src/features/room/components/RoomListSection.tsx
@@ -4,7 +4,7 @@ import { useI18n } from "@/shared/i18n";
 
 interface RoomListSectionProps {
   rooms: RoomListItem[];
-  selectedRoomNumber: number | null;
+  selectedRoomId: number | null;
   selectedRoomDetail: RoomDetailResponse | null;
   loading: boolean;
   error: string | null;
@@ -12,8 +12,8 @@ interface RoomListSectionProps {
   detailError: string | null;
   privateAccessCode: string;
   onChangePrivateAccessCode: (value: string) => void;
-  onSelectRoom: (publicRoomNumber: number) => void;
-  onEnterPublicRoom: (publicRoomNumber: number) => void;
+  onSelectRoom: (roomId: number) => void;
+  onEnterPublicRoom: (roomId: number) => void | Promise<void>;
   onEnterPrivateRoom: (accessCode?: string) => void | Promise<void>;
 }
 
@@ -33,7 +33,7 @@ function getStatusLabel(
 
 export default function RoomListSection({
   rooms,
-  selectedRoomNumber,
+  selectedRoomId,
   selectedRoomDetail,
   loading,
   error,
@@ -50,25 +50,26 @@ export default function RoomListSection({
   return (
     <div className="grid h-full min-h-0 gap-5 xl:grid-cols-[1.4fr_0.6fr]">
       <div className="flex min-h-0 flex-col rounded-[24px] border border-[#e3d9cf] bg-white p-4">
-        <h2 className="px-2 text-sm font-semibold text-[#272E37]">
-          {t("lobby.roomList.title")}
-        </h2>
         {loading ? (
           <div className="px-2 py-6 text-sm text-[#5f6368]">
             {t("lobby.roomList.loading")}
           </div>
         ) : error ? (
           <div className="px-2 py-6 text-sm text-[#d14d28]">{error}</div>
+        ) : rooms.length === 0 ? (
+          <div className="flex min-h-0 flex-1 items-center justify-center px-6 py-6 text-center text-sm text-[#5f6368]">
+            {t("lobby.roomList.empty")}
+          </div>
         ) : (
-          <div className="mt-3 flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto pr-1">
+          <div className="flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto pr-1">
             {rooms.map((room) => {
-              const selected = room.publicRoomNumber === selectedRoomNumber;
+              const selected = room.roomId === selectedRoomId;
 
               return (
                 <button
                   key={room.roomId}
                   type="button"
-                  onClick={() => onSelectRoom(room.publicRoomNumber)}
+                  onClick={() => onSelectRoom(room.roomId)}
                   className={`h-[67px] w-full rounded-[20px] border px-4 py-3 text-left transition ${
                     selected
                       ? "border-[#272E37] bg-[#272E37] text-white"
@@ -77,9 +78,6 @@ export default function RoomListSection({
                 >
                   <div className="flex items-center justify-between gap-3">
                     <div className="flex flex-1 items-center gap-2">
-                      <span className="text-sm font-semibold">
-                        #{room.publicRoomNumber}
-                      </span>
                       {room.type === "private" ? (
                         <Lock
                           size={16}
@@ -143,24 +141,20 @@ export default function RoomListSection({
                   {selectedRoomDetail.room.manage.accessCode}
                 </p>
               </div>
-            ) : (
-              <input
-                type="text"
-                value={privateAccessCode}
-                onChange={(event) =>
-                  onChangePrivateAccessCode(event.target.value.toUpperCase())
-                }
-                placeholder={t("lobby.roomList.privateAccessCodePlaceholder")}
-                className="mt-5 h-12 w-full rounded-2xl border border-[#d9cdc1] bg-white px-4 text-sm outline-none"
-              />
-            )}
+            ) : null}
+            <input
+              type="text"
+              value={privateAccessCode}
+              onChange={(event) =>
+                onChangePrivateAccessCode(event.target.value.toUpperCase())
+              }
+              placeholder={t("lobby.roomList.privateAccessCodePlaceholder")}
+              className="mt-5 h-12 w-full rounded-2xl border border-[#d9cdc1] bg-white px-4 text-sm text-[#272E37] outline-none"
+              style={{ colorScheme: "light" }}
+            />
             <button
               type="button"
-              onClick={() =>
-                void onEnterPrivateRoom(
-                  selectedRoomDetail.room.manage?.accessCode ?? undefined,
-                )
-              }
+              onClick={() => void onEnterPrivateRoom()}
               className="mt-3 w-full rounded-2xl bg-[#272E37] px-5 py-3 text-sm font-semibold text-white"
             >
               {t("lobby.roomList.enter")}
@@ -220,9 +214,7 @@ export default function RoomListSection({
               </div>
               <button
                 type="button"
-                onClick={() =>
-                  onEnterPublicRoom(selectedRoomDetail.room.publicRoomNumber)
-                }
+                onClick={() => void onEnterPublicRoom(selectedRoomDetail.room.roomId)}
                 className="mt-5 w-full rounded-2xl bg-[#272E37] px-5 py-3 text-sm font-semibold text-white"
               >
                 {t("lobby.roomList.enterRoom")}

--- a/frontend/src/features/room/hooks/useLobbyRooms.ts
+++ b/frontend/src/features/room/hooks/useLobbyRooms.ts
@@ -7,7 +7,7 @@ import {
 
 export default function useLobbyRooms() {
   const [rooms, setRooms] = useState<RoomListItem[]>([]);
-  const [selectedRoomNumber, setSelectedRoomNumber] = useState<number | null>(
+  const [selectedRoomId, setSelectedRoomId] = useState<number | null>(
     null,
   );
   const [selectedRoomDetail, setSelectedRoomDetail] =
@@ -34,23 +34,29 @@ export default function useLobbyRooms() {
     }
   }, []);
 
-  const loadRoomDetail = useCallback(async (publicRoomNumber: number) => {
+  const loadRoomDetail = useCallback(async (roomId: number) => {
     setDetailLoading(true);
     setDetailError(null);
 
     try {
-      const { data } = await roomApi.getRoomDetail(publicRoomNumber);
-      setSelectedRoomNumber(publicRoomNumber);
+      const { data } = await roomApi.getRoomDetail(roomId);
+      setSelectedRoomId(roomId);
       setSelectedRoomDetail(data);
       return data;
     } catch {
-      setSelectedRoomNumber(publicRoomNumber);
+      setSelectedRoomId(roomId);
       setSelectedRoomDetail(null);
       setDetailError("방 정보를 불러오지 못했습니다.");
       return null;
     } finally {
       setDetailLoading(false);
     }
+  }, []);
+
+  const clearSelectedRoomDetail = useCallback(() => {
+    setSelectedRoomId(null);
+    setSelectedRoomDetail(null);
+    setDetailError(null);
   }, []);
 
   useEffect(() => {
@@ -70,7 +76,7 @@ export default function useLobbyRooms() {
         setRooms(data.rooms);
 
         if (data.rooms.length > 0) {
-          void loadRoomDetail(data.rooms[0].publicRoomNumber);
+          void loadRoomDetail(data.rooms[0].roomId);
         }
       } catch {
         if (!cancelled) {
@@ -93,7 +99,7 @@ export default function useLobbyRooms() {
 
   return {
     rooms,
-    selectedRoomNumber,
+    selectedRoomId,
     selectedRoomDetail,
     loading,
     error,
@@ -101,5 +107,6 @@ export default function useLobbyRooms() {
     detailError,
     loadRooms,
     loadRoomDetail,
+    clearSelectedRoomDetail,
   };
 }

--- a/frontend/src/features/room/model/room-session-context.ts
+++ b/frontend/src/features/room/model/room-session-context.ts
@@ -2,7 +2,6 @@ const ROOM_SESSION_STORAGE_KEY = "votedots:room-session-context";
 
 export interface RoomSessionContext {
   roomId: number;
-  publicRoomNumber: number | null;
   type: "public" | "private";
 }
 
@@ -22,8 +21,6 @@ export function getStoredRoomSessionContext(): RoomSessionContext | null {
 
     if (
       typeof parsed.roomId !== "number" ||
-      (parsed.publicRoomNumber !== null &&
-        typeof parsed.publicRoomNumber !== "number") ||
       (parsed.type !== "public" && parsed.type !== "private")
     ) {
       return null;
@@ -31,7 +28,6 @@ export function getStoredRoomSessionContext(): RoomSessionContext | null {
 
     return {
       roomId: parsed.roomId,
-      publicRoomNumber: parsed.publicRoomNumber ?? null,
       type: parsed.type,
     };
   } catch {

--- a/frontend/src/pages/lobby/LobbyPage.tsx
+++ b/frontend/src/pages/lobby/LobbyPage.tsx
@@ -1,4 +1,4 @@
-﻿import { useCallback, useEffect, useRef, useState } from "react";
+﻿import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { authApi, logoutToLobby } from "@/features/auth";
 import { landingApi } from "@/features/landing/api/landing.api";
@@ -28,6 +28,26 @@ type AuthState = "authenticated" | "guest" | "unknown";
 type LobbyTab = "completed" | "rooms";
 type CompletedScope = "plaza" | "public";
 type CompletedPreset = "today" | "7d" | "30d";
+type RoomTypeFilter = "all" | "public" | "private";
+type PixelPerfectPreviewDimensions = {
+  width: number;
+  height: number;
+};
+
+function getPixelPerfectPreviewDimensions(params: {
+  gridX: number;
+  gridY: number;
+  maxLongestSide: number;
+}): PixelPerfectPreviewDimensions {
+  const { gridX, gridY, maxLongestSide } = params;
+  const longestSide = Math.max(gridX, gridY);
+  const scale = Math.max(1, Math.floor(maxLongestSide / longestSide));
+
+  return {
+    width: gridX * scale,
+    height: gridY * scale,
+  };
+}
 
 function buildCompletedRange(preset: CompletedPreset) {
   const now = new Date();
@@ -96,6 +116,7 @@ export default function LobbyPage() {
   const [enterModalOpen, setEnterModalOpen] = useState(false);
   const [createLoading, setCreateLoading] = useState(false);
   const [enterLoading, setEnterLoading] = useState(false);
+  const [roomTypeFilter, setRoomTypeFilter] = useState<RoomTypeFilter>("all");
   const [generatedAccessCode, setGeneratedAccessCode] = useState<string | null>(
     null,
   );
@@ -121,16 +142,20 @@ export default function LobbyPage() {
     useState<LandingCurrentGame | null>(null);
   const [plazaLoading, setPlazaLoading] = useState(false);
   const [plazaError, setPlazaError] = useState<string | null>(null);
+  const [plazaPreviewHostWidth, setPlazaPreviewHostWidth] = useState<number | null>(
+    null,
+  );
 
   const [roomLifecycleNoticeReason, setRoomLifecycleNoticeReason] = useState<
     "expired" | "terminated_by_owner" | null
   >(() => consumeStoredRoomLifecycleNotice());
   const rightPanelRef = useRef<HTMLElement | null>(null);
+  const plazaPreviewHostRef = useRef<HTMLDivElement | null>(null);
   const [leftPanelHeight, setLeftPanelHeight] = useState<number | null>(null);
 
   const {
     rooms,
-    selectedRoomNumber,
+    selectedRoomId,
     selectedRoomDetail,
     loading,
     error,
@@ -138,7 +163,16 @@ export default function LobbyPage() {
     detailError,
     loadRooms,
     loadRoomDetail,
+    clearSelectedRoomDetail,
   } = useLobbyRooms();
+
+  const filteredRooms = useMemo(() => {
+    if (roomTypeFilter === "all") {
+      return rooms;
+    }
+
+    return rooms.filter((room) => room.type === roomTypeFilter);
+  }, [roomTypeFilter, rooms]);
 
   const refreshAuthState = useCallback(async () => {
     try {
@@ -226,16 +260,38 @@ export default function LobbyPage() {
     }
 
     void loadRooms().then((loadedRooms) => {
-      if (selectedRoomNumber !== null) {
-        void loadRoomDetail(selectedRoomNumber);
+      if (selectedRoomId !== null) {
+        void loadRoomDetail(selectedRoomId);
         return;
       }
 
       if (loadedRooms.length > 0) {
-        void loadRoomDetail(loadedRooms[0].publicRoomNumber);
+        void loadRoomDetail(loadedRooms[0].roomId);
       }
     });
-  }, [authState, loadRoomDetail, loadRooms, selectedRoomNumber]);
+  }, [authState, loadRoomDetail, loadRooms, selectedRoomId]);
+
+  useEffect(() => {
+    if (selectedRoomId === null) {
+      return;
+    }
+
+    if (filteredRooms.some((room) => room.roomId === selectedRoomId)) {
+      return;
+    }
+
+    if (filteredRooms.length > 0) {
+      void loadRoomDetail(filteredRooms[0].roomId);
+      return;
+    }
+
+    clearSelectedRoomDetail();
+  }, [
+    clearSelectedRoomDetail,
+    filteredRooms,
+    loadRoomDetail,
+    selectedRoomId,
+  ]);
 
   useEffect(() => {
     if (activeTab !== "completed") {
@@ -302,6 +358,39 @@ export default function LobbyPage() {
     };
   }, [activeTab, authState, plazaCurrentGame, plazaLoading, plazaError]);
 
+  useEffect(() => {
+    const element = plazaPreviewHostRef.current;
+
+    if (!element || typeof ResizeObserver === "undefined") {
+      return;
+    }
+
+    const updateWidth = () => {
+      setPlazaPreviewHostWidth(element.clientWidth);
+    };
+
+    updateWidth();
+
+    const observer = new ResizeObserver(() => {
+      updateWidth();
+    });
+
+    observer.observe(element);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [plazaCurrentGame, plazaLoading, plazaError]);
+
+  const plazaPreviewDimensions =
+    plazaCurrentGame && plazaPreviewHostWidth
+      ? getPixelPerfectPreviewDimensions({
+          gridX: plazaCurrentGame.gridX,
+          gridY: plazaCurrentGame.gridY,
+          maxLongestSide: plazaPreviewHostWidth,
+        })
+      : null;
+
   const requireLogin = useCallback(async (): Promise<boolean> => {
     if (authState === "authenticated") {
       return true;
@@ -326,7 +415,6 @@ export default function LobbyPage() {
   const enterRoomFromResponse = useCallback(
     (room: {
       roomId: number;
-      publicRoomNumber: number;
       type: "public" | "private";
     }) => {
       setStoredRoomSessionContext(toRoomSessionContext(room));
@@ -404,7 +492,7 @@ export default function LobbyPage() {
     setCreateLoading(true);
 
     try {
-      const { data } = await roomApi.enterPrivateRoom(createdPrivateAccessCode);
+      const { data } = await roomApi.enterRoom(createdPrivateAccessCode);
       setCreateModalOpen(false);
       setGeneratedAccessCode(null);
       enterRoomFromResponse(data.room);
@@ -423,28 +511,7 @@ export default function LobbyPage() {
     await navigator.clipboard.writeText(generatedAccessCode);
   }, [generatedAccessCode]);
 
-  const handleEnterPublicRoom = useCallback(
-    async (publicRoomNumber: number) => {
-      if (!(await requireLogin())) {
-        return;
-      }
-
-      setEnterLoading(true);
-      setModalError(null);
-
-      try {
-        const { data } = await roomApi.enterPublicRoom(publicRoomNumber);
-        enterRoomFromResponse(data.room);
-      } catch (error) {
-        setModalError(getErrorMessage(error, t));
-      } finally {
-        setEnterLoading(false);
-      }
-    },
-    [enterRoomFromResponse, requireLogin, t],
-  );
-
-  const handleEnterPrivateRoom = useCallback(
+  const handleEnterRoomByAccessCode = useCallback(
     async (code?: string) => {
       if (!(await requireLogin())) {
         return;
@@ -455,7 +522,7 @@ export default function LobbyPage() {
 
       try {
         const accessCode = (code ?? privateAccessCode).trim();
-        const { data } = await roomApi.enterPrivateRoom(accessCode);
+        const { data } = await roomApi.enterRoom(accessCode);
         setEnterModalOpen(false);
         setPrivateAccessCode("");
         enterRoomFromResponse(data.room);
@@ -468,29 +535,20 @@ export default function LobbyPage() {
     [enterRoomFromResponse, privateAccessCode, requireLogin, t],
   );
 
-  const handleResolveRoomNumber = useCallback(
-    async (publicRoomNumber: number): Promise<void> => {
+  const handleEnterPublicRoom = useCallback(
+    async (roomId: number) => {
       if (!(await requireLogin())) {
-        throw new Error("LOGIN_REQUIRED");
+        return;
       }
 
       setEnterLoading(true);
       setModalError(null);
 
       try {
-        const { data } = await roomApi.getRoomDetail(publicRoomNumber);
-
-        if (data.room.type === "private") {
-          setModalError(t("lobby.error.privateCodePrompt"));
-          return;
-        }
-
-        const entered = await roomApi.enterPublicRoom(publicRoomNumber);
-        enterRoomFromResponse(entered.data.room);
-        setEnterModalOpen(false);
+        const { data } = await roomApi.enterPublicRoomById(roomId);
+        enterRoomFromResponse(data.room);
       } catch (error) {
         setModalError(getErrorMessage(error, t));
-        throw error;
       } finally {
         setEnterLoading(false);
       }
@@ -499,9 +557,9 @@ export default function LobbyPage() {
   );
 
   const handleSelectRoom = useCallback(
-    (publicRoomNumber: number) => {
+    (roomId: number) => {
       setPrivateAccessCode("");
-      void loadRoomDetail(publicRoomNumber);
+      void loadRoomDetail(roomId);
     },
     [loadRoomDetail],
   );
@@ -528,7 +586,10 @@ export default function LobbyPage() {
   }, [navigate]);
 
   return (
-    <main className="min-h-screen bg-[#f7f2eb] p-[10px] text-[#272E37]">
+    <main
+      className="min-h-screen bg-[#f7f2eb] p-[10px] text-[#272E37]"
+      style={{ colorScheme: "light" }}
+    >
       <div className="flex justify-end">
         <div className="flex shrink-0 rounded-full border border-[#d9cdc1] bg-white p-1 shadow-[0_12px_32px_rgba(39,46,55,0.08)]">
           <button
@@ -584,6 +645,31 @@ export default function LobbyPage() {
             ))}
           </div>
 
+          {activeTab === "rooms" ? (
+            <div className="mt-4 flex flex-wrap gap-2">
+              {(
+                [
+                  ["all", t("lobby.roomList.filter.all")],
+                  ["public", t("lobby.roomList.filter.public")],
+                  ["private", t("lobby.roomList.filter.private")],
+                ] as const
+              ).map(([value, label]) => (
+                <button
+                  key={value}
+                  type="button"
+                  onClick={() => setRoomTypeFilter(value)}
+                  className={`rounded-full px-3 py-1.5 text-sm font-semibold ${
+                    roomTypeFilter === value
+                      ? "bg-[#272E37] text-white"
+                      : "border border-[#d9cdc1] bg-white text-[#5f6368]"
+                  }`}
+                >
+                  {label}
+                </button>
+              ))}
+            </div>
+          ) : null}
+
           <div className="mt-5 min-h-0 flex-1">
             {activeTab === "completed" ? (
               <CompletedCanvasSection
@@ -597,8 +683,8 @@ export default function LobbyPage() {
               />
             ) : (
               <RoomListSection
-                rooms={rooms}
-                selectedRoomNumber={selectedRoomNumber}
+                rooms={filteredRooms}
+                selectedRoomId={selectedRoomId}
                 selectedRoomDetail={selectedRoomDetail}
                 loading={loading}
                 error={error}
@@ -608,7 +694,7 @@ export default function LobbyPage() {
                 onChangePrivateAccessCode={setPrivateAccessCode}
                 onSelectRoom={handleSelectRoom}
                 onEnterPublicRoom={handleEnterPublicRoom}
-                onEnterPrivateRoom={handleEnterPrivateRoom}
+                onEnterPrivateRoom={handleEnterRoomByAccessCode}
               />
             )}
           </div>
@@ -675,8 +761,11 @@ export default function LobbyPage() {
               <p className="mt-3 text-sm leading-6 text-white/88">{plazaError}</p>
             ) : plazaCurrentGame ? (
               <div className="mt-4 space-y-4">
-                <div className="overflow-hidden rounded-[24px] bg-white/12 p-3">
-                  <div className="overflow-hidden rounded-[20px] bg-white">
+                <div
+                  ref={plazaPreviewHostRef}
+                  className="rounded-[24px] bg-white/12 p-3"
+                >
+                  <div className="overflow-auto rounded-[20px] bg-white">
                     <img
                       src={
                         plazaCurrentGame.snapshotUrl ??
@@ -684,8 +773,10 @@ export default function LobbyPage() {
                         undefined
                       }
                       alt={t("lobby.plaza.previewAlt")}
-                      className="block h-full w-full"
+                      className="mx-auto block"
                       style={{ imageRendering: "pixelated" }}
+                      width={plazaPreviewDimensions?.width}
+                      height={plazaPreviewDimensions?.height}
                       draggable={false}
                     />
                   </div>
@@ -801,10 +892,8 @@ export default function LobbyPage() {
         loading={enterLoading}
         error={modalError}
         onClose={handleCloseEnterModal}
-        onResolveRoomNumber={handleResolveRoomNumber}
-        onEnterPrivateRoom={handleEnterPrivateRoom}
+        onEnterRoom={handleEnterRoomByAccessCode}
       />
     </main>
   );
 }
-

--- a/frontend/src/shared/i18n/resources.ts
+++ b/frontend/src/shared/i18n/resources.ts
@@ -97,7 +97,7 @@ export const resources: Record<Locale, Record<string, string>> = {
     "lobby.tab.completed": "완성된 캔버스",
     "lobby.tab.rooms": "방 목록",
     "lobby.error.roomExpired": "현재 만료된 방입니다.",
-    "lobby.error.roomNotFound": "존재하지 않는 방 번호입니다.",
+    "lobby.error.roomNotFound": "존재하지 않는 입장 코드입니다.",
     "lobby.error.activeLimitReached": "동시에 생성할 수 있는 방은 최대 2개입니다.",
     "lobby.error.accessCodeRequired": "입장 코드를 입력해 주세요.",
     "lobby.error.privateCodePrompt": "비공개방은 입장 코드를 입력해야 합니다.",
@@ -124,6 +124,10 @@ export const resources: Record<Locale, Record<string, string>> = {
     "lobby.completed.participantList": "참여자 목록",
     "lobby.roomList.title": "방 목록",
     "lobby.roomList.loading": "불러오는 중...",
+    "lobby.roomList.empty": "생성된 방이 없습니다.",
+    "lobby.roomList.filter.all": "전체",
+    "lobby.roomList.filter.public": "공개방",
+    "lobby.roomList.filter.private": "비공개방",
     "lobby.roomList.noneSelected": "선택된 방이 없습니다.",
     "lobby.roomList.detailLoading": "방 정보를 불러오는 중...",
     "lobby.roomList.owner": "내 방",
@@ -164,8 +168,8 @@ export const resources: Record<Locale, Record<string, string>> = {
     "lobby.actions.enterRoom": "방 입장",
     "lobby.roomEnter.title": "방 입장",
     "lobby.roomEnter.close": "닫기",
-    "lobby.roomEnter.description": "방 번호 또는 비공개 방 입장 코드를 입력해주세요.",
-    "lobby.roomEnter.placeholder": "방 번호 또는 입장 코드 입력",
+    "lobby.roomEnter.description": "입장 코드를 입력해주세요.",
+    "lobby.roomEnter.placeholder": "입장 코드 입력",
     "lobby.roomEnter.enter": "입장",
     "lobby.roomEnter.entering": "입장 중...",
 
@@ -374,7 +378,7 @@ export const resources: Record<Locale, Record<string, string>> = {
     "lobby.roomCreate.phase.roundStartWait": "라운드 시작 대기 시간",
     "lobby.roomCreate.privateAccessCodeTitle": "비공개 방 안내",
     "lobby.roomCreate.privateAccessCodeDescription":
-      "생성 시 입장 코드가 발급되며, 해당 코드로 방에 입장할 수 있습니다.\n입장 코드는 로비의 내 방 세부 정보와 방 입장 후 설정 메뉴에서 다시 확인할 수 있습니다.",
+      "생성 시 입장 코드가 발급되며, 해당 코드로 방에 입장할 수 있습니다.\n입장 코드는 방 입장 후 게임 내 설정 메뉴에서 다시 확인할 수 있습니다.",
     "lobby.roomCreate.unit.seconds": "초",
   },
   en: {
@@ -472,7 +476,7 @@ export const resources: Record<Locale, Record<string, string>> = {
     "lobby.tab.completed": "Completed canvases",
     "lobby.tab.rooms": "Rooms",
     "lobby.error.roomExpired": "This room has expired.",
-    "lobby.error.roomNotFound": "This room number does not exist.",
+    "lobby.error.roomNotFound": "This access code does not exist.",
     "lobby.error.activeLimitReached":
       "You can create up to two active rooms at the same time.",
     "lobby.error.accessCodeRequired": "Please enter an access code.",
@@ -507,7 +511,7 @@ export const resources: Record<Locale, Record<string, string>> = {
     "lobby.roomCreate.phase.roundStartWait": "Round start wait",
     "lobby.roomCreate.privateAccessCodeTitle": "Private room notice",
     "lobby.roomCreate.privateAccessCodeDescription":
-      "When a room is created, an access code is issued and can be used to enter the room. You can check the code again from your room details in the lobby or from the settings menu after entering the room.",
+      "When a room is created, an access code is issued and can be used to enter the room. You can check the code again from the in-game settings menu after entering the room.",
     "lobby.roomCreate.unit.seconds": "s",
     "lobby.login.usernamePlaceholder": "Username",
     "lobby.login.passwordPlaceholder": "Password",
@@ -531,6 +535,10 @@ export const resources: Record<Locale, Record<string, string>> = {
     "lobby.completed.participantList": "Participants",
     "lobby.roomList.title": "Room list",
     "lobby.roomList.loading": "Loading...",
+    "lobby.roomList.empty": "No rooms have been created.",
+    "lobby.roomList.filter.all": "All",
+    "lobby.roomList.filter.public": "Public",
+    "lobby.roomList.filter.private": "Private",
     "lobby.roomList.noneSelected": "No room selected.",
     "lobby.roomList.detailLoading": "Loading room details...",
     "lobby.roomList.owner": "My room",
@@ -571,8 +579,8 @@ export const resources: Record<Locale, Record<string, string>> = {
     "lobby.actions.enterRoom": "Enter room",
     "lobby.roomEnter.title": "Enter room",
     "lobby.roomEnter.close": "Close",
-    "lobby.roomEnter.description": "Enter a room number or a private room access code.",
-    "lobby.roomEnter.placeholder": "Enter room number or access code",
+    "lobby.roomEnter.description": "Enter an access code.",
+    "lobby.roomEnter.placeholder": "Enter access code",
     "lobby.roomEnter.enter": "Enter",
     "lobby.roomEnter.entering": "Entering...",
 
@@ -761,4 +769,3 @@ export const resources: Record<Locale, Record<string, string>> = {
     "loginBoard.patchType.breaking": "Breaking",
   },
 };
-


### PR DESCRIPTION
## 관련 이슈
- Close #435 

## 개요

로비와 광장 관련 동작을 정리했다.
광장 자동 생성이 다른 방 게임 진행 상태에 막히지 않도록 수정했고, 방 입장 흐름은 공개방/비공개방 모두 입장코드 기준으로 통일했다.
로비 UI도 브라우저 색상 설정 영향, 방 목록 표시, 완성된 캔버스 프리뷰 배치를 함께 정리했다.

## 변경사항

- 광장 캔버스 생성 시 진행 중인 일반 방 캔버스와 무관하게 광장 캔버스만 중복 검사하도록 수정
- 공개방과 비공개방 모두 `accessCode`를 발급하도록 변경
- 로비 방 입장 모달을 입장코드 입력 방식으로 통일
- 공개방 생성 시 자동 입장 흐름 유지
- 공개방 상세에는 `방 참여` 버튼을 제공하고, 비공개방은 내 방일 때만 입장코드 노출
- `publicRoomNumber` 기반 사용자 흐름과 세션/프론트 사용 제거
- `/lobby`를 라이트 테마 기준으로 고정하고 입력 UI 색상 영향 정리
- 로비 광장 카드 이미지를 정수배 기준으로 렌더링하도록 조정
- 완성된 캔버스 프리뷰 `webp`를 정수배 크기로 표시하고, 현재 이미지 크기를 유지한 채 4개가 나란히 보이도록 카드 폭/여백 조정
- 방 목록/완성된 캔버스 하위 제목 제거
- 방 목록 empty 문구 추가 및 중앙 정렬
- 방 목록에 전체/공개방/비공개방 필터 추가
- 게임 내 설정 버튼 색상을 `#5A8393`로 적용

## 코드 흐름

- `backend/src/modules/canvas/canvas.service.ts`
  광장 생성 전 검사 대상을 전체 진행 중 캔버스에서 진행 중 광장 캔버스로 좁혀 자동 생성 실패를 막음
- `backend/src/modules/room/*`
  방 생성 시 공개방도 입장코드를 발급하고, 입장 API는 입장코드 기준으로 통합
  공개방 상세 참여용 `roomId` 기반 입장 엔드포인트를 추가
  방 상세 응답에서는 비공개방 소유자만 입장코드를 확인할 수 있도록 분기
- `frontend/src/pages/lobby/LobbyPage.tsx`
  로비 탭 상태에 따라 방 목록 필터, 공개방 직접 참여, 광장 프리뷰 정수배 렌더링, 완성된 캔버스 레이아웃을 제어
- `frontend/src/features/room/*`
  로비 방 선택 기준을 `roomId`로 통일하고, 입장 모달과 세션 컨텍스트에서 방 번호 의존 제거
- `frontend/src/features/landing/*`, `frontend/src/features/lobby/components/CompletedCanvasSection.tsx`
  완성된 캔버스 `webp` 프리뷰를 grid 크기에 맞는 정수배로 렌더링하고, 카드 폭과 내부 패딩을 줄여 4열 배치를 유지

## 검증

- 프론트 `tsc --noEmit -p tsconfig.app.json` 통과
- 백엔드 `tsc --noEmit` 통과
- 브라우저 수동 검증은 별도 수행하지 않음

## 결정사항

- `publicRoomNumber`는 DB 컬럼 수준에서는 유지하되 사용자 입장 흐름에서는 사용하지 않음
- 공개방 생성 후에는 별도 코드 확인 모달 없이 바로 입장하고, 코드는 게임 내 설정에서만 확인 가능하게 유지
- 완성된 캔버스 프리뷰는 `webp` 표시 크기를 줄이지 않고, 카드 레이아웃과 여백을 조정하는 방식으로 4열 배치를 맞춤

## 리뷰 포인트

- 공개방 생성 후 자동 입장과 공개방 상세 `방 참여` 버튼 흐름이 충돌 없이 동작하는지
- 비공개방에서 소유자만 입장코드를 볼 수 있는지
- 광장 종료 후 다른 방 게임이 진행 중이어도 다음 광장이 정상 생성되는지