### PR TITLE
fix: 데일리 통계 Telegram 전송 재시도와 호스트 fallback 추가

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -15,6 +15,7 @@
     "test:integration": "vitest run test/integration",
     "test:coverage": "vitest run --coverage",
     "analytics:rollup": "ts-node src/scripts/analytics-rollup.ts",
+    "analytics:send-host-fallback": "node scripts/send-analytics-rollup-host.mjs",
     "analytics:cleanup": "ts-node src/scripts/analytics-cleanup.ts",
     "migration:generate": "ts-node --require tsconfig-paths/register ./node_modules/typeorm/cli.js migration:generate -d src/database/data-source.ts",
     "migration:run": "node ./node_modules/typeorm/cli.js migration:run -d dist/database/data-source.js",

--- a/backend/scripts/send-analytics-rollup-host.mjs
+++ b/backend/scripts/send-analytics-rollup-host.mjs
@@ -1,0 +1,183 @@
+import { readFile, rm } from "node:fs/promises";
+import path from "node:path";
+import { config } from "dotenv";
+
+const DEFAULT_ENV_PATH = "/opt/votedots/env/backend/.env.production";
+const DEFAULT_MESSAGE_PATH = "/opt/votedots/data/runtime/analytics-rollup-message.txt";
+const TELEGRAM_API_BASE_URL = "https://api.telegram.org";
+const TELEGRAM_RETRY_DELAYS_MS = [5_000, 15_000];
+
+function parseArgs(argv) {
+  const options = {
+    envFile: DEFAULT_ENV_PATH,
+    messagePath: DEFAULT_MESSAGE_PATH,
+  };
+
+  for (const arg of argv) {
+    if (arg.startsWith("--env-file=")) {
+      options.envFile = arg.slice("--env-file=".length);
+      continue;
+    }
+
+    if (arg.startsWith("--message-path=")) {
+      options.messagePath = arg.slice("--message-path=".length);
+      continue;
+    }
+
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  return options;
+}
+
+function loadEnvironment(envFile) {
+  config({
+    path: envFile,
+    quiet: true,
+  });
+}
+
+function getRequiredEnvironmentValue(name) {
+  const value = process.env[name]?.trim();
+
+  if (!value) {
+    throw new Error(`Missing required environment variable: ${name}`);
+  }
+
+  return value;
+}
+
+function isRetryableTelegramError(error) {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+
+  const message = error.message.toLowerCase();
+
+  if (
+    message.includes("timedout") ||
+    message.includes("fetch failed") ||
+    message.includes("econnreset") ||
+    message.includes("enetunreach") ||
+    message.includes("eai_again")
+  ) {
+    return true;
+  }
+
+  const cause = error.cause ?? null;
+
+  if (cause instanceof Error) {
+    return isRetryableTelegramError(cause);
+  }
+
+  if (
+    typeof cause === "object" &&
+    cause !== null &&
+    "errors" in cause &&
+    Array.isArray(cause.errors)
+  ) {
+    return cause.errors.some((childError) => isRetryableTelegramError(childError));
+  }
+
+  return false;
+}
+
+function wait(delayMs) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, delayMs);
+  });
+}
+
+async function sendMessage(text) {
+  const botToken = getRequiredEnvironmentValue("TELEGRAM_BOT_TOKEN");
+  const chatId = getRequiredEnvironmentValue("TELEGRAM_CHAT_ID");
+  const response = await fetch(`${TELEGRAM_API_BASE_URL}/bot${botToken}/sendMessage`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      chat_id: chatId,
+      text,
+      disable_web_page_preview: true,
+    }),
+  });
+
+  const rawPayload = await response.text();
+  let payload = null;
+
+  if (rawPayload) {
+    try {
+      payload = JSON.parse(rawPayload);
+    } catch {
+      payload = null;
+    }
+  }
+
+  if (!response.ok) {
+    throw new Error(
+      `Telegram API request failed with status ${response.status}${payload?.description ? `: ${payload.description}` : ""}`,
+    );
+  }
+
+  if (payload && !payload.ok) {
+    throw new Error(`Telegram API responded with ok=false${payload.description ? `: ${payload.description}` : ""}`);
+  }
+}
+
+async function sendMessageWithRetry(text) {
+  let lastError = null;
+
+  for (let attempt = 0; attempt <= TELEGRAM_RETRY_DELAYS_MS.length; attempt += 1) {
+    try {
+      await sendMessage(text);
+      return;
+    } catch (error) {
+      lastError = error;
+
+      if (
+        attempt >= TELEGRAM_RETRY_DELAYS_MS.length ||
+        !isRetryableTelegramError(error)
+      ) {
+        break;
+      }
+
+      await wait(TELEGRAM_RETRY_DELAYS_MS[attempt]);
+    }
+  }
+
+  throw lastError;
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  loadEnvironment(options.envFile);
+
+  const messagePath = path.resolve(options.messagePath);
+  let text = "";
+
+  try {
+    text = (await readFile(messagePath, "utf8")).trim();
+  } catch (error) {
+    if (error && typeof error === "object" && "code" in error && error.code === "ENOENT") {
+      console.log("[analytics:rollup:host-fallback] no pending message file");
+      return;
+    }
+
+    throw error;
+  }
+
+  if (!text) {
+    console.log("[analytics:rollup:host-fallback] message file is empty");
+    return;
+  }
+
+  await sendMessageWithRetry(text);
+  await rm(messagePath, { force: true });
+  console.log("[analytics:rollup:host-fallback] telegram notification sent");
+}
+
+main().catch((error) => {
+  console.error("[analytics:rollup:host-fallback] failed:", error);
+  process.exit(1);
+});

