### PR TITLE
feat: result 이미지 생성 정책과 강제 게임 종료 흐름 정리

### DIFF
--- a/backend/src/modules/game/game.timer.ts
+++ b/backend/src/modules/game/game.timer.ts
@@ -258,6 +258,30 @@ export async function forceGameEnd(
   roomTerminationReason: RoomTerminationReason | null = null,
 ): Promise<void> {
   clearCanvasTimers(canvasId);
+
+  const activeRound = await roundRepository.findOne({
+    where: { canvas: { id: canvasId }, isActive: true },
+    order: { roundNumber: "DESC" },
+  });
+
+  if (activeRound) {
+    try {
+      await roundService.endRound(canvasId, activeRound.id, io);
+      await transitionToGameEnd(
+        io,
+        canvasId,
+        activeRound.roundNumber,
+        roomTerminationReason,
+      );
+      return;
+    } catch (error) {
+      console.error(
+        `[game-timer] failed to end active round before forced game end (canvasId=${canvasId}, roundId=${activeRound.id}):`,
+        error,
+      );
+    }
+  }
+
   await transitionToGameEnd(io, canvasId, roundNumber, roomTerminationReason);
 }
 

--- a/backend/src/modules/history/final-result-image.service.ts
+++ b/backend/src/modules/history/final-result-image.service.ts
@@ -183,6 +183,7 @@ export const finalResultImageService = {
     });
     const resultTemplateImageBuffer =
       await loadResultTemplateAsset(resultTemplateAssetKey);
