### PR TITLE
docs: 서비스 약관에 캔버스 저장 및 저작권 조항 추가

### DIFF
--- a/frontend/src/shared/content/site-content.ts
+++ b/frontend/src/shared/content/site-content.ts
@@ -226,10 +226,14 @@ const SITE_CONTENT: Record<Locale, SiteContent> = {
             ],
           },
           {
-            heading: "7. 게임 결과, 닉네임 및 공개 정보의 이용",
+            heading: "7. 게임 결과, 캔버스 작업물의 저장 및 이용",
             paragraphs: [
-              "VoteDots는 서비스 운영, 게임 결과 안내, 서비스 소개 및 기록 보관을 위하여 회원의 닉네임, 게임 결과, 참여 통계 및 이에 부수되는 공개 정보를 서비스 내에 표시할 수 있습니다. 게임 결과에는 캔버스 이미지, 라운드 진행 내역, 참여 인원, 투표 통계, 닉네임 기반 요약 정보, 스냅샷 및 이에 준하는 정보가 포함될 수 있습니다.",
-              "회원은 서비스 이용 과정에서 자신의 닉네임 및 게임 참여 결과가 위와 같은 범위에서 공개될 수 있음을 이해하고 이에 동의합니다. 다만 VoteDots는 관련 법령, 회원 탈퇴, 운영상 필요 또는 권리 보호를 위하여 공개 정보의 전부 또는 일부를 수정, 비공개 처리, 삭제 또는 비식별 처리할 수 있으며, 유해하거나 부적절하다고 판단되는 이미지, 결과물 또는 관련 공개 정보를 숨김 또는 삭제할 수 있습니다.",
+              "VoteDots는 서비스 운영, 게임 진행, 게임 결과 제공, 기록 보관, 분쟁 대응, 서비스 개선 및 안내를 위하여 회원이 서비스 이용 과정에서 생성하거나 참여한 정보와 결과물을 서버에 저장할 수 있습니다. 여기에는 광장, 공개방, 비공개방을 포함한 모든 방의 정보와 게임 결과가 포함되며, 방 정보에는 방의 생성 및 설정 정보, 캔버스 이미지, 라운드 진행 내역, 참여 인원, 투표 기록 및 통계, 스냅샷, 닉네임 기반 요약 정보 및 이에 준하는 정보가 포함될 수 있습니다.",
+              "비공개방은 외부에 공개되지 않을 수 있으나, 서비스 운영, 기록 보관, 장애 대응, 분쟁 대응 및 권리 보호를 위하여 서버에 저장될 수 있습니다. 회원은 서비스 이용 과정에서 자신의 닉네임, 게임 참여 결과 및 관련 공개 정보가 서비스 내 또는 VoteDots가 정한 범위에서 표시되거나 보관될 수 있음을 이해하고 이에 동의합니다.",
+              "회원이 서비스 이용 과정에서 생성한 캔버스 작업물 또는 이에 포함된 개별 창작 요소에 대한 저작권은 원칙적으로 해당 회원 또는 정당한 권리자에게 귀속됩니다. 다만 VoteDots의 게임 결과는 다수 회원의 참여, 투표 및 시스템 처리에 의해 결합되어 형성되는 협업형 결과물일 수 있으며, 회원은 자신의 참여 결과가 다른 참여자의 결과와 함께 하나의 게임 결과로 저장, 표시, 보관될 수 있음을 이해하고 이에 동의합니다.",
+              "회원은 VoteDots에 대하여 서비스 운영, 게임 결과 제공, 표시, 복제, 저장, 전송, 공개, 기록 보관, 백업, 서비스 소개, 비식별 통계 작성 및 서비스 개선에 필요한 범위 내에서 자신의 캔버스 작업물, 게임 결과, 스냅샷, 닉네임 및 관련 공개 정보를 이용할 수 있는 비독점적, 무상, 전 세계적 이용허락을 부여합니다. 이 이용허락에는 서비스 운영에 필요한 범위 내에서의 썸네일 생성, 스냅샷 생성, 포맷 변환, 크기 조정, 비식별화, 아카이빙 및 이에 준하는 수정 또는 편집이 포함될 수 있습니다.",
+              "회원은 자신이 참여하여 생성된 게임 결과 및 캔버스 작업물을 상업적 이용이 아닌 범위에서는 자유롭게 열람, 저장, 공유 및 게시할 수 있습니다. 다만 관련 법령, 제3자의 권리, 개인정보, 서비스 운영정책 또는 본 약관을 위반하는 방식의 이용은 허용되지 않으며, 상업적 이용을 하고자 하는 경우에는 해당 결과물에 포함된 권리관계와 제3자 권리를 스스로 확인하여야 합니다.",
+              "VoteDots는 관련 법령, 회원 탈퇴, 운영상 필요, 권리 보호 또는 유해성 판단에 따라 공개 정보, 게임 결과, 캔버스 작업물 또는 관련 기록의 전부 또는 일부를 수정, 비공개 처리, 삭제 또는 비식별 처리할 수 있으며, 유해하거나 부적절하다고 판단되는 이미지, 결과물 또는 관련 공개 정보를 숨김 또는 삭제할 수 있습니다.",
             ],
           },
           {
@@ -529,10 +533,14 @@ const SITE_CONTENT: Record<Locale, SiteContent> = {
             ],
           },
           {
-            heading: "7. Use of game results, nicknames, and public information",
+            heading: "7. Storage and use of game results and canvas works",
             paragraphs: [
-              "VoteDots may display member nicknames, game results, participation statistics, and related public information within the service for service operation, game result guidance, service presentation, and record keeping. Game results may include the canvas image, round history, participant counts, voting statistics, nickname-based summaries, snapshots, and similar information.",
-              "Members understand and agree that their nickname and gameplay results may be displayed within that scope. However, VoteDots may modify, hide, delete, or de-identify all or part of public information when required by law, account withdrawal, operational needs, or protection of rights, and may hide or delete images, results, or public records considered harmful or inappropriate.",
+              "VoteDots may store on its servers the information and outputs that a member creates or participates in through the service for service operation, gameplay, game result delivery, record keeping, dispute response, service improvement, and notices. This includes information and game results for all rooms, including the plaza, public rooms, and private rooms. Room information may include room creation and settings, canvas images, round history, participant counts, voting records and statistics, snapshots, nickname-based summaries, and similar information.",
+              "A private room may not be publicly visible to others, but it may still be stored on the server for service operation, record keeping, incident response, dispute response, and protection of rights. Members understand and agree that their nickname, gameplay results, and related public information may be displayed or retained within the service or within a scope designated by VoteDots.",
+              "Copyright in a canvas work created through use of the service, or in an individual creative element contained in it, in principle belongs to the relevant member or other legitimate right holder. However, a game result on VoteDots may be a collaborative output formed through the participation, voting, and system processing of multiple members, and each member understands and agrees that their contribution may be stored, displayed, and retained together with the contributions of other participants as a single game result.",
+              "Each member grants VoteDots a non-exclusive, royalty-free, worldwide license to use that member's canvas works, game results, snapshots, nickname, and related public information to the extent necessary for service operation, game result delivery, display, reproduction, storage, transmission, publication, record keeping, backup, service presentation, de-identified statistics, and service improvement. This license may include creating thumbnails and snapshots, format conversion, resizing, de-identification, archiving, and similar edits or modifications to the extent necessary for service operation.",
+              "Members may freely view, save, share, and post the game results and canvas works in which they participated, provided that the use is non-commercial. However, use that violates applicable law, third-party rights, personal information, the service policy, or these terms is not permitted. If a member intends to use a result commercially, that member is responsible for confirming the rights involved in the result and any third-party rights included in it.",
+              "VoteDots may modify, hide, delete, or de-identify all or part of public information, game results, canvas works, or related records when required by law, account withdrawal, operational needs, protection of rights, or a determination of harmfulness, and may hide or delete images, results, or public records considered harmful or inappropriate.",
             ],
           },
           {


### PR DESCRIPTION
## 관련 이슈
- Close #448 

## 변경 내용

- 서비스 이용 약관에 `게임 결과, 캔버스 작업물의 저장 및 이용` 조항을 추가
- 광장, 공개방, 비공개방을 포함한 모든 방 정보와 게임 결과가 서버에 저장될 수 있음을 명시
- 비공개방도 외부 공개 여부와 별개로 서버 저장 대상이 될 수 있음을 명시
- 캔버스 작업물 또는 개별 창작 요소의 저작권은 원칙적으로 회원 또는 정당한 권리자에게 귀속된다고 정리
- VoteDots가 서비스 운영을 위해 받는 비독점적, 무상, 전 세계적 이용허락 범위를 명시
- 회원이 상업적 이용이 아닌 범위에서는 결과물을 자유롭게 열람, 저장, 공유, 게시할 수 있음을 명시
- 동일한 의미의 영문 약관 문구도 함께 추가

## 기대 동작

- 회원이 자신의 캔버스 작업물과 게임 결과가 서버에 저장될 수 있음을 약관에서 명확히 확인할 수 있다
- 저작권 귀속과 서비스 이용허락 구조를 약관에서 분명하게 확인할 수 있다
- 비공개방도 외부 공개 여부와 별개로 저장될 수 있다는 점을 약관에서 확인할 수 있다
- 비상업적 이용 가능 범위와 상업적 이용 시 회원의 확인 책임이 명시된다

## 확인 내용

- `frontend`에서 `npx tsc -b` 통과
- 한국어/영문 약관 섹션 7에 동일한 취지의 문구가 반영되었는지 확인
- 기존 게임 결과, 공개 정보, 비식별 처리 관련 문구와 충돌 없는지 확인