--- a/backend/src/modules/analytics/analytics-rollup-telegram.service.ts
+++ b/backend/src/modules/analytics/analytics-rollup-telegram.service.ts
@@ -29,6 +29,8 @@ interface TelegramApiResponse {
   ok: boolean;
 }
 
+const TELEGRAM_RETRY_DELAYS_MS = [5_000, 15_000];
+
 function getRequiredEnvironmentValue(name: string): string {
   const value = process.env[name]?.trim();
 
@@ -154,6 +156,47 @@ function buildRollupSummaryMessage(summary: AnalyticsRollupSummary): string {
   return lines.join("\n");
 }
 
+function isRetryableTelegramError(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+
+  const message = error.message.toLowerCase();
+
+  if (
+    message.includes("timedout") ||
+    message.includes("fetch failed") ||
+    message.includes("econnreset") ||
+    message.includes("enetunreach") ||
+    message.includes("eai_again")
+  ) {
+    return true;
+  }
+
+  const cause = "cause" in error ? error.cause : null;
+
+  if (cause instanceof Error) {
+    return isRetryableTelegramError(cause);
+  }
+
+  if (
+    typeof cause === "object" &&
+    cause !== null &&
+    "errors" in cause &&
+    Array.isArray(cause.errors)
+  ) {
+    return cause.errors.some((childError) => isRetryableTelegramError(childError));
+  }
+
+  return false;
+}
+
+function wait(delayMs: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, delayMs);
+  });
+}
+
 async function parseTelegramApiResponse(response: Response): Promise<TelegramApiResponse | null> {
   const raw = await response.text();
 
@@ -195,8 +238,36 @@ async function sendMessage(text: string): Promise<void> {
   }
 }
 
+async function sendMessageWithRetry(text: string): Promise<void> {
+  let lastError: unknown = null;
+
+  for (let attempt = 0; attempt <= TELEGRAM_RETRY_DELAYS_MS.length; attempt += 1) {
+    try {
+      await sendMessage(text);
+      return;
+    } catch (error) {
+      lastError = error;
+
+      if (
+        attempt >= TELEGRAM_RETRY_DELAYS_MS.length ||
+        !isRetryableTelegramError(error)
+      ) {
+        break;
+      }
+
+      await wait(TELEGRAM_RETRY_DELAYS_MS[attempt]);
+    }
+  }
+
+  throw lastError;
+}
+
 export const analyticsRollupTelegramService = {
+  buildRollupSummaryMessage,
+  async sendTextMessage(text: string): Promise<void> {
+    await sendMessageWithRetry(text);
+  },
   async sendRollupSummary(summary: AnalyticsRollupSummary): Promise<void> {
-    await sendMessage(buildRollupSummaryMessage(summary));
+    await sendMessageWithRetry(buildRollupSummaryMessage(summary));
   },
 };

--- a/backend/src/scripts/analytics-rollup.ts
+++ b/backend/src/scripts/analytics-rollup.ts
@@ -1,4 +1,6 @@
 import "reflect-metadata";
+import { mkdir, rename, rm, writeFile } from "node:fs/promises";
+import path from "node:path";
 import { loadEnvironment } from "../config/load-env";
 import { AppDataSource } from "../database/data-source";
 import { analyticsRetentionService } from "../modules/analytics/analytics-retention.service";
@@ -8,6 +10,8 @@ interface AnalyticsRollupCliOptions {
   apply: boolean;
   before?: Date;
 }
