### PR TITLE
feat: 랜딩 페이지 모바일 레이아웃과 탭형 프리뷰를 최적화

### DIFF
--- a/frontend/src/features/landing/components/FeaturedPreviewCard.tsx
+++ b/frontend/src/features/landing/components/FeaturedPreviewCard.tsx
@@ -8,7 +8,6 @@ export interface FeaturedPreviewCardLabels {
   participants: string;
   votes: string;
   topVoter: string;
-  participantList: string;
 }
 
 interface FeaturedPreviewCardProps {
@@ -30,7 +29,6 @@ export default function FeaturedPreviewCard({
     locale === "ko" ? "ko-KR" : "en-US",
   );
   const preview = item?.preview ?? null;
-  const participantNames = preview?.participants ?? [];
 
   return (
     <article className="mx-auto w-[332px] overflow-hidden rounded-[30px] bg-white shadow-[0_24px_70px_rgba(39,46,55,0.08)]">
@@ -83,32 +81,6 @@ export default function FeaturedPreviewCard({
                     )})`
                   : "-"}
               </p>
-            </div>
-          </div>
-
-          <div className="space-y-1.5 text-center text-sm leading-6 text-[#51545a]">
-            <div>
-              <p className="font-semibold text-[#7b6b62]">
-                {labels.participantList}
-              </p>
-              <div className="mt-1.5 rounded-2xl bg-white px-3 py-2 shadow-[inset_0_0_0_1px_rgba(234,215,200,0.95)]">
-                {participantNames.length > 0 ? (
-                  <div className="flex h-24 flex-wrap content-start justify-center gap-2 overflow-y-auto pr-1">
-                    {participantNames.map((name, index) => (
-                      <span
-                        key={`${name}-${index}`}
-                        className="inline-flex items-center rounded-full bg-[#f6ede5] px-3 py-1 text-xs font-medium text-[#51545a]"
-                      >
-                        {name}
-                      </span>
-                    ))}
-                  </div>
-                ) : (
-                  <p className="flex h-24 items-center justify-center text-sm text-[#7b6b62]">
-                    -
-                  </p>
-                )}
-              </div>
             </div>
           </div>
         </div>

--- a/frontend/src/features/lobby/components/CompletedCanvasSection.tsx
+++ b/frontend/src/features/lobby/components/CompletedCanvasSection.tsx
@@ -117,7 +117,6 @@ export default function CompletedCanvasSection({
                   participants: t("lobby.completed.participants"),
                   votes: t("lobby.completed.votes"),
                   topVoter: t("lobby.completed.topVoter"),
-                  participantList: t("lobby.completed.participantList"),
                 }}
               />
             ))}

--- a/frontend/src/pages/landing/LandingPage.tsx
+++ b/frontend/src/pages/landing/LandingPage.tsx
@@ -23,6 +23,17 @@ const SMALL_SNAPSHOT_SIZE = 256;
 const MOBILE_BREAKPOINT_MEDIA_QUERY = "(max-width: 767px)";
 const MOBILE_SWIPE_THRESHOLD_PX = 40;
 
+function readMobileLayoutMatch(): boolean {
+  if (
+    typeof window === "undefined" ||
+    typeof window.matchMedia !== "function"
+  ) {
+    return false;
+  }
+
+  return window.matchMedia(MOBILE_BREAKPOINT_MEDIA_QUERY).matches;
+}
+
 type MobileLandingTab = "current" | "completed" | "guide";
 type CarouselAnimationStage =
   | "idle"
@@ -121,11 +132,7 @@ export default function LandingPage({ locale }: LandingPageProps) {
     [locale],
   );
   const [isMobileLayout, setIsMobileLayout] = useState(() => {
-    if (typeof window === "undefined") {
-      return false;
-    }
-
-    return window.matchMedia(MOBILE_BREAKPOINT_MEDIA_QUERY).matches;
+    return readMobileLayoutMatch();
   });
   const [mobileTab, setMobileTab] = useState<MobileLandingTab>("current");
   const [completedPageIndex, setCompletedPageIndex] = useState(0);
@@ -151,7 +158,10 @@ export default function LandingPage({ locale }: LandingPageProps) {
   useTrackVisitEvent("landing_visit");
 
   useEffect(() => {
-    if (typeof window === "undefined") {
+    if (
+      typeof window === "undefined" ||
+      typeof window.matchMedia !== "function"
+    ) {
       return undefined;
     }
 

--- a/frontend/src/pages/landing/LandingPage.tsx
+++ b/frontend/src/pages/landing/LandingPage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { Link } from "react-router-dom";
 import { useTrackVisitEvent } from "@/features/analytics/hooks/use-track-visit-event";
 import { landingApi } from "@/features/landing/api/landing.api";
+import FeaturedPreviewCard from "@/features/landing/components/FeaturedPreviewCard";
 import FeaturedPreviewSection from "@/features/landing/components/FeaturedPreviewSection";
 import type {
   LandingFeaturedPreviewItem,
@@ -19,6 +20,17 @@ import { SiteHeader } from "@/shared/ui/site-header";
 
 const LARGE_SNAPSHOT_SIZE = 512;
 const SMALL_SNAPSHOT_SIZE = 256;
+const MOBILE_BREAKPOINT_MEDIA_QUERY = "(max-width: 767px)";
+const MOBILE_SWIPE_THRESHOLD_PX = 40;
+
+type MobileLandingTab = "current" | "completed" | "guide";
+type CarouselAnimationStage =
+  | "idle"
+  | "out-left"
+  | "out-right"
+  | "in-left"
+  | "in-right";
+
 interface LandingPageProps {
   locale: PublicSiteLocale;
 }
@@ -67,12 +79,61 @@ function InfoStatRow({ label, value }: { label: string; value: string }) {
   );
 }
 
+function MobilePaginationDots({
+  count,
+  activeIndex,
+  onSelect,
+}: {
+  count: number;
+  activeIndex: number;
+  onSelect: (index: number) => void;
+}) {
+  if (count <= 1) {
+    return null;
+  }
+
+  return (
+    <div className="flex items-center justify-center gap-2">
+      {Array.from({ length: count }, (_, index) => {
+        const active = index === activeIndex;
+
+        return (
+          <button
+            key={index}
+            type="button"
+            onClick={() => onSelect(index)}
+            className={[
+              "h-2.5 w-2.5 rounded-full transition",
+              active ? "bg-[#272E37]" : "bg-white/55",
+            ].join(" ")}
+            aria-label={`Go to page ${index + 1}`}
+          />
+        );
+      })}
+    </div>
+  );
+}
+
 export default function LandingPage({ locale }: LandingPageProps) {
   const siteContent = useMemo(() => getSiteContent(locale), [locale]);
   const formatNumber = useMemo(
     () => new Intl.NumberFormat(locale === "ko" ? "ko-KR" : "en-US"),
     [locale],
   );
+  const [isMobileLayout, setIsMobileLayout] = useState(() => {
+    if (typeof window === "undefined") {
+      return false;
+    }
+
+    return window.matchMedia(MOBILE_BREAKPOINT_MEDIA_QUERY).matches;
+  });
+  const [mobileTab, setMobileTab] = useState<MobileLandingTab>("current");
+  const [completedPageIndex, setCompletedPageIndex] = useState(0);
+  const [guidePageIndex, setGuidePageIndex] = useState(0);
+  const [completedAnimationStage, setCompletedAnimationStage] =
+    useState<CarouselAnimationStage>("idle");
+  const [guideAnimationStage, setGuideAnimationStage] =
+    useState<CarouselAnimationStage>("idle");
 
   const [landingData, setLandingData] = useState<LandingPayload | null>(null);
   const [featuredPreviewItems, setFeaturedPreviewItems] = useState<
@@ -80,12 +141,31 @@ export default function LandingPage({ locale }: LandingPageProps) {
   >([]);
   const [landingError, setLandingError] = useState("");
   const currentGamePanelRef = useRef<HTMLDivElement | null>(null);
+  const completedSwipeStartXRef = useRef<number | null>(null);
+  const guideSwipeStartXRef = useRef<number | null>(null);
   const [currentGameSnapshotSize, setCurrentGameSnapshotSize] =
     useState<256 | 512>(LARGE_SNAPSHOT_SIZE);
 
   usePageRootClass("page-shell-root");
   usePublicSiteLocale(locale);
   useTrackVisitEvent("landing_visit");
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return undefined;
+    }
+
+    const mediaQuery = window.matchMedia(MOBILE_BREAKPOINT_MEDIA_QUERY);
+    const handleMediaQueryChange = (event: MediaQueryListEvent) => {
+      setIsMobileLayout(event.matches);
+    };
+
+    mediaQuery.addEventListener("change", handleMediaQueryChange);
+
+    return () => {
+      mediaQuery.removeEventListener("change", handleMediaQueryChange);
+    };
+  }, []);
 
   useEffect(() => {
     let cancelled = false;
@@ -133,6 +213,179 @@ export default function LandingPage({ locale }: LandingPageProps) {
   };
 
   const currentGame = landingData?.currentGame ?? null;
+  const mobileTabLabels = locale === "ko"
+    ? {
+        current: "진행중인 게임",
+        completed: "완성된 캔버스",
+        guide: "게임 소개",
+      }
+    : {
+        current: "Current game",
+        completed: "Completed",
+        guide: "How to play",
+      };
+  const completedPageCount = featuredPreviewItems.length;
+  const guidePageCount = siteContent.tutorial.cards.length;
+  const activeCompletedPageIndex =
+    completedPageCount > 0
+      ? Math.min(completedPageIndex, completedPageCount - 1)
+      : 0;
+  const activeGuidePageIndex =
+    guidePageCount > 0 ? Math.min(guidePageIndex, guidePageCount - 1) : 0;
+  const activeCompletedItem =
+    featuredPreviewItems[activeCompletedPageIndex] ?? null;
+  const activeGuideCard =
+    siteContent.tutorial.cards[activeGuidePageIndex] ?? null;
+  const shouldShowCompletedPagination =
+    mobileTab === "completed" && completedPageCount > 1;
+  const shouldShowGuidePagination = mobileTab === "guide" && guidePageCount > 1;
+
+  const resolveCarouselAnimationClassName = (
+    animationStage: CarouselAnimationStage,
+  ) => {
+    switch (animationStage) {
+      case "out-left":
+        return "-translate-x-6 opacity-0";
+      case "out-right":
+        return "translate-x-6 opacity-0";
+      case "in-left":
+        return "-translate-x-4 opacity-0";
+      case "in-right":
+        return "translate-x-4 opacity-0";
+      default:
+        return "translate-x-0 opacity-100";
+    }
+  };
+
+  const runCarouselTransition = (
+    direction: "previous" | "next",
+    count: number,
+    setIndex: React.Dispatch<React.SetStateAction<number>>,
+    setAnimationStage: React.Dispatch<React.SetStateAction<CarouselAnimationStage>>,
+  ) => {
+    if (count <= 1) {
+      return;
+    }
+
+    setAnimationStage(direction === "next" ? "out-left" : "out-right");
+
+    window.setTimeout(() => {
+      setIndex((previousIndex) => {
+        if (direction === "next") {
+          return Math.min(previousIndex + 1, count - 1);
+        }
+
+        return Math.max(previousIndex - 1, 0);
+      });
+      setAnimationStage(direction === "next" ? "in-right" : "in-left");
+
+      window.requestAnimationFrame(() => {
+        window.requestAnimationFrame(() => {
+          setAnimationStage("idle");
+        });
+      });
+    }, 160);
+  };
+
+  const handleCompletedPaginationSelect = (index: number) => {
+    if (index === activeCompletedPageIndex) {
+      return;
+    }
+
+    runCarouselTransition(
+      index > activeCompletedPageIndex ? "next" : "previous",
+      completedPageCount,
+      setCompletedPageIndex,
+      setCompletedAnimationStage,
+    );
+  };
+
+  const handleGuidePaginationSelect = (index: number) => {
+    if (index === activeGuidePageIndex) {
+      return;
+    }
+
+    runCarouselTransition(
+      index > activeGuidePageIndex ? "next" : "previous",
+      guidePageCount,
+      setGuidePageIndex,
+      setGuideAnimationStage,
+    );
+  };
+
+  const handleCompletedTouchStart = (
+    event: React.TouchEvent<HTMLDivElement>,
+  ) => {
+    completedSwipeStartXRef.current = event.changedTouches[0]?.clientX ?? null;
+  };
+
+  const handleCompletedTouchEnd = (event: React.TouchEvent<HTMLDivElement>) => {
+    const startX = completedSwipeStartXRef.current;
+    const endX = event.changedTouches[0]?.clientX ?? null;
+    completedSwipeStartXRef.current = null;
+
+    if (
+      startX === null ||
+      endX === null ||
+      completedPageCount <= 1 ||
+      Math.abs(endX - startX) < MOBILE_SWIPE_THRESHOLD_PX
+    ) {
+      return;
+    }
+
+    if (endX < startX) {
+      runCarouselTransition(
+        "next",
+        completedPageCount,
+        setCompletedPageIndex,
+        setCompletedAnimationStage,
+      );
+      return;
+    }
+
+    runCarouselTransition(
+      "previous",
+      completedPageCount,
+      setCompletedPageIndex,
+      setCompletedAnimationStage,
+    );
+  };
+
+  const handleGuideTouchStart = (event: React.TouchEvent<HTMLDivElement>) => {
+    guideSwipeStartXRef.current = event.changedTouches[0]?.clientX ?? null;
+  };
+
+  const handleGuideTouchEnd = (event: React.TouchEvent<HTMLDivElement>) => {
+    const startX = guideSwipeStartXRef.current;
+    const endX = event.changedTouches[0]?.clientX ?? null;
+    guideSwipeStartXRef.current = null;
+
+    if (
+      startX === null ||
+      endX === null ||
+      guidePageCount <= 1 ||
+      Math.abs(endX - startX) < MOBILE_SWIPE_THRESHOLD_PX
+    ) {
+      return;
+    }
+
+    if (endX < startX) {
+      runCarouselTransition(
+        "next",
+        guidePageCount,
+        setGuidePageIndex,
+        setGuideAnimationStage,
+      );
+      return;
+    }
+
+    runCarouselTransition(
+      "previous",
+      guidePageCount,
+      setGuidePageIndex,
+      setGuideAnimationStage,
+    );
+  };
 
   useEffect(() => {
     const element = currentGamePanelRef.current;
@@ -188,7 +441,7 @@ export default function LandingPage({ locale }: LandingPageProps) {
         ]}
       />
 
-      <main className="px-4 pb-20 pt-6 sm:px-6 lg:px-10">
+      <main className="px-4 pb-4 pt-6 sm:px-6 md:pb-20 lg:px-10">
         <section className="mx-auto max-w-6xl rounded-[42px] bg-[#ff8870] px-5 py-6 text-white shadow-[0_40px_120px_rgba(39,46,55,0.24)] sm:px-8 sm:py-8">
           <div className="grid gap-8 xl:grid-cols-[minmax(0,1fr)_584px] xl:items-stretch">
             <div className="min-w-0 flex flex-col justify-center text-left">
@@ -199,15 +452,15 @@ export default function LandingPage({ locale }: LandingPageProps) {
                 >
                   {siteContent.hero.title}
                 </div>
+              </div>
+
+              <div className="mt-8 flex w-full max-w-3xl items-end justify-between gap-4 sm:mt-10 xl:mt-[48px]">
                 <p
-                  className="max-w-2xl whitespace-pre-line break-keep text-sm leading-6 sm:text-base sm:leading-7 lg:text-lg"
+                  className="max-w-[13rem] flex-1 whitespace-pre-line break-keep text-sm leading-6 sm:max-w-2xl sm:text-base sm:leading-7 lg:text-lg"
                   style={{ color: "rgba(0, 0, 0, 0.82)" }}
                 >
                   {siteContent.hero.description}
                 </p>
-              </div>
-
-              <div className="mt-8 flex w-full max-w-3xl justify-start sm:mt-10 xl:mt-[48px] xl:justify-end">
                 <Button
                   type="button"
                   size="lg"
@@ -226,6 +479,179 @@ export default function LandingPage({ locale }: LandingPageProps) {
               {landingError ? (
                 <div className="flex min-h-[420px] items-center justify-center rounded-[28px] bg-[#f6ede5] px-6 text-center text-sm text-[#5f6368]">
                   {landingError}
+                </div>
+              ) : isMobileLayout ? (
+                <div className="space-y-4">
+                  <div className="grid grid-cols-3 rounded-full bg-[#fff1ea]/24 p-1">
+                    {(
+                      [
+                        ["current", mobileTabLabels.current],
+                        ["completed", mobileTabLabels.completed],
+                        ["guide", mobileTabLabels.guide],
+                      ] as const
+                    ).map(([tabKey, label]) => (
+                      <button
+                        key={tabKey}
+                        type="button"
+                        onClick={() => setMobileTab(tabKey)}
+                        className={[
+                          "rounded-full px-2 py-2 text-[11px] font-semibold transition sm:text-xs",
+                          mobileTab === tabKey
+                            ? "bg-white text-[#272E37]"
+                            : "text-white/82",
+                        ].join(" ")}
+                      >
+                        {label}
+                      </button>
+                    ))}
+                  </div>
+
+                  {shouldShowCompletedPagination ? (
+                    <MobilePaginationDots
+                      count={completedPageCount}
+                      activeIndex={activeCompletedPageIndex}
+                      onSelect={handleCompletedPaginationSelect}
+                    />
+                  ) : null}
+
+                  {shouldShowGuidePagination ? (
+                    <MobilePaginationDots
+                      count={guidePageCount}
+                      activeIndex={activeGuidePageIndex}
+                      onSelect={handleGuidePaginationSelect}
+                    />
+                  ) : null}
+
+                  {mobileTab === "current" ? (
+                    currentGame ? (
+                      <div className="space-y-4">
+                        <SnapshotImage
+                          imageUrl={
+                            currentGame.snapshotUrl ?? currentGame.fallbackImageUrl
+                          }
+                          alt={
+                            currentGame.snapshotUrl
+                              ? siteContent.currentGame.snapshotLabel
+                              : siteContent.currentGame.fallbackPreviewAlt
+                          }
+                          size={currentGameSnapshotSize}
+                        />
+
+                        <div
+                          className="mx-auto w-full max-w-full rounded-2xl bg-[#f6ede5] px-4 py-2 shadow-[0_10px_24px_rgba(39,46,55,0.05)]"
+                          style={{ maxWidth: `${currentGameSnapshotSize}px` }}
+                        >
+                          <InfoStatRow
+                            label={siteContent.currentGame.stats.grid}
+                            value={`${currentGame.gridX} x ${currentGame.gridY}`}
+                          />
+                          <div className="h-px bg-[#ead7c8]" />
+                          <InfoStatRow
+                            label={siteContent.currentGame.stats.round}
+                            value={`${formatNumber.format(
+                              currentGame.currentRoundNumber,
+                            )} / ${formatNumber.format(currentGame.totalRounds)}`}
+                          />
+                          <div className="h-px bg-[#ead7c8]" />
+                          <InfoStatRow
+                            label={siteContent.currentGame.stats.participants}
+                            value={formatNumber.format(currentGame.participantCount)}
+                          />
+                        </div>
+                      </div>
+                    ) : (
+                      <div className="flex min-h-[420px] flex-col items-start justify-center rounded-[28px] bg-[#f6ede5] px-6 text-left">
+                        <h2 className="text-2xl font-semibold text-[#272E37]">
+                          {siteContent.currentGame.emptyTitle}
+                        </h2>
+                        <p className="mt-4 whitespace-pre-line text-base leading-7 text-[#5f6368]">
+                          {siteContent.currentGame.emptyDescription}
+                        </p>
+                      </div>
+                    )
+                  ) : mobileTab === "completed" ? (
+                    activeCompletedItem ? (
+                      <div
+                        className="space-y-4"
+                        onTouchStart={handleCompletedTouchStart}
+                        onTouchEnd={handleCompletedTouchEnd}
+                      >
+                        <div
+                          className={[
+                            "transition-all duration-200 ease-out",
+                            resolveCarouselAnimationClassName(
+                              completedAnimationStage,
+                            ),
+                          ].join(" ")}
+                        >
+                          <FeaturedPreviewCard
+                            locale={locale}
+                            gridX={activeCompletedItem.preview.gridX}
+                            gridY={activeCompletedItem.preview.gridY}
+                            item={activeCompletedItem}
+                            labels={siteContent.featured.stats}
+                          />
+                        </div>
+                      </div>
+                    ) : (
+                      <div className="flex min-h-[420px] flex-col items-start justify-center rounded-[28px] bg-[#f6ede5] px-6 text-left">
+                        <h2 className="text-2xl font-semibold text-[#272E37]">
+                          {siteContent.featured.title}
+                        </h2>
+                        <p className="mt-4 whitespace-pre-line text-base leading-7 text-[#5f6368]">
+                          {siteContent.featured.description}
+                        </p>
+                      </div>
+                    )
+                  ) : activeGuideCard ? (
+                    <div
+                      className="space-y-4"
+                      onTouchStart={handleGuideTouchStart}
+                      onTouchEnd={handleGuideTouchEnd}
+                    >
+                      <div
+                        className={[
+                          "transition-all duration-200 ease-out",
+                          resolveCarouselAnimationClassName(guideAnimationStage),
+                        ].join(" ")}
+                      >
+                        <article className="overflow-hidden rounded-[30px] bg-white shadow-[0_24px_70px_rgba(39,46,55,0.08)]">
+                          <div className="bg-[linear-gradient(180deg,#fff4e9_0%,#f6ede5_100%)] p-4">
+                            <div className="mx-auto w-full max-w-[240px] overflow-hidden rounded-[24px] shadow-[0_24px_60px_rgba(39,46,55,0.10)]">
+                              <div className="aspect-video w-full">
+                                <img
+                                  src={activeGuideCard.imageUrl}
+                                  alt={activeGuideCard.imageAlt}
+                                  className="block h-full w-full object-contain"
+                                  draggable={false}
+                                />
+                              </div>
+                            </div>
+                          </div>
+
+                          <div className="px-5 py-5 text-left">
+                            <div className="flex items-center gap-3">
+                              <h3 className="text-xl font-semibold text-[#272E37]">
+                                {activeGuideCard.title}
+                              </h3>
+                              {activeGuideCard.iconUrl ? (
+                                <img
+                                  src={activeGuideCard.iconUrl}
+                                  alt=""
+                                  aria-hidden="true"
+                                  className="h-12 w-12 flex-none object-contain"
+                                  draggable={false}
+                                />
+                              ) : null}
+                            </div>
+                            <p className="mt-4 whitespace-pre-line text-sm leading-6 text-[#5f6368]">
+                              {activeGuideCard.description}
+                            </p>
+                          </div>
+                        </article>
+                      </div>
+                    </div>
+                  ) : null}
                 </div>
               ) : currentGame ? (
                 <div className="space-y-4">
@@ -281,77 +707,79 @@ export default function LandingPage({ locale }: LandingPageProps) {
           </div>
         </section>
 
-        <FeaturedPreviewSection
-          locale={locale}
-          items={featuredPreviewItems}
-          labels={{
-            title: siteContent.featured.title,
-            description: siteContent.featured.description,
-            participants: siteContent.featured.stats.participants,
-            votes: siteContent.featured.stats.votes,
-            topVoter: siteContent.featured.stats.topVoter,
-            participantList: siteContent.featured.stats.participantList,
-          }}
-        />
+        {!isMobileLayout ? (
+          <>
+            <FeaturedPreviewSection
+              locale={locale}
+              items={featuredPreviewItems}
+              labels={{
+                title: siteContent.featured.title,
+                description: siteContent.featured.description,
+                participants: siteContent.featured.stats.participants,
+                votes: siteContent.featured.stats.votes,
+                topVoter: siteContent.featured.stats.topVoter,
+              }}
+            />
 
-        <section className="mx-auto mt-10 max-w-6xl">
-          <div className="text-left">
-            <div className="text-[24px] font-semibold leading-[118%] text-[#272E37] lg:text-[24px]">
-              {siteContent.tutorial.title}
-            </div>
-            <p className="mt-3 max-w-3xl whitespace-pre-line text-base leading-7 text-[#5f6368] sm:text-lg">
-              {siteContent.tutorial.description}
-            </p>
-          </div>
+            <section className="mx-auto mt-10 max-w-6xl">
+              <div className="text-left">
+                <div className="text-[24px] font-semibold leading-[118%] text-[#272E37] lg:text-[24px]">
+                  {siteContent.tutorial.title}
+                </div>
+                <p className="mt-3 max-w-3xl whitespace-pre-line text-base leading-7 text-[#5f6368] sm:text-lg">
+                  {siteContent.tutorial.description}
+                </p>
+              </div>
 
-          <div className="mt-8 space-y-6">
-            {siteContent.tutorial.cards.map((card) => (
-              <article
-                key={card.id}
-                className="grid gap-5 overflow-hidden rounded-[34px] bg-white shadow-[0_24px_80px_rgba(39,46,55,0.06)] xl:grid-cols-[auto_minmax(0,1fr)]"
-                //className="grid gap-5 rounded-[34px] bg-white shadow-[0_24px_80px_rgba(39,46,55,0.06)] xl:grid-cols-[minmax(0,5fr)_minmax(0,3fr)]"
-              >
-                <div className="bg-[linear-gradient(180deg,#fff4e9_0%,#f6ede5_100%)] p-5">
-                  <div className="mx-auto h-[405px] w-fit overflow-hidden rounded-[24px] shadow-[0_24px_60px_rgba(39,46,55,0.10)]">
-                    <div className="aspect-video h-full">
-                      <img
-                        src={card.imageUrl}
-                        alt={card.imageAlt}
-                        className="block h-full w-full object-contain"
-                        draggable={false}
-                      />
+              <div className="mt-8 space-y-6">
+                {siteContent.tutorial.cards.map((card) => (
+                  <article
+                    key={card.id}
+                    className="grid gap-5 overflow-hidden rounded-[34px] bg-white shadow-[0_24px_80px_rgba(39,46,55,0.06)] xl:grid-cols-[auto_minmax(0,1fr)]"
+                  >
+                    <div className="bg-[linear-gradient(180deg,#fff4e9_0%,#f6ede5_100%)] p-5">
+                      <div className="mx-auto h-[405px] w-fit overflow-hidden rounded-[24px] shadow-[0_24px_60px_rgba(39,46,55,0.10)]">
+                        <div className="aspect-video h-full">
+                          <img
+                            src={card.imageUrl}
+                            alt={card.imageAlt}
+                            className="block h-full w-full object-contain"
+                            draggable={false}
+                          />
+                        </div>
+                      </div>
                     </div>
-                  </div>
-                </div>
 
-                <div className="flex flex-col justify-center px-6 py-6 text-left sm:px-8">
-                  <div className="flex items-center gap-3">
-                    <h3 className="text-2xl font-semibold text-[#272E37]">
-                      {card.title}
-                    </h3>
-                    {card.iconUrl ? (
-                      <img
-                        src={card.iconUrl}
-                        alt=""
-                        aria-hidden="true"
-                        className="h-16 w-16 flex-none object-contain"
-                        draggable={false}
-                      />
-                    ) : null}
-                  </div>
-                  <p className="mt-4 whitespace-pre-line text-base leading-7 text-[#5f6368]">
-                    {card.description}
-                  </p>
-                </div>
-              </article>
-            ))}
-          </div>
-        </section>
+                    <div className="flex flex-col justify-center px-6 py-6 text-left sm:px-8">
+                      <div className="flex items-center gap-3">
+                        <h3 className="text-2xl font-semibold text-[#272E37]">
+                          {card.title}
+                        </h3>
+                        {card.iconUrl ? (
+                          <img
+                            src={card.iconUrl}
+                            alt=""
+                            aria-hidden="true"
+                            className="h-16 w-16 flex-none object-contain"
+                            draggable={false}
+                          />
+                        ) : null}
+                      </div>
+                      <p className="mt-4 whitespace-pre-line text-base leading-7 text-[#5f6368]">
+                        {card.description}
+                      </p>
+                    </div>
+                  </article>
+                ))}
+              </div>
+            </section>
+          </>
+        ) : null}
       </main>
 
-      <footer className="border-t border-[#20262f] bg-[#272E37] px-4 py-10 text-[#f6ede5] sm:px-6 lg:px-10">
-        <div className="mx-auto flex max-w-6xl flex-wrap items-center justify-between gap-5">
-          <div className="flex min-w-0 items-center gap-4">
+      <footer className="border-t border-[#20262f] bg-[#272E37] px-4 pb-10 pt-7 text-[#f6ede5] sm:px-6 sm:py-10 lg:px-10">
+        <div className="mx-auto flex max-w-6xl flex-col gap-4 md:flex-row md:flex-wrap md:items-center md:justify-between md:gap-5">
+          <div className="flex min-w-0 flex-col items-start gap-3 md:flex-row md:items-center md:gap-4">
             <div className="inline-flex items-center gap-3">
               <BrandLogo variant="symbol" className="w-7" />
               <BrandLogo variant="wordmarkLight" className="w-20" />
@@ -361,7 +789,7 @@ export default function LandingPage({ locale }: LandingPageProps) {
             </p>
           </div>
 
-          <nav className="flex flex-wrap items-center gap-x-5 gap-y-2 text-sm font-semibold">
+          <nav className="flex flex-wrap items-center gap-x-5 gap-y-2 text-sm font-semibold md:justify-end">
             <Link to={`/${locale}/terms`} className="hover:text-[#DE5548]">
               {siteContent.footer.links.terms}
             </Link>

--- a/frontend/src/shared/content/site-content.ts
+++ b/frontend/src/shared/content/site-content.ts
@@ -85,9 +85,9 @@ const SITE_CONTENT: Record<Locale, SiteContent> = {
       home: "홈",
     },
     hero: {
-      title: "직접 그리고 함께 투표하는\n픽셀 캔버스",
+      title: "직접 그리고 투표하는\n픽셀 캔버스",
       description:
-        "색을 고르고, 투표를 하고, 함께 완성하세요.",
+        "색을 고르고,\n투표를 하고,\n함께 완성하세요.",
       cta: "참여하기",
     },
     currentGame: {
@@ -390,7 +390,7 @@ const SITE_CONTENT: Record<Locale, SiteContent> = {
       title:
         "Draw and vote together\non a shared pixel canvas.",
       description:
-        "Pick a color, cast your vote, and complete it together.",
+        "Pick a color,\ncast your vote,\nand complete it together.",
       cta: "Join the game",
     },
     currentGame: {

--- a/frontend/src/shared/ui/site-header.tsx
+++ b/frontend/src/shared/ui/site-header.tsx
@@ -18,7 +18,7 @@ interface SiteHeaderProps {
 
 function HeaderItem({ item }: { item: SiteHeaderItem }) {
   const className = [
-    "rounded-full px-3 py-2 text-sm font-semibold transition",
+    "rounded-full px-2.5 py-2 text-xs font-semibold transition sm:px-3 sm:text-sm",
     item.active
       ? "bg-[#272E37] text-white"
       : "text-[#5f6368] hover:bg-white/80 hover:text-[#272E37]",
@@ -44,40 +44,34 @@ export function SiteHeader({
     <header className="px-4 pt-4 sm:px-6 lg:px-10 lg:pt-6">
       <div
         className={[
-          "mx-auto flex max-w-6xl flex-wrap items-center justify-between gap-3 rounded-[28px] border px-4 py-3 shadow-[0_18px_60px_rgba(39,46,55,0.08)] backdrop-blur-xl sm:px-5",
+          "mx-auto flex max-w-6xl flex-nowrap items-center justify-between gap-2 rounded-[28px] border px-4 py-3 shadow-[0_18px_60px_rgba(39,46,55,0.08)] backdrop-blur-xl sm:gap-3 sm:px-5",
           translucent
             ? "border-[#ead7c8] bg-[#f6ede5]/88"
             : "border-[#ead7c8] bg-[#f6ede5]",
         ].join(" ")}
       >
-        <div className="flex min-w-0 items-center gap-3">
+        <div className="flex min-w-0 flex-1 items-center gap-2 sm:gap-3">
           <Link
             to={`/${locale}`}
             className="inline-flex items-center"
             aria-label="VoteDots home"
           >
-            <BrandLogo variant="wordmark" className="w-28 sm:w-32" />
+            <BrandLogo variant="wordmark" className="w-20 sm:w-32" />
           </Link>
 
-          <nav className="hidden items-center gap-1 rounded-full bg-[#f7f2eb] p-1 md:flex">
+          <nav className="flex min-w-0 items-center gap-1 rounded-full bg-[#f7f2eb] p-1">
             {items.map((item) => (
               <HeaderItem key={item.key} item={item} />
             ))}
           </nav>
         </div>
 
-        <div className="flex items-center gap-3">
-          <nav className="flex items-center gap-1 rounded-full bg-[#f7f2eb] p-1 md:hidden">
-            {items.map((item) => (
-              <HeaderItem key={item.key} item={item} />
-            ))}
-          </nav>
-
+        <div className="flex shrink-0 items-center gap-2 sm:gap-3">
           <div className="inline-flex items-center gap-1 rounded-full bg-[#f7f2eb] p-1">
             <Link
               to={targetPath("ko")}
               className={[
-                "rounded-full px-3 py-2 text-sm font-semibold transition",
+                "rounded-full px-2.5 py-2 text-xs font-semibold transition sm:px-3 sm:text-sm",
                 locale === "ko"
                   ? "bg-[#272E37] text-white"
                   : "text-[#5f6368] hover:bg-white/80 hover:text-[#272E37]",
@@ -88,7 +82,7 @@ export function SiteHeader({
             <Link
               to={targetPath("en")}
               className={[
-                "rounded-full px-3 py-2 text-sm font-semibold transition",
+                "rounded-full px-2.5 py-2 text-xs font-semibold transition sm:px-3 sm:text-sm",
                 locale === "en"
                   ? "bg-[#272E37] text-white"
                   : "text-[#5f6368] hover:bg-white/80 hover:text-[#272E37]",

--- a/frontend/test/unit/featured-preview-section.test.tsx
+++ b/frontend/test/unit/featured-preview-section.test.tsx
@@ -8,7 +8,6 @@ const labels = {
   participants: "Participants",
   votes: "Votes",
   topVoter: "Top voter",
-  participantList: "Participant list",
 };
 
 function getCardImages() {
@@ -78,7 +77,5 @@ describe("FeaturedPreviewSection", () => {
     expect(screen.getByText("5")).toBeInTheDocument();
     expect(screen.getByText("120")).toBeInTheDocument();
     expect(screen.getByText("Alice (50)")).toBeInTheDocument();
-    expect(screen.getByText("Alice")).toBeInTheDocument();
-    expect(screen.getByText("Bob")).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## 관련 이슈
- Close #446 

## 변경 내용

- 모바일 상단 헤더에서 패치노트, 로드맵, 로케일 전환이 한 줄로 유지되도록 헤더 레이아웃을 조정
- 히어로 문구를 `직접 그리고 투표하는 / 픽셀 캔버스` 구조로 정리하고, 설명과 `참여하기` 버튼을 모바일 기준 가로 배치로 조정
- 현재 진행 중인 게임 영역을 모바일에서 `진행중인 게임 / 완성된 캔버스 / 게임 소개` 탭 구조로 재구성
- `완성된 캔버스`, `게임 소개` 탭은 한 번에 1개씩 보이도록 하고 점 페이지네이션과 스와이프 전환 애니메이션을 추가
- 모바일 `게임 소개` 카드 이미지 폭을 줄여 화면 밖으로 넘치지 않도록 조정
- 완성된 캔버스 카드에서 참여자 목록 영역을 제거해 모바일 카드 밀도를 정리
- 모바일 푸터에서 브랜드 로고, 설명, 링크 간격을 조정해 겹침을 해소

## 기대 동작

- 모바일 랜딩 상단 헤더가 줄바꿈 없이 안정적으로 보인다
- 히어로 영역에서 설명과 `참여하기` 버튼이 같은 가로선에서 읽히고 CTA가 더 명확하게 보인다
- 모바일 사용자는 현재 게임 카드 안에서 탭 전환만으로 진행중인 게임, 완성된 캔버스, 게임 소개를 탐색할 수 있다
- 완성된 캔버스와 게임 소개는 좌우 스와이프와 페이지네이션으로 자연스럽게 넘겨볼 수 있다
- 모바일 푸터에서 브랜드 로고, 설명, 링크가 겹치지 않고 정리된 구조로 보인다

## 확인 내용

- `frontend`에서 `npx tsc -b` 통과
- 모바일에서 상단 헤더 한 줄 유지 여부 수동 확인 필요
- 모바일에서 탭 전환, 스와이프 애니메이션, 페이지네이션 위치가 의도대로 보이는지 수동 확인 필요
- 모바일 푸터에서 로고/설명/링크 간격이 겹치지 않는지 수동 확인 필요