### PR TITLE
feat: 일일 통계 이벤트 타입과 집계 기준을 행동 단위로 정리

### DIFF
--- a/backend/src/database/migrations/1784800000000-RenameVisitEventTypes.ts
+++ b/backend/src/database/migrations/1784800000000-RenameVisitEventTypes.ts
@@ -1,0 +1,119 @@
+import type { MigrationInterface, QueryRunner } from "typeorm";
+
+const VISIT_EVENT_RENAMES = [
+  {
+    from: "site_visit",
+    to: "landing_visit",
+  },
+  {
+    from: "game_entry",
+    to: "room_visit",
+  },
+] as const;
+
+function buildAggregateMergeCondition(sourceAlias: string, targetAlias: string): string {
+  return `
+    ${sourceAlias}.bucket_date = ${targetAlias}.bucket_date
+    AND ${sourceAlias}.browser_language = ${targetAlias}.browser_language
+    AND ${sourceAlias}.time_zone = ${targetAlias}.time_zone
+    AND ${sourceAlias}.device_type = ${targetAlias}.device_type
+  `;
+}
+
+export class RenameVisitEventTypes1784800000000 implements MigrationInterface {
+  name = "RenameVisitEventTypes1784800000000";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    for (const rename of VISIT_EVENT_RENAMES) {
+      await queryRunner.query(
+        `
+          UPDATE "visit_event"
+          SET "event_type" = $1
+          WHERE "event_type" = $2
+        `,
+        [rename.to, rename.from],
+      );
+
+      await queryRunner.query(
+        `
+          UPDATE "visit_event_daily_aggregate" AS target
+          SET
+            "event_count" = target."event_count" + source."event_count",
+            "updated_at" = GREATEST(target."updated_at", source."updated_at")
+          FROM "visit_event_daily_aggregate" AS source
+          WHERE source."event_type" = $2
+            AND target."event_type" = $1
+            AND ${buildAggregateMergeCondition("source", "target")}
+        `,
+        [rename.to, rename.from],
+      );
+
+      await queryRunner.query(
+        `
+          DELETE FROM "visit_event_daily_aggregate" AS source
+          USING "visit_event_daily_aggregate" AS target
+          WHERE source."event_type" = $2
+            AND target."event_type" = $1
+            AND ${buildAggregateMergeCondition("source", "target")}
+        `,
+        [rename.to, rename.from],
+      );
+
+      await queryRunner.query(
+        `
+          UPDATE "visit_event_daily_aggregate"
+          SET "event_type" = $1
+          WHERE "event_type" = $2
+        `,
+        [rename.to, rename.from],
+      );
+    }
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    for (const rename of [...VISIT_EVENT_RENAMES].reverse()) {
+      await queryRunner.query(
+        `
+          UPDATE "visit_event"
+          SET "event_type" = $1
+          WHERE "event_type" = $2
+        `,
+        [rename.from, rename.to],
+      );
+
+      await queryRunner.query(
+        `
+          UPDATE "visit_event_daily_aggregate" AS target
+          SET
+            "event_count" = target."event_count" + source."event_count",
+            "updated_at" = GREATEST(target."updated_at", source."updated_at")
+          FROM "visit_event_daily_aggregate" AS source
+          WHERE source."event_type" = $2
+            AND target."event_type" = $1
+            AND ${buildAggregateMergeCondition("source", "target")}
+        `,
+        [rename.from, rename.to],
+      );
+
+      await queryRunner.query(
+        `
+          DELETE FROM "visit_event_daily_aggregate" AS source
+          USING "visit_event_daily_aggregate" AS target
+          WHERE source."event_type" = $2
+            AND target."event_type" = $1
+            AND ${buildAggregateMergeCondition("source", "target")}
+        `,
+        [rename.from, rename.to],
+      );
+
+      await queryRunner.query(
+        `
+          UPDATE "visit_event_daily_aggregate"
+          SET "event_type" = $1
+          WHERE "event_type" = $2
+        `,
+        [rename.from, rename.to],
+      );
+    }
+  }
+}