+    const capturedAt = canvas.endedAt ?? new Date();
 
     const renderedSnapshot = roundSnapshotRenderService.renderPngBuffer({
       gridWidth: canvas.gridX,
@@ -195,9 +196,13 @@ export const finalResultImageService = {
       backgroundImageBuffer: resultTemplateImageBuffer,
     });
 
-    await ensureGameResultDirectory();
+    await ensureGameResultDirectory({
+      capturedAt,
+      canvasId,
+    });
 
     const relativePath = buildGameResultRelativePath({
+      capturedAt,
       canvasId,
       format: "png",
     });
@@ -211,7 +216,7 @@ export const finalResultImageService = {
     gameSummary.finalResultWidth = renderedSnapshot.imageWidth;
     gameSummary.finalResultHeight = renderedSnapshot.imageHeight;
     gameSummary.finalResultByteSize = renderedSnapshot.buffer.byteLength;
-    gameSummary.finalResultCapturedAt = canvas.endedAt ?? new Date();
+    gameSummary.finalResultCapturedAt = capturedAt;
 
     await gameSummaryRepository.save(gameSummary);
   },

--- a/backend/src/modules/history/final-result-image.service.ts
+++ b/backend/src/modules/history/final-result-image.service.ts
@@ -24,6 +24,16 @@ const finalResultDownloadLocks = new Map<string, Promise<string>>();
 
 type FinalResultDownloadVariant = "original" | "hd";
 
+function clearFinalResultMetadata(summary: GameSummary): void {
+  summary.finalResultStoragePath = null;
+  summary.finalResultMimeType = null;
+  summary.finalResultFormat = null;
+  summary.finalResultWidth = null;
+  summary.finalResultHeight = null;
+  summary.finalResultByteSize = null;
+  summary.finalResultCapturedAt = null;
+}
+
 export const finalResultImageService = {
   buildFinalResultImageApiPath(canvasId: number): string {
     return `/api/public/canvas/${canvasId}/final-result`;
@@ -169,6 +179,12 @@ export const finalResultImageService = {
 
     if (!gameSummary) {
       throw new Error(`Game summary was not found. (canvasId=${canvasId})`);
+    }
+
+    if (gameSummary.totalVotes <= 0) {
+      clearFinalResultMetadata(gameSummary);
+      await gameSummaryRepository.save(gameSummary);
+      return;
     }
 
     const cells = await cellRepository

--- a/backend/src/modules/history/history-storage.service.ts
+++ b/backend/src/modules/history/history-storage.service.ts
@@ -101,21 +101,41 @@ export function getLandingPreviewFilename(
 }
 
 export function getGameResultFilename(
-  canvasId: number,
   format: StorageImageFormat = "png",
 ): string {
-  return `canvas-${canvasId}-result.${format}`;
+  return `result.${format}`;
+}
+
+export function getGameResultRelativeDirectory(params: {
+  capturedAt: Date;
+  canvasId: number;
+}): string {
+  const year = String(params.capturedAt.getFullYear());
+  const month = formatMonth(params.capturedAt.getMonth() + 1);
+  const day = formatDay(params.capturedAt.getDate());
+
+  return path.posix.join(
+    GAME_RESULT_PREFIX,
+    year,
+    month,
+    day,
+    `canvas-${params.canvasId}`,
+  );
 }
 
 export function buildGameResultRelativePath(params: {
+  capturedAt: Date;
   canvasId: number;
   format?: StorageImageFormat;
 }): string {
   const format = params.format ?? "png";
 
   return path.posix.join(
-    GAME_RESULT_PREFIX,
-    getGameResultFilename(params.canvasId, format),
+    getGameResultRelativeDirectory({
+      capturedAt: params.capturedAt,
+      canvasId: params.canvasId,
+    }),
+    getGameResultFilename(format),
   );
 }
 
@@ -234,11 +254,17 @@ export async function ensureLandingPreviewDirectory(params: {
   };
 }
 
-export async function ensureGameResultDirectory(): Promise<{
+export async function ensureGameResultDirectory(params: {
+  capturedAt: Date;
+  canvasId: number;
+}): Promise<{
   relativeDirPath: string;
   absoluteDirPath: string;
 }> {
-  const relativeDirPath = GAME_RESULT_PREFIX;
+  const relativeDirPath = getGameResultRelativeDirectory({
+    capturedAt: params.capturedAt,
+    canvasId: params.canvasId,
+  });
   const absoluteDirPath = resolveGameHistoryAbsolutePath(relativeDirPath);
 
   await mkdir(absoluteDirPath, { recursive: true });

--- a/frontend/src/features/gameplay/session/components/GameSummaryModal.tsx
+++ b/frontend/src/features/gameplay/session/components/GameSummaryModal.tsx
@@ -366,13 +366,13 @@ export default function GameSummaryModal({
 
   return (
     <div
-      className="pointer-events-none fixed inset-0 z-50 bg-[color:var(--page-theme-overlay)] px-3 py-6"
+      className="pointer-events-none fixed inset-0 z-50 px-3 py-6"
     >
       <div
         className={
           mobileLayout
-            ? "pointer-events-auto fixed inset-0 bg-[color:var(--page-theme-overlay)]"
-            : "pointer-events-auto fixed bottom-0 right-0 bg-[color:var(--page-theme-overlay)]"
+            ? "pointer-events-auto fixed inset-0"
+            : "pointer-events-auto fixed bottom-0 right-0"
         }
         style={
           mobileLayout

--- a/frontend/src/features/gameplay/vote/components/VotePanel.tsx
+++ b/frontend/src/features/gameplay/vote/components/VotePanel.tsx
@@ -56,6 +56,7 @@ interface Props {
   ) => void;
   currentRoomManage?: RoomCurrentManageResponse["room"] | null;
   roomEndGameLoading?: boolean;
+  roomEndGameDisabled?: boolean;
   onEndGame?: () => void;
   roomTerminateLoading?: boolean;
   onTerminateRoom?: () => void;
@@ -95,6 +96,7 @@ export default function VotePanel({
   onNavigateToCoordinate,
   currentRoomManage = null,
   roomEndGameLoading = false,
+  roomEndGameDisabled = false,
   onEndGame,
   roomTerminateLoading = false,
   onTerminateRoom,
@@ -229,6 +231,7 @@ export default function VotePanel({
               onBackgroundModeChange={onBackgroundModeChange}
               roomManage={currentRoomManage}
               roomEndGameLoading={roomEndGameLoading}
+              roomEndGameDisabled={roomEndGameDisabled}
               onEndGame={onEndGame}
               roomTerminateLoading={roomTerminateLoading}
               onTerminateRoom={onTerminateRoom}

--- a/frontend/src/features/gameplay/vote/components/VotePanelSettings.tsx
+++ b/frontend/src/features/gameplay/vote/components/VotePanelSettings.tsx
@@ -9,6 +9,7 @@ interface Props {
   onBackgroundModeChange: (mode: PlayBackgroundMode) => void;
   roomManage?: RoomCurrentManageResponse["room"] | null;
   roomEndGameLoading?: boolean;
+  roomEndGameDisabled?: boolean;
   onEndGame?: () => void;
   roomTerminateLoading?: boolean;
   onTerminateRoom?: () => void;
@@ -24,6 +25,7 @@ const VotePanelSettings = forwardRef<HTMLDivElement, Props>(
       onBackgroundModeChange,
       roomManage,
       roomEndGameLoading = false,
+      roomEndGameDisabled = false,
       onEndGame,
       roomTerminateLoading = false,
       onTerminateRoom,
@@ -144,7 +146,9 @@ const VotePanelSettings = forwardRef<HTMLDivElement, Props>(
               </div>
               <button
                 type="button"
-                disabled={roomEndGameLoading || !onEndGame}
+                disabled={
+                  roomEndGameLoading || roomEndGameDisabled || !onEndGame
+                }
                 onClick={onEndGame}
                 className="mt-3 w-full rounded-lg bg-[#272E37] px-3 py-2 text-xs font-semibold text-white disabled:cursor-not-allowed disabled:opacity-60"
               >

--- a/frontend/src/pages/canvas/CanvasPage.tsx
+++ b/frontend/src/pages/canvas/CanvasPage.tsx
@@ -302,6 +302,7 @@ export default function CanvasPage({ sessionSourceApi }: CanvasPageProps) {
     RoomCurrentManageResponse["room"] | null
   >(null);
   const [roomEndGameLoading, setRoomEndGameLoading] = useState(false);
+  const [roomEndGameRequested, setRoomEndGameRequested] = useState(false);
   const [roomTerminateLoading, setRoomTerminateLoading] = useState(false);
   const [roomExpiredReason, setRoomExpiredReason] = useState<
     "expired" | "terminated_by_owner" | null
@@ -536,6 +537,17 @@ export default function CanvasPage({ sessionSourceApi }: CanvasPageProps) {
     };
   }, [sessionSourceApi.key]);
 
+  useEffect(() => {
+    if (sessionSourceApi.key !== "room") {
+      setRoomEndGameRequested(false);
+      return;
+    }
+
+    if (phase === GAME_PHASE.GAME_END) {
+      setRoomEndGameRequested(true);
+    }
+  }, [phase, sessionSourceApi.key]);
+
   const handleTerminateRoom = useCallback(async () => {
     if (sessionSourceApi.key !== "room" || !currentRoomManage) {
       return;
@@ -596,6 +608,7 @@ export default function CanvasPage({ sessionSourceApi }: CanvasPageProps) {
       return;
     }
 
+    setRoomEndGameRequested(true);
     setRoomEndGameLoading(true);
 
     try {
@@ -621,6 +634,7 @@ export default function CanvasPage({ sessionSourceApi }: CanvasPageProps) {
             : "Failed to end the game.",
         );
       }
+      setRoomEndGameRequested(false);
     } finally {
       setRoomEndGameLoading(false);
     }
@@ -1814,7 +1828,11 @@ export default function CanvasPage({ sessionSourceApi }: CanvasPageProps) {
                 <div className="mt-3 grid grid-cols-2 gap-2">
                   <button
                     type="button"
-                    disabled={roomEndGameLoading}
+                    disabled={
+                      roomEndGameLoading ||
+                      roomEndGameRequested ||
+                      phase === GAME_PHASE.GAME_END
+                    }
                     onClick={handleEndGame}
                     className="rounded-xl bg-[#272E37] px-3 py-2 text-sm font-semibold text-white disabled:opacity-50"
                   >
@@ -2221,6 +2239,9 @@ export default function CanvasPage({ sessionSourceApi }: CanvasPageProps) {
               sessionSourceApi.key === "room" ? currentRoomManage : null
             }
             roomEndGameLoading={roomEndGameLoading}
+            roomEndGameDisabled={
+              roomEndGameRequested || phase === GAME_PHASE.GAME_END
+            }
             onEndGame={handleEndGame}
             roomTerminateLoading={roomTerminateLoading}
             onTerminateRoom={handleTerminateRoom}

--- a/frontend/src/pages/canvas/CanvasPage.tsx
+++ b/frontend/src/pages/canvas/CanvasPage.tsx
@@ -537,17 +537,6 @@ export default function CanvasPage({ sessionSourceApi }: CanvasPageProps) {
     };
   }, [sessionSourceApi.key]);
 
-  useEffect(() => {
-    if (sessionSourceApi.key !== "room") {
-      setRoomEndGameRequested(false);
-      return;
-    }
-
-    if (phase === GAME_PHASE.GAME_END) {
-      setRoomEndGameRequested(true);
-    }
-  }, [phase, sessionSourceApi.key]);
-
   const handleTerminateRoom = useCallback(async () => {
     if (sessionSourceApi.key !== "room" || !currentRoomManage) {
       return;


### PR DESCRIPTION
## 관련 이슈
- Close #455 

## 개요

게임 종료 결과 이미지 `result.png`의 생성 정책과 저장 경로를 정리했습니다.
종료 시점 총 투표 수가 0인 경우 결과 이미지를 생성하지 않도록 기준을 명확히 했고, 저장 경로를 날짜 기반 구조로 변경했습니다.
추가로 게임 진행 중 `게임 종료` 버튼을 눌렀을 때 현재 라운드가 정상 종료되지 않아 `game_preview`가 `FAILED`로 남던 흐름을 보정했습니다.

## 변경사항

- 백엔드
  - `result.png` 저장 경로를 날짜 기반 구조로 변경
    - `game-result/YYYY/MM/DD/canvas-{canvasId}/result.png`
  - `game_summary.totalVotes <= 0`이면 `result.png` 생성 스킵
  - 생성 스킵 시 `game_summary.final_result_*` 메타 초기화
  - 강제 게임 종료 시 활성 라운드가 있으면 먼저 `endRound()`를 수행한 뒤 `GAME_END`로 전환하도록 수정
    - `round snapshot` 저장
    - `round summary` 저장
    - 이후 `game_summary`, `result.png`, `game_preview` 생성 흐름 유지

- 프론트
  - 게임 종료 요청 후 버튼 재클릭 방지
  - `GAME_END` phase에서 종료 버튼 비활성화 유지
  - 게임 종료 통계 모달 상단의 밝은 오버레이 제거

## 코드 흐름

1. 게임 종료 시 요약 저장
- `summaryService.saveGameSummary(canvasId)`가 먼저 실행되어 `game_summary.totalVotes`를 저장합니다.

2. result 이미지 생성
- `finalResultImageService.saveForCanvas(canvasId)`가 `game_summary.totalVotes`를 기준으로 동작합니다.
- `totalVotes <= 0`
  - `result.png` 생성 안 함
  - `final_result_*` 메타를 `null`로 저장
- `totalVotes > 0`
  - 셀 데이터 + result template로 PNG 렌더
  - `game-result/YYYY/MM/DD/canvas-{canvasId}/result.png`에 저장
  - `game_summary.final_result_*` 메타 저장

3. 강제 게임 종료
- 기존에는 `ROUND_ACTIVE` 중 강제 종료 시 현재 라운드를 닫지 않고 바로 `GAME_END`로 넘어갔습니다.
- 이제 활성 라운드가 있으면 먼저 `roundService.endRound()`를 호출한 뒤 `transitionToGameEnd()`로 넘어갑니다.
- 그래서 `round snapshot`이 없는 상태로 `game_preview` 생성이 실패하는 문제가 줄어듭니다.

4. 게임 종료 버튼
- 프론트에서 종료 요청 시작 시 즉시 disabled 상태로 전환합니다.
- 요청 실패 시에만 다시 활성화합니다.
- 성공 후에는 `GAME_END` phase까지 재클릭되지 않습니다.

## 검증

- 백엔드 타입 체크 통과
  - `node backend/node_modules/typescript/bin/tsc --noEmit -p backend/tsconfig.json`
- 프론트 타입 체크 통과
  - `node frontend/node_modules/typescript/bin/tsc -b frontend`

- 수동 확인 포인트
  - `totalVotes > 0`인 종료 캔버스에서 `result.png`가 날짜 기반 경로에 생성되는지
  - `totalVotes <= 0`인 종료 캔버스에서 `result.png`가 생성되지 않고 `final_result_*` 메타가 비어 있는지
  - 게임 진행 중 `게임 종료` 클릭 시 `game_preview`가 `missing_round_snapshots`로 `FAILED` 되지 않는지
  - 게임 종료 버튼이 중복 클릭되지 않는지

## 결정사항

- `result.png` 생성 기준은 종료 시점 집계 결과 `game_summary.totalVotes <= 0` 여부를 사용합니다.
- `totalVotes <= 0`이면 `result.png`를 생성하지 않습니다.
- 저장 경로는 `game-result/YYYY/MM/DD/canvas-{canvasId}/result.png` 형식을 사용합니다.
- 기존 다운로드 링크/생성 파일이 있다면 원본이 없어도 다운로드는 가능한 현재 정책은 유지합니다.
- root 권한 파일 생성 문제와 round snapshot 생성 최적화는 이번 범위에서 제외했습니다.

## 리뷰 포인트

- `finalResultImageService`의 `totalVotes <= 0` 분기와 메타 초기화 방식이 의도에 맞는지
- 강제 게임 종료 시 활성 라운드를 먼저 종료하도록 바꾼 흐름이 다른 phase 전환에 부작용이 없는지
- 게임 종료 버튼 비활성화 시점과 복구 조건이 적절한지