+
+const ANALYTICS_ROLLUP_MESSAGE_PATH_ENV = "ANALYTICS_ROLLUP_MESSAGE_PATH";
 
 function parseBeforeDate(value: string): Date {
   const parsed = new Date(value);
@@ -73,10 +77,24 @@ function printSummary(summary: Awaited<
   console.log("[analytics:rollup] markedEventCount:", summary.markedEventCount);
 }
 
+async function writeRollupMessageFile(messagePath: string, text: string): Promise<void> {
+  const directoryPath = path.dirname(messagePath);
+  const temporaryPath = `${messagePath}.tmp`;
+
+  await mkdir(directoryPath, { recursive: true });
+  await writeFile(temporaryPath, text, "utf8");
+  await rename(temporaryPath, messagePath);
+}
+
+async function removeRollupMessageFile(messagePath: string): Promise<void> {
+  await rm(messagePath, { force: true });
+}
+
 async function main() {
   loadEnvironment();
 
   const options = parseArgs(process.argv.slice(2));
+  const rollupMessagePath = process.env[ANALYTICS_ROLLUP_MESSAGE_PATH_ENV]?.trim() || null;
 
   await AppDataSource.initialize();
 
@@ -85,8 +103,22 @@ async function main() {
     printSummary(summary);
 
     if (options.apply) {
+      const messageText =
+        analyticsRollupTelegramService.buildRollupSummaryMessage(summary);
+
+      if (rollupMessagePath) {
+        await writeRollupMessageFile(rollupMessagePath, messageText);
+        console.log("[analytics:rollup] fallback message file written:", rollupMessagePath);
+      }
+
       try {
-        await analyticsRollupTelegramService.sendRollupSummary(summary);
+        await analyticsRollupTelegramService.sendTextMessage(messageText);
+
+        if (rollupMessagePath) {
+          await removeRollupMessageFile(rollupMessagePath);
+          console.log("[analytics:rollup] fallback message file removed:", rollupMessagePath);
+        }
+
         console.log("[analytics:rollup] telegram notification sent");
       } catch (error) {
         console.error("[analytics:rollup] telegram notification failed:", error);

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -36,6 +36,9 @@ services:
       - ./frontend/public/result-templates:/app/result-templates:ro
       - /opt/votedots/data/storage:/votedots-storage
       - /opt/votedots/data/login-board:/votedots-login-board
+      - /opt/votedots/data/runtime:/votedots-runtime
+    environment:
+      ANALYTICS_ROLLUP_MESSAGE_PATH: /votedots-runtime/analytics-rollup-message.txt
     networks:
       - default
       - shared-db-network


### PR DESCRIPTION
## 관련 이슈
- Close #459 

## 변경 내용

- 데일리 통계 Telegram 전송에 네트워크성 실패 재시도 로직을 추가
- 롤업 스크립트가 전송할 최종 Telegram 메시지를 공유 runtime 파일로 남길 수 있도록 확장
- 컨테이너 전송 성공 시 fallback 메시지 파일을 삭제하고, 실패 시 그대로 남겨 호스트가 재전송할 수 있도록 처리
- 운영용 backend 컨테이너에 `/opt/votedots/data/runtime` 공유 볼륨과 `ANALYTICS_ROLLUP_MESSAGE_PATH` 환경값을 추가
- 호스트에서 `/opt/votedots/env/backend/.env.production`을 읽어 Telegram으로 대신 전송하는 `send-analytics-rollup-host.mjs` 스크립트를 추가
- backend package script에 `analytics:send-host-fallback` 스크립트를 추가

## 기대 동작

- 컨테이너에서 Telegram API 연결이 일시적으로 timeout 나더라도 내부 재시도로 먼저 복구를 시도한다
- 재시도 후에도 컨테이너 전송이 실패하면 fallback 메시지 파일이 남아 호스트가 같은 메시지를 대신 보낼 수 있다
- 호스트 sender는 pending 메시지 파일이 없을 때 실패하지 않고 정상 종료한다
- 운영 cron은 롤업 집계와 Telegram 호스트 fallback 전송을 분리해 더 안정적으로 동작할 수 있다

## 확인 내용

- `backend npx tsc --noEmit` 통과
- `backend node scripts/send-analytics-rollup-host.mjs --message-path=/tmp/does-not-exist.txt` 정상 종료 확인
- 운영 반영 시 backend 컨테이너 재배포 필요
- 운영 crontab에서 host fallback sender 실행과 cleanup cron 오타 수정 필요
