### PR TITLE
feat: 데스크톱 투표 모드 추가

### DIFF
--- a/backend/src/modules/canvas/canvas.controller.ts
+++ b/backend/src/modules/canvas/canvas.controller.ts
@@ -108,7 +108,7 @@ export const canvasController = {
 
   async getCurrent(req: Request, res: Response) {
     try {
-      const canvas = await canvasService.getCurrentPlaza();
+      const canvas = await canvasService.getCurrentPlayingPlaza();
       if (!canvas) {
         return res
           .status(404)

--- a/backend/src/modules/canvas/canvas.service.ts
+++ b/backend/src/modules/canvas/canvas.service.ts
@@ -178,6 +178,10 @@ export const canvasService = {
     return findCurrentPlazaCanvas();
   },
 
+  async getCurrentPlayingPlaza(): Promise<Canvas | null> {
+    return findPlayingPlazaCanvas();
+  },
+
   async getCurrentParticipantCount(): Promise<{
     canvasId: number;
     count: number;
@@ -202,7 +206,7 @@ export const canvasService = {
     canvasId: number;
     count: number;
   }> {
-    const canvas = await this.getCurrentPlaza();
+    const canvas = await this.getCurrentPlayingPlaza();
 
     if (!canvas) {
       throw new Error("No plaza canvas is currently in progress.");
@@ -242,7 +246,7 @@ export const canvasService = {
     canvasId: number;
     participants: ParticipantSummary[];
   }> {
-    const canvas = await this.getCurrentPlaza();
+    const canvas = await this.getCurrentPlayingPlaza();
 
     if (!canvas) {
       throw new Error("No plaza canvas is currently in progress.");

--- a/frontend/src/features/gameplay/vote/components/ColorPalette.tsx
+++ b/frontend/src/features/gameplay/vote/components/ColorPalette.tsx
@@ -188,72 +188,71 @@ export default function ColorPalette({
             />
           </>
         ) : (
-          <div className="mt-3 flex items-center gap-1.5">
-            <button
-              onClick={handleEyeDropper}
-              className="flex h-7 w-7 shrink-0 items-center justify-center rounded border border-[color:var(--page-theme-border-primary)] text-xs text-[color:var(--page-theme-text-secondary)] hover:bg-[color:var(--page-theme-surface-secondary)]"
-              title={t("vote.palette.eyeDropper")}
+          <>
+            <div
+              className="overflow-hidden rounded-md border border-[color:var(--page-theme-border-primary)]"
+              onClick={(e) => e.stopPropagation()}
             >
-              <img
-                src={eyedropperIcon}
-                alt=""
-                className="h-4 w-4 object-contain"
-                draggable={false}
-              />
-            </button>
-
-            <div className="flex flex-1 items-center overflow-hidden rounded border border-[color:var(--page-theme-border-primary)] bg-[color:var(--page-theme-surface-primary)]">
-              <div
-                className="h-7 w-7 shrink-0 cursor-pointer"
-                style={{ backgroundColor: selected }}
-                onClick={(e) => {
-                  e.stopPropagation();
-                  colorInputRef.current?.click();
-                }}
-              />
-              <input
-                ref={colorInputRef}
-                type="color"
-                value={selected}
-                onChange={(e) => {
-                  e.stopPropagation();
-                  onChange(e.target.value);
-                }}
-                className="absolute h-0 w-0 opacity-0"
-              />
-              <input
-                type="text"
-                value={resolvedDraftHex}
-                onChange={handleHexInput}
-                onBlur={handleHexBlur}
-                onClick={(e) => e.stopPropagation()}
-                className="w-0 flex-1 bg-transparent px-1.5 text-xs text-[color:var(--page-theme-text-primary)] outline-none"
-                maxLength={7}
+              <HexColorPicker
+                color={selected}
+                onChange={onChange}
+                style={{ width: "100%", height: 148 }}
               />
             </div>
 
-            <button
-              onClick={(e) => {
-                e.stopPropagation();
-                onSlotAdd();
-              }}
-              className="flex h-7 w-7 shrink-0 items-center justify-center rounded border border-[color:var(--page-theme-border-primary)] text-sm text-[color:var(--page-theme-text-secondary)] hover:bg-[color:var(--page-theme-surface-secondary)]"
-              title={t("vote.palette.addSlot")}
-            >
-              +
-            </button>
+            <div className="mt-3 flex items-center gap-1.5">
+              <button
+                onClick={handleEyeDropper}
+                className="flex h-7 w-7 shrink-0 items-center justify-center rounded border border-[color:var(--page-theme-border-primary)] text-xs text-[color:var(--page-theme-text-secondary)] hover:bg-[color:var(--page-theme-surface-secondary)]"
+                title={t("vote.palette.eyeDropper")}
+              >
+                <img
+                  src={eyedropperIcon}
+                  alt=""
+                  className="h-4 w-4 object-contain"
+                  draggable={false}
+                />
+              </button>
 
-            <button
-              onClick={(e) => {
-                e.stopPropagation();
-                onSlotReset();
-              }}
-              className="flex h-7 w-7 shrink-0 items-center justify-center rounded border border-[color:var(--page-theme-border-primary)] text-xs text-[color:var(--page-theme-text-secondary)] hover:bg-[color:var(--page-theme-surface-secondary)]"
-              title={t("vote.palette.reset")}
-            >
-              ↺
-            </button>
-          </div>
+              <div className="flex flex-1 items-center overflow-hidden rounded border border-[color:var(--page-theme-border-primary)] bg-[color:var(--page-theme-surface-primary)]">
+                <div
+                  className="h-7 w-7 shrink-0"
+                  style={{ backgroundColor: selected }}
+                />
+                <input
+                  type="text"
+                  value={resolvedDraftHex}
+                  onChange={handleHexInput}
+                  onBlur={handleHexBlur}
+                  onClick={(e) => e.stopPropagation()}
+                  className="w-0 flex-1 bg-transparent px-1.5 text-xs text-[color:var(--page-theme-text-primary)] outline-none"
+                  maxLength={7}
+                />
+              </div>
+
+              <button
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onSlotAdd();
+                }}
+                className="flex h-7 w-7 shrink-0 items-center justify-center rounded border border-[color:var(--page-theme-border-primary)] text-sm text-[color:var(--page-theme-text-secondary)] hover:bg-[color:var(--page-theme-surface-secondary)]"
+                title={t("vote.palette.addSlot")}
+              >
+                +
+              </button>
+
+              <button
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onSlotReset();
+                }}
+                className="flex h-7 w-7 shrink-0 items-center justify-center rounded border border-[color:var(--page-theme-border-primary)] text-xs text-[color:var(--page-theme-text-secondary)] hover:bg-[color:var(--page-theme-surface-secondary)]"
+                title={t("vote.palette.reset")}
+              >
+                ↺
+              </button>
+            </div>
+          </>
         )}
       </div>
 

--- a/frontend/src/features/gameplay/vote/components/VotePanel.tsx
+++ b/frontend/src/features/gameplay/vote/components/VotePanel.tsx
@@ -59,6 +59,9 @@ interface Props {
   onEndGame?: () => void;
   roomTerminateLoading?: boolean;
   onTerminateRoom?: () => void;
+  voteMode: "select" | "instant";
+  onVoteModeChange: (mode: "select" | "instant") => void;
+  onOpenInstantVotePalette?: (anchorRect: DOMRect) => void;
 }
 
 export default function VotePanel({
@@ -95,6 +98,9 @@ export default function VotePanel({
   onEndGame,
   roomTerminateLoading = false,
   onTerminateRoom,
+  voteMode,
+  onVoteModeChange,
+  onOpenInstantVotePalette,
 }: Props) {
   const navigate = useNavigate();
   const { locale, setLocale, t } = useI18n();
@@ -113,6 +119,8 @@ export default function VotePanel({
   const isVotingPhase = phase === GAME_PHASE.ROUND_ACTIVE;
   const isSettingsVisible =
     forceSettingsOpen || (!settingsDisabled && isSettingsOpen);
+  const shouldShowInstantVoteTicketsMessage =
+    voteMode === "instant" && isVotingPhase && remaining !== null && remaining <= 0;
 
   useEffect(() => {
     if (!isSettingsOpen) {
@@ -245,19 +253,67 @@ export default function VotePanel({
           votingParticipantCount={votingParticipantCount}
         />
 
-        <div className="flex min-h-2 items-center justify-between gap-3">
-          <p className="text-sm font-semibold text-[color:var(--page-theme-text-primary)]">
-            {t("vote.remainingVotes")}
-          </p>
-          {isVotingPhase && remaining !== null ? (
-            <span className="text-sm font-bold text-[color:var(--page-theme-primary-action)]">
-              {remaining}/{votesPerRound}
-            </span>
-          ) : (
-            <span className="text-sm text-[color:var(--page-theme-text-tertiary)]">
-              -
-            </span>
-          )}
+        <div className="rounded-xl border border-[color:var(--page-theme-border-primary)] bg-[color:var(--page-theme-surface-primary)] p-2.5">
+          <div className="mb-2 flex items-center justify-between gap-3">
+            <p className="text-sm font-semibold text-[color:var(--page-theme-text-primary)]">
+              {locale === "ko" ? "투표 모드" : "Vote mode"}
+            </p>
+            {shouldShowInstantVoteTicketsMessage ? (
+              <span className="text-xs font-medium text-[color:var(--page-theme-alert)]">
+                {locale === "ko"
+                  ? "남은 투표권이 없어요"
+                  : "No votes remaining"}
+              </span>
+            ) : null}
+          </div>
+          <div className="grid grid-cols-2 gap-2">
+            <button
+              type="button"
+              onClick={() => onVoteModeChange("select")}
+              className={[
+                "rounded-full border px-3 py-2 text-xs font-semibold transition",
+                voteMode === "select"
+                  ? "border-[color:var(--page-theme-primary-action)] bg-[color:var(--page-theme-primary-action)] text-[color:var(--page-theme-primary-action-text)]"
+                  : "border-[color:var(--page-theme-border-primary)] text-[color:var(--page-theme-text-secondary)] hover:bg-[color:var(--page-theme-surface-secondary)]",
+              ].join(" ")}
+            >
+              {locale === "ko" ? "색상 선택" : "Color select"}
+            </button>
+            <button
+              type="button"
+              onClick={(event) => {
+                onVoteModeChange("instant");
+                onOpenInstantVotePalette?.(
+                  event.currentTarget.getBoundingClientRect(),
+                );
+              }}
+              className={[
+                "rounded-full border px-3 py-2 text-xs font-semibold transition",
+                voteMode === "instant"
+                  ? "border-[color:var(--page-theme-primary-action)] bg-[color:var(--page-theme-primary-action)] text-[color:var(--page-theme-primary-action-text)]"
+                  : "border-[color:var(--page-theme-border-primary)] text-[color:var(--page-theme-text-secondary)] hover:bg-[color:var(--page-theme-surface-secondary)]",
+              ].join(" ")}
+            >
+              {locale === "ko" ? "바로 투표" : "Instant vote"}
+            </button>
+          </div>
+        </div>
+
+        <div className="rounded-xl border border-[color:var(--page-theme-border-primary)] bg-[color:var(--page-theme-surface-primary)] px-3 py-2.5">
+          <div className="flex min-h-2 items-center justify-between gap-3">
+            <p className="text-sm font-semibold text-[color:var(--page-theme-text-primary)]">
+              {t("vote.remainingVotes")}
+            </p>
+            {isVotingPhase && remaining !== null ? (
+              <span className="text-sm font-bold text-[color:var(--page-theme-primary-action)]">
+                {remaining}/{votesPerRound}
+              </span>
+            ) : (
+              <span className="text-sm text-[color:var(--page-theme-text-tertiary)]">
+                -
+              </span>
+            )}
+          </div>
         </div>
       </div>
 

--- a/frontend/src/features/gameplay/vote/components/VotePopup.tsx
+++ b/frontend/src/features/gameplay/vote/components/VotePopup.tsx
@@ -36,6 +36,7 @@ interface Props {
   tutorialMode?: boolean;
   tutorialId?: string;
   fixedPosition?: { x: number; y: number } | null;
+  hideSubmitButton?: boolean;
   layerClassName?: string;
 }
 
@@ -111,6 +112,7 @@ export default function VotePopup({
   tutorialMode = false,
   tutorialId,
   fixedPosition = null,
+  hideSubmitButton = false,
   layerClassName = "z-50",
 }: Props) {
   const { locale, t } = useI18n();
@@ -532,14 +534,16 @@ export default function VotePopup({
           onSlotSelect={handleSlotSelect}
         />
 
-        <Button
-          type="button"
-          className="w-full"
-          disabled={isVoteDisabled}
-          onClick={handleSubmit}
-        >
-          {buttonLabel}
-        </Button>
+        {!hideSubmitButton ? (
+          <Button
+            type="button"
+            className="w-full"
+            disabled={isVoteDisabled}
+            onClick={handleSubmit}
+          >
+            {buttonLabel}
+          </Button>
+        ) : null}
 
         {!isVotingPhase && (
           <p className="text-sm text-[color:var(--page-theme-text-secondary)]">

--- a/frontend/src/pages/canvas/CanvasPage.tsx
+++ b/frontend/src/pages/canvas/CanvasPage.tsx
@@ -268,6 +268,12 @@ export default function CanvasPage({ sessionSourceApi }: CanvasPageProps) {
   const [mobileSheet, setMobileSheet] = useState<MobileSheetType>(null);
   const [mobileVoteMode, setMobileVoteMode] =
     useState<MobileVoteMode>("select");
+  const [desktopVoteMode, setDesktopVoteMode] =
+    useState<MobileVoteMode>("select");
+  const [desktopPaletteColor, setDesktopPaletteColor] = useState(() =>
+    loadLastPaletteColor(),
+  );
+  const [desktopVoteLoading, setDesktopVoteLoading] = useState(false);
   const [mobilePalettePinned, setMobilePalettePinned] = useState(false);
   const [mobilePaletteColor, setMobilePaletteColor] = useState(() =>
     loadLastPaletteColor(),
@@ -372,7 +378,7 @@ export default function CanvasPage({ sessionSourceApi }: CanvasPageProps) {
     },
     [sessionSourceApi.key],
   );
-  const mobileCellActivatedHandlerRef = useRef<(cell: Cell) => void>(() => {});
+  const cellActivatedHandlerRef = useRef<(cell: Cell) => void>(() => {});
 
   const {
     paintCanvasRef,
@@ -439,6 +445,7 @@ export default function CanvasPage({ sessionSourceApi }: CanvasPageProps) {
     roundSummaryPosition,
     handleRoundSummaryDragStart,
     latestRoundSnapshot,
+    openVotePopupForCell,
     backgroundMode,
     setBackgroundMode,
     historyItems,
@@ -451,10 +458,11 @@ export default function CanvasPage({ sessionSourceApi }: CanvasPageProps) {
     onContextMissing:
       sessionSourceApi.key === "room" ? handleContextMissing : undefined,
     onUnauthorized: handleUnauthorized,
-    openPopupOnActivate: !isMobileLayout,
-    resetPreviewOnActivate: !isMobileLayout,
+    openPopupOnActivate: isMobileLayout ? false : desktopVoteMode === "select",
+    resetPreviewOnActivate:
+      isMobileLayout ? false : desktopVoteMode === "select",
     onCellActivated: (cell) => {
-      mobileCellActivatedHandlerRef.current(cell);
+      cellActivatedHandlerRef.current(cell);
     },
   });
 
@@ -723,8 +731,14 @@ export default function CanvasPage({ sessionSourceApi }: CanvasPageProps) {
             {
               id: "round-info",
               targetIds: ["tutorial-round-info"],
-              title: t("tutorial.step.roundInfo.title"),
-              description: t("tutorial.step.roundInfo.description"),
+              title:
+                locale === "ko"
+                  ? "좌측 정보 패널"
+                  : "Left info panel",
+              description:
+                locale === "ko"
+                  ? "현재 라운드 상태, 남은시간, 종료 예정 시각을 이 영역에서 확인합니다.\n두 가지 투표 모드를 지원하며 색상 선택 모드는 하나의 칸마다 색상을 선택하고 투표할 수 있습니다.\n바로 투표 모드는 처음에 색상을 선택하고 칸을 클릭하여 바로 투표할 수 있습니다.\n이번 라운드에서 사용할 수 있는 남은 투표권 수를 확인할 수 있습니다."
+                  : "Check the current round state, remaining time, and expected end time in this area.\nTwo voting modes are supported. In color select mode, you can choose a color and vote for each individual cell.\nIn instant vote mode, you choose a color first and then click cells to vote immediately.\nYou can also check how many vote tickets remain for this round here.",
               padding: 8,
             },
             {
@@ -830,6 +844,58 @@ export default function CanvasPage({ sessionSourceApi }: CanvasPageProps) {
   const shouldDisableSettingsButton =
     (introGuideOpen || roundSummaryOpen || Boolean(gameSummaryModal)) &&
     !tutorialNeedsSettingsPanel;
+  const desktopInstantVoteTargetCell = useMemo(() => {
+    if (selectedCell) {
+      return selectedCell;
+    }
+
+    const fallbackX = Math.max(0, Math.floor(gridX / 2));
+    const fallbackY = Math.max(0, Math.floor(gridY / 2));
+
+    return (
+      cells.find((cell) => cell.x === fallbackX && cell.y === fallbackY) ?? {
+        x: fallbackX,
+        y: fallbackY,
+        color: null,
+        status: "idle" as const,
+      }
+    );
+  }, [cells, gridX, gridY, selectedCell]);
+  const openDesktopInstantVotePalette = useCallback((anchorRect: DOMRect) => {
+    if (isMobileLayout) {
+      return;
+    }
+
+    const popupWidth = 256;
+    const popupHeight = 356;
+    const viewportPadding = 12;
+    const horizontalGap = anchorRect.width / 2;
+    const desiredX = Math.min(
+      window.innerWidth - popupWidth - viewportPadding,
+      Math.max(
+        viewportPadding,
+        anchorRect.left - popupWidth - horizontalGap,
+      ),
+    );
+    const desiredY = Math.min(
+      window.innerHeight - popupHeight - viewportPadding,
+      Math.max(
+        viewportPadding,
+        anchorRect.top + anchorRect.height / 2 - popupHeight / 2,
+      ),
+    );
+    const popupPosition = {
+      // VotePopup desktop positioning interprets `position` like a pointer
+      // anchor and applies its own internal offset (+190, -120). Feed the
+      // inverse so the final modal lands at the desired absolute position.
+      x: desiredX - 190,
+      y: desiredY + 120,
+    };
+
+    openVotePopupForCell(desktopInstantVoteTargetCell, popupPosition);
+  }, [desktopInstantVoteTargetCell, isMobileLayout, openVotePopupForCell]);
+
+  const handleCloseVotePopup = handlePopupClose;
   const selectionLabels = useMemo(() => {
     if (!currentVoterUuid) {
       return [];
@@ -1207,22 +1273,77 @@ export default function CanvasPage({ sessionSourceApi }: CanvasPageProps) {
     ],
   );
 
+  const handleSubmitDesktopInstantVote = useCallback(
+    async (targetCell: Cell) => {
+      if (desktopVoteLoading || !canvasId || !roundId) {
+        return;
+      }
+
+      if (phase !== GAME_PHASE.ROUND_ACTIVE) {
+        return;
+      }
+
+      if (isRoundExpired) {
+        return;
+      }
+
+      if (remaining !== null && remaining <= 0) {
+        return;
+      }
+
+      setDesktopVoteLoading(true);
+
+      try {
+        await voteApi.submit({
+          canvasId,
+          roundId,
+          x: targetCell.x,
+          y: targetCell.y,
+          color: desktopPaletteColor,
+        });
+
+        handleVoteSuccess(desktopPaletteColor);
+      } catch (err: unknown) {
+        if (err && typeof err === "object" && "response" in err) {
+          return;
+        }
+      } finally {
+        setDesktopVoteLoading(false);
+      }
+    },
+    [
+      canvasId,
+      desktopPaletteColor,
+      desktopVoteLoading,
+      handleVoteSuccess,
+      isRoundExpired,
+      phase,
+      remaining,
+      roundId,
+    ],
+  );
+
   useEffect(() => {
-    mobileCellActivatedHandlerRef.current = (cell) => {
-      if (!isMobileLayout) {
+    cellActivatedHandlerRef.current = (cell) => {
+      if (isMobileLayout) {
+        setMobileVoteError("");
+
+        if (mobileVoteMode === "instant") {
+          void handleSubmitMobileVote(cell);
+          return;
+        }
+
+        openMobilePaletteSheet();
         return;
       }
 
-      setMobileVoteError("");
-
-      if (mobileVoteMode === "instant") {
-        void handleSubmitMobileVote(cell);
-        return;
+      if (desktopVoteMode === "instant") {
+        void handleSubmitDesktopInstantVote(cell);
       }
-
-      openMobilePaletteSheet();
     };
   }, [
+    desktopVoteMode,
+    handleSubmitDesktopInstantVote,
     handleSubmitMobileVote,
     isMobileLayout,
     mobileVoteMode,
@@ -2103,6 +2224,11 @@ export default function CanvasPage({ sessionSourceApi }: CanvasPageProps) {
             onEndGame={handleEndGame}
             roomTerminateLoading={roomTerminateLoading}
             onTerminateRoom={handleTerminateRoom}
+            voteMode={desktopVoteMode}
+            onVoteModeChange={(nextMode) => {
+              setDesktopVoteMode(nextMode);
+            }}
+            onOpenInstantVotePalette={openDesktopInstantVotePalette}
           />
         )}
       </div>
@@ -2132,12 +2258,19 @@ export default function CanvasPage({ sessionSourceApi }: CanvasPageProps) {
           votes={votes}
           position={popupPos}
           onVoteSuccess={handleVoteSuccess}
-          onColorChange={handleColorChange}
-          onClose={handlePopupClose}
+          onColorChange={(nextColor) => {
+            handleColorChange(nextColor);
+
+            if (nextColor) {
+              setDesktopPaletteColor(nextColor);
+            }
+          }}
+          onClose={handleCloseVotePopup}
           tutorialMode={shouldDecorateLiveVotePopup}
           tutorialId={
             shouldDecorateLiveVotePopup ? "tutorial-vote-modal" : undefined
           }
+          hideSubmitButton={!isMobileLayout && desktopVoteMode === "instant"}
           layerClassName={shouldDecorateLiveVotePopup ? "z-[81]" : undefined}
         />
       )}

--- a/frontend/src/pages/canvas/model/useCanvasPage.ts
+++ b/frontend/src/pages/canvas/model/useCanvasPage.ts
@@ -117,6 +117,7 @@ export default function useCanvasPage({
     clearSelectedCell,
     applySelectedCellColor,
     hideSelectedCellVisual,
+    openVotePopupForCell,
   } = useCanvasScene({
     previewColor,
     votingCellIds,
@@ -449,5 +450,6 @@ export default function useCanvasPage({
     historyItems,
     historyLoading,
     historyError,
+    openVotePopupForCell,
   };
 }

--- a/frontend/src/pages/canvas/model/useCanvasScene.ts
+++ b/frontend/src/pages/canvas/model/useCanvasScene.ts
@@ -1128,6 +1128,29 @@ export default function useCanvasScene({
     emitSelectionUpdate(null);
   }, [emitSelectionUpdate]);
 
+  const openVotePopupForCell = useCallback(
+    (cell: Cell, popupPosition?: { x: number; y: number }) => {
+      if (resetPreviewOnActivate) {
+        resetPreviewColor();
+      }
+
+      setSelectedCell(cell);
+      selectedCellRef.current = cell;
+      setSelectionVisible(true);
+      emitSelectionUpdate(cell);
+      openPopup(
+        popupPosition ?? getPopupPositionForCell(cell.x, cell.y) ?? { x: 0, y: 0 },
+      );
+    },
+    [
+      emitSelectionUpdate,
+      getPopupPositionForCell,
+      openPopup,
+      resetPreviewColor,
+      resetPreviewOnActivate,
+    ],
+  );
+
   return {
     paintCanvasRef,
     canvasRef,
@@ -1164,5 +1187,6 @@ export default function useCanvasScene({
     clearSelectedCell,
     applySelectedCellColor,
     hideSelectedCellVisual,
+    openVotePopupForCell,
   };
 }


### PR DESCRIPTION
## 관련 이슈
- Close #451 

## 변경 내용

- 데스크톱 우측 패널에 `투표 모드` 영역을 추가하고 `색상 선택`, `바로 투표` 토글 버튼을 배치
- `바로 투표` 모드에서는 버튼 클릭 시 버튼 좌측에 투표 모달이 열리도록 조정
- `바로 투표`로 열린 데스크톱 투표 모달은 드래그 가능하게 유지하고, `투표하기` 버튼은 숨김
- 데스크톱 투표 모달의 색상 팔레트를 다시 기본 형태로 복구하고 현재 색상 클릭으로 별도 팔레트를 여는 동작 제거
- `남은 투표권` 영역을 카드 형태로 정리하고, 표를 모두 사용한 경우 `투표 모드` 옆에 안내 문구 표시
- 데스크톱 튜토리얼 4번째 안내 문구를 `좌측 정보 패널` 기준 설명으로 수정
- 광장 플레이용 current 조회를 `진행 중인 캔버스`만 반환하도록 조정해, 게임 종료 후 광장 재시작 재접속 흐름을 복구
- 랜딩/조회용 광장 current fallback은 유지해 기존 랜딩 카드 동작에는 영향 없도록 분리

## 기대 동작

- 데스크톱에서 `색상 선택`과 `바로 투표` 모드를 명확하게 전환할 수 있다
- `바로 투표` 버튼을 누르면 버튼 근처에 투표 모달이 열리고, 색상을 먼저 고른 뒤 셀 클릭으로 즉시 투표할 수 있다
- 광장 게임 종료 후 새 게임이 생성되면 플레이 화면이 끝난 캔버스에 고정되지 않고 다음 진행 중 캔버스로 다시 붙는다
- 데스크톱 튜토리얼에서 좌측 정보 패널의 역할을 더 명확하게 이해할 수 있다

## 확인 내용

- `frontend npx tsc -b` 통과
- `frontend npm run lint -- --quiet` 통과
- `backend npx tsc --noEmit` 통과
- `backend npm run build`는 기존 `dist` 쓰기 권한 문제로 확인 불가
- 광장 종료 후 새 캔버스 재접속 시나리오 수동 확인 필요