--- a/backend/src/entities/visit-event.entity.ts
+++ b/backend/src/entities/visit-event.entity.ts
@@ -1,8 +1,12 @@
 import { Column, CreateDateColumn, Entity, Index, PrimaryGeneratedColumn } from "typeorm";
 
 export enum VisitEventType {
-  SITE_VISIT = "site_visit",
-  GAME_ENTRY = "game_entry",
+  LANDING_VISIT = "landing_visit",
+  LOBBY_VISIT = "lobby_visit",
+  PLAZA_VISIT = "plaza_visit",
+  ROOM_VISIT = "room_visit",
+  PUBLIC_ROOM_CREATED = "public_room_created",
+  PRIVATE_ROOM_CREATED = "private_room_created",
 }
 
 export enum VisitDeviceType {

--- a/backend/src/modules/analytics/analytics-retention.service.ts
+++ b/backend/src/modules/analytics/analytics-retention.service.ts
@@ -31,6 +31,7 @@ export interface AnalyticsRollupDeviceTimeZoneEventCount {
 export interface AnalyticsRollupSummary {
   aggregateGroupCount: number;
   applied: boolean;
+  dailySignupCount: number;
   deviceTimeZoneEventCounts: AnalyticsRollupDeviceTimeZoneEventCount[];
   eventCounts: AnalyticsRetentionEventCount[];
   eligibleEventCount: number;
@@ -72,6 +73,10 @@ interface DeviceTimeZoneEventCountRow {
   deviceType: string;
   eventType: string;
   timeZone: string;
+}
+
+interface DailySignupCountRow {
+  count: string;
 }
 
 function resolveRollupUpperBound(before?: Date): Date {
@@ -152,6 +157,7 @@ async function loadDeviceTimeZoneEventCounts(
 
 async function loadRollupPreview(upperBound: Date): Promise<{
   aggregateGroupCount: number;
+  dailySignupCount: number;
   deviceTimeZoneEventCounts: AnalyticsRollupDeviceTimeZoneEventCount[];
   eligibleEventCount: number;
   eventCounts: AnalyticsRetentionEventCount[];
@@ -195,9 +201,20 @@ async function loadRollupPreview(upperBound: Date): Promise<{
     "rolled_up_at IS NULL AND entered_at < $1",
     [upperBound.toISOString()],
   );
+  const previousDayStart = new Date(upperBound.getTime() - DAY_MS);
+  const [dailySignupCountRow] = (await AppDataSource.query(
+    `
+      SELECT COUNT(*)::int AS "count"
+      FROM voter
+      WHERE "createdAt" >= $1
+        AND "createdAt" < $2
+    `,
+    [previousDayStart.toISOString(), upperBound.toISOString()],
+  )) as DailySignupCountRow[];
 
   return {
     aggregateGroupCount: Number(previewRow?.aggregateGroupCount ?? 0),
+    dailySignupCount: Number(dailySignupCountRow?.count ?? 0),
     deviceTimeZoneEventCounts,
     eligibleEventCount: Number(previewRow?.eligibleEventCount ?? 0),
     eventCounts,

--- a/backend/src/modules/analytics/analytics-rollup-telegram.service.ts
+++ b/backend/src/modules/analytics/analytics-rollup-telegram.service.ts
@@ -7,10 +7,21 @@ const TELEGRAM_API_BASE_URL = "https://api.telegram.org";
 const TELEGRAM_BOT_TOKEN_ENV = "TELEGRAM_BOT_TOKEN";
 const TELEGRAM_CHAT_ID_ENV = "TELEGRAM_CHAT_ID";
 const ROLLUP_NOTIFICATION_TIME_ZONE = "Asia/Seoul";
-const DETAILED_EVENT_TYPE_ORDER = ["site_visit", "game_entry"];
+const DETAILED_EVENT_TYPE_ORDER = [
+  "landing_visit",
+  "lobby_visit",
+  "plaza_visit",
+  "room_visit",
+  "public_room_created",
+  "private_room_created",
+];
 const VISIT_EVENT_TYPE_LABELS: Record<string, string> = {
-  game_entry: "\uac8c\uc784 \uc9c4\uc785",
-  site_visit: "\uc0ac\uc774\ud2b8 \ubc29\ubb38",
+  landing_visit: "\ub79c\ub529 \uc811\uc18d",
+  lobby_visit: "\ub85c\ube44 \uc811\uc18d",
+  plaza_visit: "\uad11\uc7a5 \uc811\uc18d",
+  private_room_created: "\ube44\uacf5\uac1c\ubc29 \uc0dd\uc131",
+  public_room_created: "\uacf5\uac1c\ubc29 \uc0dd\uc131",
+  room_visit: "\ubc29 \uc811\uc18d",
 };
 
 interface TelegramApiResponse {
@@ -54,15 +65,14 @@ function formatDetailedEventCounts(
     countsByEventType.set(eventCount.eventType, eventCount.count);
   }
 
-  const extraEventTypes = [...countsByEventType.keys()].filter(
-    (eventType) => !DETAILED_EVENT_TYPE_ORDER.includes(eventType),
+  const orderedEventTypes = DETAILED_EVENT_TYPE_ORDER.filter((eventType) =>
+    countsByEventType.has(eventType),
   );
-  const orderedEventTypes = [
-    ...DETAILED_EVENT_TYPE_ORDER,
-    ...extraEventTypes.sort((left, right) => left.localeCompare(right)),
-  ];
+  const extraEventTypes = [...countsByEventType.keys()]
+    .filter((eventType) => !DETAILED_EVENT_TYPE_ORDER.includes(eventType))
+    .sort((left, right) => left.localeCompare(right));
 
-  return orderedEventTypes
+  return [...orderedEventTypes, ...extraEventTypes]
     .map((eventType) => `${eventType}=${countsByEventType.get(eventType) ?? 0}`)
     .join(" | ");
 }
@@ -118,6 +128,7 @@ function buildRollupSummaryMessage(summary: AnalyticsRollupSummary): string {
     "KST \uae30\uc900 \ub370\uc77c\ub9ac \uc9d1\uacc4 \uc644\ub8cc",
     "",
     `- \uc9d1\uacc4 \uae30\uc900 \uc2dc\uac01: ${formatDateTimeKst(summary.upperBoundIso)} (${summary.upperBoundIso})`,
+    `- \uc77c\uc77c \uac00\uc785\ub7c9: ${summary.dailySignupCount}`,
     `- \uc9d1\uacc4 \ub300\uc0c1 \uc774\ubca4\ud2b8 \uc218: ${summary.eligibleEventCount}`,
     `- \uc9d1\uacc4 \uadf8\ub8f9 \uc218: ${summary.aggregateGroupCount}`,
     `- \ubc18\uc601\ub41c \uc9d1\uacc4 \uadf8\ub8f9 \uc218: ${summary.rolledUpGroupCount}`,

--- a/backend/src/scripts/analytics-rollup.ts
+++ b/backend/src/scripts/analytics-rollup.ts
@@ -53,6 +53,7 @@ function printSummary(summary: Awaited<
 >): void {
   console.log("[analytics:rollup] mode:", summary.applied ? "apply" : "dry-run");
   console.log("[analytics:rollup] upperBound:", summary.upperBoundIso);
+  console.log("[analytics:rollup] dailySignupCount:", summary.dailySignupCount);
   console.log("[analytics:rollup] eligibleEventCount:", summary.eligibleEventCount);
   console.log("[analytics:rollup] aggregateGroupCount:", summary.aggregateGroupCount);
   console.log(
@@ -83,7 +84,7 @@ async function main() {
     const summary = await analyticsRetentionService.rollupVisitEvents(options);
     printSummary(summary);
 
-    if (options.apply && summary.applied) {
+    if (options.apply) {
       try {
         await analyticsRollupTelegramService.sendRollupSummary(summary);
         console.log("[analytics:rollup] telegram notification sent");

--- a/backend/test/integration/analytics-retention.integration.test.ts
+++ b/backend/test/integration/analytics-retention.integration.test.ts
@@ -23,7 +23,7 @@ describe("analytics retention integration", () => {
 
   it("supports dry-run rollup without changing data", async () => {
     const oldEvent = visitEventRepository.create({
-      eventType: VisitEventType.SITE_VISIT,
+      eventType: VisitEventType.LANDING_VISIT,
       browserLanguage: "ko-KR",
       timeZone: "Asia/Seoul",
       deviceType: VisitDeviceType.DESKTOP,
@@ -50,28 +50,28 @@ describe("analytics retention integration", () => {
   it("rolls up eligible raw events and marks them as rolled up", async () => {
     await visitEventRepository.save([
       visitEventRepository.create({
-        eventType: VisitEventType.SITE_VISIT,
+        eventType: VisitEventType.LANDING_VISIT,
         browserLanguage: "ko-KR",
         timeZone: "Asia/Seoul",
         deviceType: VisitDeviceType.DESKTOP,
         enteredAt: new Date("2025-12-31T16:30:00.000Z"),
       }),
       visitEventRepository.create({
-        eventType: VisitEventType.SITE_VISIT,
+        eventType: VisitEventType.LANDING_VISIT,
         browserLanguage: "ko-KR",
         timeZone: "Asia/Seoul",
         deviceType: VisitDeviceType.DESKTOP,
         enteredAt: new Date("2026-01-01T02:00:00.000Z"),
       }),
       visitEventRepository.create({
-        eventType: VisitEventType.GAME_ENTRY,
+        eventType: VisitEventType.ROOM_VISIT,
         browserLanguage: "en-US",
         timeZone: "UTC",
         deviceType: VisitDeviceType.MOBILE,
         enteredAt: new Date("2026-01-02T01:00:00.000Z"),
       }),
       visitEventRepository.create({
-        eventType: VisitEventType.GAME_ENTRY,
+        eventType: VisitEventType.ROOM_VISIT,
         browserLanguage: "ko-KR",
         timeZone: "Asia/Seoul",
         deviceType: VisitDeviceType.DESKTOP,
@@ -90,8 +90,8 @@ describe("analytics retention integration", () => {
     expect(summary.rolledUpGroupCount).toBe(2);
     expect(summary.markedEventCount).toBe(3);
     expect(summary.eventCounts).toEqual([
-      { eventType: VisitEventType.GAME_ENTRY, count: 1 },
-      { eventType: VisitEventType.SITE_VISIT, count: 2 },
+      { eventType: VisitEventType.LANDING_VISIT, count: 2 },
+      { eventType: VisitEventType.ROOM_VISIT, count: 1 },
     ]);
 
     const events = await visitEventRepository.find({
@@ -102,7 +102,7 @@ describe("analytics retention integration", () => {
     expect(events.slice(0, 3).every((event) => event.rolledUpAt instanceof Date)).toBe(
       true,
     );
-    expect(events[3]?.eventType).toBe(VisitEventType.GAME_ENTRY);
+    expect(events[3]?.eventType).toBe(VisitEventType.ROOM_VISIT);
     expect(events[3]?.browserLanguage).toBe("ko-KR");
     expect(events[3]?.rolledUpAt).toBeNull();
 
@@ -117,7 +117,7 @@ describe("analytics retention integration", () => {
     expect(aggregateRows).toHaveLength(2);
     expect(aggregateRows[0]).toMatchObject({
       bucketDate: "2026-01-01",
-      eventType: VisitEventType.SITE_VISIT,
+      eventType: VisitEventType.LANDING_VISIT,
       browserLanguage: "ko-KR",
       timeZone: "Asia/Seoul",
       deviceType: VisitDeviceType.DESKTOP,
@@ -125,7 +125,7 @@ describe("analytics retention integration", () => {
     });
     expect(aggregateRows[1]).toMatchObject({
       bucketDate: "2026-01-02",
-      eventType: VisitEventType.GAME_ENTRY,
+      eventType: VisitEventType.ROOM_VISIT,
       browserLanguage: "en-US",
       timeZone: "UTC",
       deviceType: VisitDeviceType.MOBILE,
@@ -136,7 +136,7 @@ describe("analytics retention integration", () => {
   it("deletes only rolled-up raw events that are older than the retention cutoff", async () => {
     await visitEventRepository.save([
       visitEventRepository.create({
-        eventType: VisitEventType.SITE_VISIT,
+        eventType: VisitEventType.LANDING_VISIT,
         browserLanguage: "ko-KR",
         timeZone: "Asia/Seoul",
         deviceType: VisitDeviceType.DESKTOP,
@@ -144,7 +144,7 @@ describe("analytics retention integration", () => {
         rolledUpAt: new Date("2026-01-02T00:00:00.000Z"),
       }),
       visitEventRepository.create({
-        eventType: VisitEventType.GAME_ENTRY,
+        eventType: VisitEventType.ROOM_VISIT,
         browserLanguage: "en-US",
         timeZone: "UTC",
         deviceType: VisitDeviceType.MOBILE,
@@ -152,7 +152,7 @@ describe("analytics retention integration", () => {
         rolledUpAt: null,
       }),
       visitEventRepository.create({
-        eventType: VisitEventType.GAME_ENTRY,
+        eventType: VisitEventType.ROOM_VISIT,
         browserLanguage: "ko-KR",
         timeZone: "Asia/Seoul",
         deviceType: VisitDeviceType.DESKTOP,
@@ -172,7 +172,7 @@ describe("analytics retention integration", () => {
     expect(summary.pendingUnrolledEventCount).toBe(1);
     expect(summary.deletedCount).toBe(1);
     expect(summary.eventCounts).toEqual([
-      { eventType: VisitEventType.SITE_VISIT, count: 1 },
+      { eventType: VisitEventType.LANDING_VISIT, count: 1 },
     ]);
 
     const remainingEvents = await visitEventRepository.find({
@@ -183,7 +183,7 @@ describe("analytics retention integration", () => {
     expect(
       remainingEvents.some(
         (event) =>
-          event.eventType === VisitEventType.GAME_ENTRY &&
+          event.eventType === VisitEventType.ROOM_VISIT &&
           event.browserLanguage === "en-US" &&
           event.rolledUpAt === null,
       ),
@@ -191,7 +191,7 @@ describe("analytics retention integration", () => {
     expect(
       remainingEvents.some(
         (event) =>
-          event.eventType === VisitEventType.GAME_ENTRY &&
+          event.eventType === VisitEventType.ROOM_VISIT &&
           event.browserLanguage === "ko-KR" &&
           event.rolledUpAt instanceof Date,
       ),

--- a/backend/test/integration/analytics.integration.test.ts
+++ b/backend/test/integration/analytics.integration.test.ts
@@ -10,9 +10,9 @@ describe("analytics integration", () => {
   const suite = setupIntegrationSuite();
   const visitEventRepository = AppDataSource.getRepository(VisitEvent);
 
-  it("stores a site visit event", async () => {
+  it("stores a landing visit event", async () => {
     const response = await suite.request().post("/analytics/events").send({
-      eventType: "site_visit",
+      eventType: "landing_visit",
       browserLanguage: "ko-KR",
       timeZone: "Asia/Seoul",
       deviceType: "desktop",
@@ -22,7 +22,7 @@ describe("analytics integration", () => {
     expect(response.body).toEqual({ message: "TRACK_VISIT_EVENT_SUCCESS" });
 
     const event = await visitEventRepository.findOneByOrFail({
-      eventType: VisitEventType.SITE_VISIT,
+      eventType: VisitEventType.LANDING_VISIT,
     });
 
     expect(event.browserLanguage).toBe("ko-KR");

--- a/frontend/src/features/analytics/api/analytics.api.ts
+++ b/frontend/src/features/analytics/api/analytics.api.ts
@@ -1,6 +1,12 @@
 import api from "@/shared/api/client";
 
-export type VisitEventType = "site_visit" | "game_entry";
+export type VisitEventType =
+  | "landing_visit"
+  | "lobby_visit"
+  | "plaza_visit"
+  | "room_visit"
+  | "public_room_created"
+  | "private_room_created";
 export type VisitDeviceType = "desktop" | "mobile" | "tablet" | "other";
 
 export interface TrackVisitEventRequest {

--- a/frontend/src/features/analytics/hooks/use-track-visit-event.ts
+++ b/frontend/src/features/analytics/hooks/use-track-visit-event.ts
@@ -1,7 +1,7 @@
 import { useEffect } from "react";
 import { useLocation } from "react-router-dom";
-import { analyticsApi, type VisitEventType } from "../api/analytics.api";
-import { buildVisitEventPayload } from "../model/visit-event";
+import type { VisitEventType } from "../api/analytics.api";
+import { trackVisitEvent } from "../model/visit-event";
 
 function buildPageViewStorageKey(eventType: VisitEventType, locationKey: string) {
   return `votedots:analytics:${eventType}:${locationKey}`;
@@ -23,7 +23,7 @@ export function useTrackVisitEvent(eventType: VisitEventType) {
 
     window.sessionStorage.setItem(storageKey, "sent");
 
-    void analyticsApi.trackVisitEvent(buildVisitEventPayload(eventType)).catch(() => {
+    void trackVisitEvent(eventType).catch(() => {
       window.sessionStorage.removeItem(storageKey);
     });
   }, [eventType, location.key]);

--- a/frontend/src/features/analytics/model/visit-event.ts
+++ b/frontend/src/features/analytics/model/visit-event.ts
@@ -3,6 +3,7 @@ import type {
   VisitDeviceType,
   VisitEventType,
 } from "../api/analytics.api";
+import { analyticsApi } from "../api/analytics.api";
 
 function resolveDeviceType(userAgent: string): VisitDeviceType {
   const normalizedUserAgent = userAgent.toLowerCase();
@@ -48,4 +49,8 @@ export function buildVisitEventPayload(
     timeZone,
     deviceType: resolveDeviceType(userAgent),
   };
+}
+
+export async function trackVisitEvent(eventType: VisitEventType) {
+  return analyticsApi.trackVisitEvent(buildVisitEventPayload(eventType));
 }

--- a/frontend/src/pages/canvas/CanvasPage.tsx
+++ b/frontend/src/pages/canvas/CanvasPage.tsx
@@ -99,9 +99,11 @@ function buildIntroGuideSeenStorageKey(canvasId: number): string {
 export default function CanvasPage({ sessionSourceApi }: CanvasPageProps) {
   const navigate = useNavigate();
   const { locale, t } = useI18n();
+  const gameplayEntryEventType =
+    sessionSourceApi.key === "plaza" ? "plaza_visit" : "room_visit";
 
   usePageRootClass("page-shell-root");
-  useTrackVisitEvent("game_entry");
+  useTrackVisitEvent(gameplayEntryEventType);
   const [currentVoterUuid, setCurrentVoterUuid] = useState<string | null>(null);
   const [selectionGuideState, dispatchSelectionGuide] = useReducer(
     selectionGuideReducer,

--- a/frontend/src/pages/landing/LandingPage.tsx
+++ b/frontend/src/pages/landing/LandingPage.tsx
@@ -85,7 +85,7 @@ export default function LandingPage({ locale }: LandingPageProps) {
 
   usePageRootClass("page-shell-root");
   usePublicSiteLocale(locale);
-  useTrackVisitEvent("site_visit");
+  useTrackVisitEvent("landing_visit");
 
   useEffect(() => {
     let cancelled = false;

--- a/frontend/src/pages/lobby/LobbyPage.tsx
+++ b/frontend/src/pages/lobby/LobbyPage.tsx
@@ -1,5 +1,7 @@
 ﻿import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
+import { useTrackVisitEvent } from "@/features/analytics/hooks/use-track-visit-event";
+import { trackVisitEvent } from "@/features/analytics/model/visit-event";
 import { authApi, logoutToLobby } from "@/features/auth";
 import { landingApi } from "@/features/landing/api/landing.api";
 import type {
@@ -105,6 +107,7 @@ function getErrorMessage(
 export default function LobbyPage() {
   const navigate = useNavigate();
   usePageRootClass("page-shell-root");
+  useTrackVisitEvent("lobby_visit");
 
   const { locale, setLocale, t } = useI18n();
   const [authState, setAuthState] = useState<AuthState>("unknown");
@@ -465,6 +468,11 @@ export default function LobbyPage() {
 
       try {
         const { data } = await roomApi.createRoom(payload);
+        void trackVisitEvent(
+          payload.type === "public"
+            ? "public_room_created"
+            : "private_room_created",
+        ).catch(() => {});
         await loadRooms();
 
         if (data.entered) {


### PR DESCRIPTION
## 관련 이슈
- Close #437 

## 변경 내용

- 랜딩, 로비, 광장, 방 접속 및 공개방/비공개방 생성 기준으로 일일 통계 이벤트 포인트를 확장
- 기존 `site_visit`, `game_entry` 저장값을 `landing_visit`, `room_visit`로 통일
- 기존 `visit_event`, `visit_event_daily_aggregate` 데이터 이관용 migration 추가
- 일일 가입 건수를 `voter.createdAt` 기준으로 집계하도록 rollup summary 확장
- Telegram 일일 통계 메시지를 `사용자 수`가 아닌 `행동 건수` 기준 문구로 정리

## 기대 동작

- 랜딩 접속, 로비 접속, 광장 접속, 방 접속, 공개방 생성, 비공개방 생성이 각각 분리된 이벤트 타입으로 기록된다
- 기존 저장 데이터도 migration 실행 후 새 이벤트 타입 기준으로 일관되게 정리된다
- 일일 통계에서 가입량은 이벤트가 아니라 실제 회원 생성 건수 기준으로 집계된다
- Telegram 통계 메시지는 접속 수, 생성 건수, 가입 건수처럼 행동 총량 기준으로 표시된다

## 확인 내용

- `frontend tsc -b` 통과
- `backend tsc --noEmit` 통과
- 실행 필요: `npm run build && npm run migration:run`
- 실행 필요: `analytics:rollup --apply` 결과와 Telegram 메시지 확인