### PR TITLE
[FE-fix] 모바일 인게임 UX와 캔버스 렌더링 동작 보정

### DIFF
--- a/frontend/src/features/gameplay/canvas/hooks/useCanvasInteraction.ts
+++ b/frontend/src/features/gameplay/canvas/hooks/useCanvasInteraction.ts
@@ -2,7 +2,9 @@ import { useRef, useState, type PointerEvent as ReactPointerEvent, type RefObjec
 import { getGameConfig } from "@/shared/config/game-config";
 import { Cell } from "../model/canvas.types";
 
-const TAP_DISTANCE_THRESHOLD = 6;
+const MOUSE_TAP_DISTANCE_THRESHOLD = 6;
+const TOUCH_TAP_DISTANCE_THRESHOLD = 12;
+const GESTURE_TAP_SUPPRESSION_MS = 240;
 
 interface UseCanvasInteractionParams {
   canvasRef: RefObject<HTMLCanvasElement | null>;
@@ -65,6 +67,7 @@ export function useCanvasInteraction({
   const activePointersRef = useRef(new Map<number, { x: number; y: number }>());
   const activeGestureRef = useRef<{
     pointerId: number;
+    pointerType: string;
     startX: number;
     startY: number;
     lastX: number;
@@ -72,6 +75,7 @@ export function useCanvasInteraction({
     hasPanned: boolean;
   } | null>(null);
   const pinchDistanceRef = useRef<number | null>(null);
+  const suppressTapUntilRef = useRef(0);
   const [isDraggingCanvas, setIsDraggingCanvas] = useState(false);
 
   const resetGesture = () => {
@@ -80,9 +84,15 @@ export function useCanvasInteraction({
     setIsDraggingCanvas(false);
   };
 
-  const beginSinglePointerGesture = (pointerId: number, clientX: number, clientY: number) => {
+  const beginSinglePointerGesture = (
+    pointerId: number,
+    pointerType: string,
+    clientX: number,
+    clientY: number,
+  ) => {
     activeGestureRef.current = {
       pointerId,
+      pointerType,
       startX: clientX,
       startY: clientY,
       lastX: clientX,
@@ -125,7 +135,12 @@ export function useCanvasInteraction({
     }
 
     if (activePointersRef.current.size === 1) {
-      beginSinglePointerGesture(event.pointerId, event.clientX, event.clientY);
+      beginSinglePointerGesture(
+        event.pointerId,
+        event.pointerType,
+        event.clientX,
+        event.clientY,
+      );
       return;
     }
 
@@ -133,6 +148,7 @@ export function useCanvasInteraction({
       activeGestureRef.current = null;
       setIsDraggingCanvas(false);
       pinchDistanceRef.current = getTrackedDistance();
+      suppressTapUntilRef.current = performance.now() + GESTURE_TAP_SUPPRESSION_MS;
     }
   };
 
@@ -184,13 +200,18 @@ export function useCanvasInteraction({
     const dy = event.clientY - activeGesture.lastY;
     const totalDx = event.clientX - activeGesture.startX;
     const totalDy = event.clientY - activeGesture.startY;
+    const tapDistanceThreshold =
+      activeGesture.pointerType === "mouse"
+        ? MOUSE_TAP_DISTANCE_THRESHOLD
+        : TOUCH_TAP_DISTANCE_THRESHOLD;
 
     if (
       !activeGesture.hasPanned &&
-      Math.hypot(totalDx, totalDy) > TAP_DISTANCE_THRESHOLD
+      Math.hypot(totalDx, totalDy) > tapDistanceThreshold
     ) {
       activeGesture.hasPanned = true;
       setIsDraggingCanvas(true);
+      suppressTapUntilRef.current = performance.now() + GESTURE_TAP_SUPPRESSION_MS;
     }
 
     if (activeGesture.hasPanned) {
@@ -229,6 +250,7 @@ export function useCanvasInteraction({
         ) {
           beginSinglePointerGesture(
             remainingPointerId,
+            event.pointerType,
             remainingPointer.x,
             remainingPointer.y,
           );
@@ -244,6 +266,10 @@ export function useCanvasInteraction({
     }
 
     if (activeGesture.hasPanned) {
+      return;
+    }
+
+    if (performance.now() < suppressTapUntilRef.current) {
       return;
     }
 
@@ -305,6 +331,7 @@ export function useCanvasInteraction({
       ) {
         beginSinglePointerGesture(
           remainingPointerId,
+          event.pointerType,
           remainingPointer.x,
           remainingPointer.y,
         );

--- a/frontend/src/features/gameplay/canvas/hooks/useCanvasNavigation.ts
+++ b/frontend/src/features/gameplay/canvas/hooks/useCanvasNavigation.ts
@@ -5,6 +5,10 @@ import {
   type SetStateAction,
 } from "react";
 import { getGameConfig } from "@/shared/config/game-config";
+import {
+  getUsableViewportSize,
+  type CanvasViewportPadding,
+} from "../model/viewport";
 
 interface UseCanvasNavigationParams {
   containerRef: RefObject<HTMLDivElement | null>;
@@ -13,6 +17,7 @@ interface UseCanvasNavigationParams {
   zoom: number;
   setCameraX: Dispatch<SetStateAction<number>>;
   setCameraY: Dispatch<SetStateAction<number>>;
+  viewportPadding?: CanvasViewportPadding;
 }
 
 interface CoordinateLike {
@@ -45,6 +50,7 @@ export function useCanvasNavigation({
   zoom,
   setCameraX,
   setCameraY,
+  viewportPadding,
 }: UseCanvasNavigationParams) {
   const navigateToCoordinate = useCallback(
     (xOrPoint: number | CoordinateLike, maybeY?: number) => {
@@ -60,8 +66,13 @@ export function useCanvasNavigation({
       const worldWidth = gridX * cellSize;
       const worldHeight = gridY * cellSize;
 
-      const viewportWorldWidth = container.clientWidth / zoom;
-      const viewportWorldHeight = container.clientHeight / zoom;
+      const usableViewport = getUsableViewportSize({
+        viewportWidth: container.clientWidth,
+        viewportHeight: container.clientHeight,
+        viewportPadding,
+      });
+      const viewportWorldWidth = usableViewport.width / zoom;
+      const viewportWorldHeight = usableViewport.height / zoom;
 
       const targetWorldCenterX = x * cellSize + cellSize / 2;
       const targetWorldCenterY = y * cellSize + cellSize / 2;
@@ -81,7 +92,7 @@ export function useCanvasNavigation({
       setCameraX(nextCameraX);
       setCameraY(nextCameraY);
     },
-    [containerRef, gridX, gridY, zoom, setCameraX, setCameraY],
+    [containerRef, gridX, gridY, zoom, setCameraX, setCameraY, viewportPadding],
   );
 
   return {

--- a/frontend/src/features/gameplay/canvas/hooks/useCanvasRenderer.ts
+++ b/frontend/src/features/gameplay/canvas/hooks/useCanvasRenderer.ts
@@ -4,7 +4,7 @@ import {
   renderOverlayLayer,
   renderPaintWorldCache,
 } from "../model/canvas.render";
-import type { Cell, VisibleCellBounds } from "../model/canvas.types";
+import type { Cell } from "../model/canvas.types";
 
 interface UseCanvasRendererParams {
   paintCanvasRef: RefObject<HTMLCanvasElement | null>;
@@ -15,7 +15,6 @@ interface UseCanvasRendererParams {
   previewColor: string | null;
   votingCellIds: Set<string>;
   topColorMap: Map<string, string>;
-  visibleCellBounds: VisibleCellBounds | null;
   cameraX: number;
   cameraY: number;
   zoom: number;
@@ -35,7 +34,6 @@ export function useCanvasRenderer({
   previewColor,
   votingCellIds,
   topColorMap,
-  visibleCellBounds,
   cameraX,
   cameraY,
   zoom,
@@ -146,7 +144,6 @@ export function useCanvasRenderer({
         previewColor,
         votingCellIds,
         topColorMap,
-        visibleCellBounds,
         cameraX,
         cameraY,
         zoom,
@@ -180,7 +177,6 @@ export function useCanvasRenderer({
     previewColor,
     votingCellIds,
     topColorMap,
-    visibleCellBounds,
     cameraX,
     cameraY,
     zoom,

--- a/frontend/src/features/gameplay/canvas/hooks/useCanvasViewport.ts
+++ b/frontend/src/features/gameplay/canvas/hooks/useCanvasViewport.ts
@@ -4,6 +4,7 @@ import {
   calculateVisibleCellBounds,
 } from "../model/viewport";
 import type { Viewport, VisibleCellBounds } from "../model/canvas.types";
+import type { CanvasViewportPadding } from "../model/viewport";
 
 interface UseCanvasViewportParams {
   containerRef: RefObject<HTMLDivElement | null>;
@@ -13,6 +14,7 @@ interface UseCanvasViewportParams {
   cameraX: number;
   cameraY: number;
   zoom: number;
+  viewportPadding?: CanvasViewportPadding;
 }
 
 export function useCanvasViewport({
@@ -23,6 +25,7 @@ export function useCanvasViewport({
   cameraX,
   cameraY,
   zoom,
+  viewportPadding,
 }: UseCanvasViewportParams) {
   const [viewport, setViewport] = useState<Viewport | null>(null);
   const [visibleCellBounds, setVisibleCellBounds] =
@@ -55,6 +58,7 @@ export function useCanvasViewport({
         zoom,
         viewportWidth,
         viewportHeight,
+        viewportPadding,
       }),
     );
 
@@ -67,9 +71,10 @@ export function useCanvasViewport({
         zoom,
         viewportWidth,
         viewportHeight,
+        viewportPadding,
       }),
     );
-  }, [containerRef, gridX, gridY, cameraX, cameraY, zoom]);
+  }, [containerRef, gridX, gridY, cameraX, cameraY, zoom, viewportPadding]);
 
   useEffect(() => {
     if (!canvasReady) {

--- a/frontend/src/features/gameplay/canvas/model/canvas.render.ts
+++ b/frontend/src/features/gameplay/canvas/model/canvas.render.ts
@@ -1,6 +1,6 @@
 import { getGameConfig } from "@/shared/config/game-config";
 import { SELECTED_STROKE_COLOR, VOTING_STROKE_COLOR } from "./canvas.constants";
-import type { Cell, VisibleCellBounds } from "./canvas.types";
+import type { Cell } from "./canvas.types";
 
 interface RenderPaintWorldCacheParams {
   ctx: CanvasRenderingContext2D;
@@ -26,7 +26,6 @@ interface RenderOverlayLayerParams {
   previewColor: string | null;
   votingCellIds: Set<string>;
   topColorMap: Map<string, string>;
-  visibleCellBounds: VisibleCellBounds | null;
   cameraX: number;
   cameraY: number;
   zoom: number;
@@ -34,23 +33,6 @@ interface RenderOverlayLayerParams {
   worldOffsetY: number;
   isDraggingCanvas?: boolean;
   timestamp?: number;
-}
-
-function isVisible(
-  x: number,
-  y: number,
-  bounds: VisibleCellBounds | null,
-): boolean {
-  if (!bounds) {
-    return false;
-  }
-
-  return (
-    x >= bounds.startCellX &&
-    x <= bounds.endCellX &&
-    y >= bounds.startCellY &&
-    y <= bounds.endCellY
-  );
 }
 
 function clearCanvas(ctx: CanvasRenderingContext2D) {
@@ -151,35 +133,17 @@ export function drawPaintLayerFromCache({
     return;
   }
 
-  const viewportRect = ctx.canvas.getBoundingClientRect();
-  const viewportWidth = viewportRect.width;
-  const viewportHeight = viewportRect.height;
-
-  if (viewportWidth <= 0 || viewportHeight <= 0) {
-    return;
-  }
-
-  const sourceX = Math.min(Math.max(0, cameraX), worldWidth);
-  const sourceY = Math.min(Math.max(0, cameraY), worldHeight);
-  const sourceWidth = Math.min(worldWidth - sourceX, viewportWidth / zoom);
-  const sourceHeight = Math.min(worldHeight - sourceY, viewportHeight / zoom);
-
-  if (sourceWidth <= 0 || sourceHeight <= 0) {
-    return;
-  }
+  const backgroundTranslateX = worldOffsetX - cameraX * zoom;
+  const backgroundTranslateY = worldOffsetY - cameraY * zoom;
 
   ctx.save();
   ctx.imageSmoothingEnabled = false;
   ctx.drawImage(
     sourceCanvas,
-    sourceX,
-    sourceY,
-    sourceWidth,
-    sourceHeight,
-    worldOffsetX,
-    worldOffsetY,
-    sourceWidth * zoom,
-    sourceHeight * zoom,
+    backgroundTranslateX,
+    backgroundTranslateY,
+    worldWidth * zoom,
+    worldHeight * zoom,
   );
   ctx.restore();
 }
@@ -190,7 +154,6 @@ export function renderOverlayLayer({
   previewColor,
   votingCellIds,
   topColorMap,
-  visibleCellBounds,
   cameraX,
   cameraY,
   zoom,
@@ -200,10 +163,6 @@ export function renderOverlayLayer({
   timestamp = 0,
 }: RenderOverlayLayerParams) {
   clearCanvas(ctx);
-
-  if (!visibleCellBounds) {
-    return;
-  }
 
   const cellSize = getGameConfig().board.cellSize;
   const pulse = isDraggingCanvas ? 0.5 : (Math.sin(timestamp / 220) + 1) / 2;
@@ -215,10 +174,6 @@ export function renderOverlayLayer({
     const y = Number(yValue);
 
     if (!Number.isFinite(x) || !Number.isFinite(y)) {
-      continue;
-    }
-
-    if (!isVisible(x, y, visibleCellBounds)) {
       continue;
     }
 
@@ -234,6 +189,11 @@ export function renderOverlayLayer({
       worldOffsetX,
       worldOffsetY,
     );
+
+    if (!isScreenRectVisible(ctx, rect.x, rect.y, rect.size)) {
+      continue;
+    }
+
     const { inset, strokeSize, lineWidth } = getStrokeMetrics(rect.size);
 
     if (topColor && !isSelected) {

--- a/frontend/src/features/gameplay/canvas/model/viewport.ts
+++ b/frontend/src/features/gameplay/canvas/model/viewport.ts
@@ -158,20 +158,14 @@ export function calculateVisibleCellBounds({
   zoom,
   viewportWidth,
   viewportHeight,
-  viewportPadding,
 }: CalculateViewportParams): VisibleCellBounds | null {
   if (gridX === 0 || gridY === 0 || zoom <= 0) {
     return null;
   }
 
   const cellSize = getGameConfig().board.cellSize;
-  const usableViewport = getUsableViewportSize({
-    viewportWidth,
-    viewportHeight,
-    viewportPadding,
-  });
-  const visibleWorldWidth = usableViewport.width / zoom;
-  const visibleWorldHeight = usableViewport.height / zoom;
+  const visibleWorldWidth = viewportWidth / zoom;
+  const visibleWorldHeight = viewportHeight / zoom;
 
   if (visibleWorldWidth <= 0 || visibleWorldHeight <= 0) {
     return null;

--- a/frontend/src/features/gameplay/canvas/model/viewport.ts
+++ b/frontend/src/features/gameplay/canvas/model/viewport.ts
@@ -2,6 +2,13 @@ import { getGameConfig } from "@/shared/config/game-config";
 import { MINIMAP_SIZE } from "./canvas.constants";
 import type { Viewport, VisibleCellBounds } from "./canvas.types";
 
+export interface CanvasViewportPadding {
+  top: number;
+  right: number;
+  bottom: number;
+  left: number;
+}
+
 interface CalculateViewportParams {
   gridX: number;
   gridY: number;
@@ -10,6 +17,7 @@ interface CalculateViewportParams {
   zoom: number;
   viewportWidth: number;
   viewportHeight: number;
+  viewportPadding?: CanvasViewportPadding;
 }
 
 interface CalculateWorldScreenOffsetParams {
@@ -18,10 +26,36 @@ interface CalculateWorldScreenOffsetParams {
   viewportWidth: number;
   viewportHeight: number;
   zoom: number;
+  viewportPadding?: CanvasViewportPadding;
 }
 
 function clamp(value: number, min: number, max: number) {
   return Math.min(Math.max(value, min), max);
+}
+
+export function resolveViewportPadding(
+  viewportPadding?: Partial<CanvasViewportPadding> | null,
+): CanvasViewportPadding {
+  return {
+    top: Math.max(0, viewportPadding?.top ?? 0),
+    right: Math.max(0, viewportPadding?.right ?? 0),
+    bottom: Math.max(0, viewportPadding?.bottom ?? 0),
+    left: Math.max(0, viewportPadding?.left ?? 0),
+  };
+}
+
+export function getUsableViewportSize(params: {
+  viewportWidth: number;
+  viewportHeight: number;
+  viewportPadding?: Partial<CanvasViewportPadding> | null;
+}) {
+  const { viewportWidth, viewportHeight, viewportPadding } = params;
+  const padding = resolveViewportPadding(viewportPadding);
+
+  return {
+    width: Math.max(0, viewportWidth - padding.left - padding.right),
+    height: Math.max(0, viewportHeight - padding.top - padding.bottom),
+  };
 }
 
 export function calculateWorldScreenOffset({
@@ -30,12 +64,20 @@ export function calculateWorldScreenOffset({
   viewportWidth,
   viewportHeight,
   zoom,
+  viewportPadding,
 }: CalculateWorldScreenOffsetParams) {
+  const padding = resolveViewportPadding(viewportPadding);
+  const usableViewport = getUsableViewportSize({
+    viewportWidth,
+    viewportHeight,
+    viewportPadding: padding,
+  });
+
   if (
     worldWidth <= 0 ||
     worldHeight <= 0 ||
-    viewportWidth <= 0 ||
-    viewportHeight <= 0 ||
+    usableViewport.width <= 0 ||
+    usableViewport.height <= 0 ||
     zoom <= 0
   ) {
     return {
@@ -45,8 +87,8 @@ export function calculateWorldScreenOffset({
   }
 
   return {
-    x: Math.max(0, (viewportWidth - worldWidth * zoom) / 2),
-    y: Math.max(0, (viewportHeight - worldHeight * zoom) / 2),
+    x: padding.left + Math.max(0, (usableViewport.width - worldWidth * zoom) / 2),
+    y: padding.top + Math.max(0, (usableViewport.height - worldHeight * zoom) / 2),
   };
 }
 
@@ -58,6 +100,7 @@ export function calculateViewport({
   zoom,
   viewportWidth,
   viewportHeight,
+  viewportPadding,
 }: CalculateViewportParams): Viewport | null {
   if (gridX === 0 || gridY === 0 || zoom <= 0) {
     return null;
@@ -66,9 +109,13 @@ export function calculateViewport({
   const cellSize = getGameConfig().board.cellSize;
   const worldWidth = gridX * cellSize;
   const worldHeight = gridY * cellSize;
-
-  const visibleWorldWidth = viewportWidth / zoom;
-  const visibleWorldHeight = viewportHeight / zoom;
+  const usableViewport = getUsableViewportSize({
+    viewportWidth,
+    viewportHeight,
+    viewportPadding,
+  });
+  const visibleWorldWidth = usableViewport.width / zoom;
+  const visibleWorldHeight = usableViewport.height / zoom;
 
   const minimapScale = MINIMAP_SIZE / Math.max(gridX, gridY, 1);
   const minimapWidth = gridX * minimapScale;
@@ -111,14 +158,20 @@ export function calculateVisibleCellBounds({
   zoom,
   viewportWidth,
   viewportHeight,
+  viewportPadding,
 }: CalculateViewportParams): VisibleCellBounds | null {
   if (gridX === 0 || gridY === 0 || zoom <= 0) {
     return null;
   }
 
   const cellSize = getGameConfig().board.cellSize;
-  const visibleWorldWidth = viewportWidth / zoom;
-  const visibleWorldHeight = viewportHeight / zoom;
+  const usableViewport = getUsableViewportSize({
+    viewportWidth,
+    viewportHeight,
+    viewportPadding,
+  });
+  const visibleWorldWidth = usableViewport.width / zoom;
+  const visibleWorldHeight = usableViewport.height / zoom;
 
   if (visibleWorldWidth <= 0 || visibleWorldHeight <= 0) {
     return null;

--- a/frontend/src/features/gameplay/intro/components/IntroGuideModal.tsx
+++ b/frontend/src/features/gameplay/intro/components/IntroGuideModal.tsx
@@ -130,8 +130,14 @@ export default function IntroGuideModal({
     handleTouchMove,
     handleTouchEnd,
     handleTouchCancel,
+    dragOffsetY,
+    isDragging,
+    isClosing,
+    backdropOpacity,
+    transitionDurationMs,
   } = useSwipeDownDismiss({
     onDismiss: onClose,
+    active: open,
   });
 
   const description = useMemo(() => buildDescription(gameConfig), [gameConfig]);
@@ -489,10 +495,19 @@ export default function IntroGuideModal({
         }
         style={
           mobileLayout
-            ? undefined
+            ? {
+                opacity: backdropOpacity,
+                transition: isDragging
+                  ? "none"
+                  : `opacity ${transitionDurationMs}ms ease-out`,
+              }
             : {
                 top: `${RIGHT_PANEL_ACTIONS_EXPOSED_HEIGHT}px`,
                 left: `${HISTORY_PANEL_WIDTH}px`,
+                opacity: backdropOpacity,
+                transition: isDragging
+                  ? "none"
+                  : `opacity ${transitionDurationMs}ms ease-out`,
               }
         }
         onMouseDown={(event) => event.stopPropagation()}
@@ -503,10 +518,22 @@ export default function IntroGuideModal({
         ref={modalRef}
         className={`pointer-events-auto fixed flex max-h-[calc(100dvh-16px)] flex-col overflow-hidden rounded-3xl border border-[color:var(--page-theme-border-primary)] bg-[color:var(--page-theme-surface-primary)] shadow-2xl ${
           mobileLayout
-            ? "left-1/2 top-1/2 w-[min(92vw,380px)] -translate-x-1/2 -translate-y-1/2"
+            ? "left-1/2 top-1/2 w-[min(92vw,380px)]"
             : "w-[1400px] max-w-[calc(100vw-24px)]"
         }`}
-        style={mobileLayout ? undefined : { top: position.y, left: position.x }}
+        style={
+          mobileLayout
+            ? {
+                transform: isClosing
+                  ? "translate(-50%, calc(-50% + 100dvh))"
+                  : `translate(-50%, calc(-50% + ${Math.max(0, dragOffsetY)}px))`,
+                transition: isDragging
+                  ? "none"
+                  : `transform ${transitionDurationMs}ms cubic-bezier(0.22, 1, 0.36, 1)`,
+                willChange: "transform",
+              }
+            : { top: position.y, left: position.x }
+        }
         onMouseDown={(event) => event.stopPropagation()}
         onClick={(event) => event.stopPropagation()}
       >

--- a/frontend/src/features/gameplay/intro/components/IntroGuideModal.tsx
+++ b/frontend/src/features/gameplay/intro/components/IntroGuideModal.tsx
@@ -5,6 +5,7 @@ import {
   HISTORY_PANEL_WIDTH,
   RIGHT_PANEL_ACTIONS_EXPOSED_HEIGHT,
 } from "@/pages/canvas/model/modal-position";
+import { useSwipeDownDismiss } from "@/shared/hooks/use-swipe-down-dismiss";
 import { useI18n } from "@/shared/i18n";
 import IntroCanvasPreview from "./IntroCanvasPreview";
 
@@ -116,7 +117,7 @@ export default function IntroGuideModal({
   formattedGameEndTime,
   onClose,
 }: Props) {
-  const { t } = useI18n();
+  const { locale, t } = useI18n();
   const [position, setPosition] = useState(getDefaultPosition);
   const [mobilePageIndex, setMobilePageIndex] = useState(0);
 
@@ -124,6 +125,14 @@ export default function IntroGuideModal({
   const isDraggingRef = useRef(false);
   const dragOffsetRef = useRef({ x: 0, y: 0 });
   const touchStartXRef = useRef<number | null>(null);
+  const {
+    handleTouchStart,
+    handleTouchMove,
+    handleTouchEnd,
+    handleTouchCancel,
+  } = useSwipeDownDismiss({
+    onDismiss: onClose,
+  });
 
   const description = useMemo(() => buildDescription(gameConfig), [gameConfig]);
   const effectivePreviewMaxSize = mobileLayout
@@ -166,6 +175,67 @@ export default function IntroGuideModal({
         };
       }),
     [t],
+  );
+  const resolvedInteractionGuides = useMemo(
+    () =>
+      mobileLayout
+        ? [
+            {
+              key: "mobile-palette",
+              order: "01",
+              title: locale === "ko" ? "색상 바꾸기" : "Change color",
+              bodyLines:
+                locale === "ko"
+                  ? [
+                      "우상단 팔레트 버튼을 눌러 현재 투표 색상을 바꿉니다.",
+                      "버튼 아래에는 최근에 고른 색상이 최신순으로 최대 6개까지 쌓입니다.",
+                    ]
+                  : [
+                      "Tap the top-right palette button to change your current vote color.",
+                      "Up to six recent colors stack below it with the newest color first.",
+                    ],
+              highlightPhrases:
+                locale === "ko"
+                  ? ["우상단 팔레트 버튼", "최근에 고른 색상"]
+                  : ["top-right palette button", "recent colors"],
+            },
+            {
+              key: "mobile-vote",
+              order: "02",
+              title: locale === "ko" ? "바로 투표하기" : "Vote instantly",
+              bodyLines:
+                locale === "ko"
+                  ? [
+                      "모바일에서는 타일을 누르면 현재 선택한 색상으로 바로 투표합니다.",
+                    ]
+                  : [
+                      "On mobile, tapping a tile votes immediately with the color you currently selected.",
+                    ],
+              highlightPhrases:
+                locale === "ko"
+                  ? ["현재 선택한 색상"]
+                  : ["votes immediately"],
+            },
+            {
+              key: "mobile-move",
+              order: "03",
+              title: locale === "ko" ? "이동과 확대" : "Move and zoom",
+              bodyLines:
+                locale === "ko"
+                  ? [
+                      "드래그로 화면을 이동하고, 두 손가락으로 확대하거나 축소할 수 있습니다.",
+                    ]
+                  : [
+                      "Drag to move the canvas, and use two fingers to zoom in or out.",
+                    ],
+              highlightPhrases:
+                locale === "ko"
+                  ? ["드래그", "두 손가락"]
+                  : ["Drag", "two fingers"],
+            },
+          ]
+        : interactionGuides,
+    [interactionGuides, locale, mobileLayout],
   );
   const warningGuide = useMemo(
     () => parseGuideText(t("intro.vote.warning")),
@@ -365,7 +435,7 @@ export default function IntroGuideModal({
       </h3>
 
       <div className="mt-3 space-y-3">
-        {interactionGuides.map((guide) => (
+        {resolvedInteractionGuides.map((guide) => (
           <article
             key={guide.key}
             className="rounded-2xl border border-[color:var(--page-theme-border-primary)] bg-[color:var(--page-theme-surface-primary)] px-4 py-3"
@@ -398,7 +468,19 @@ export default function IntroGuideModal({
   const mobilePages = [previewSection, gameDescriptionSection, voteGuideSection];
 
   return (
-    <div className="pointer-events-none fixed inset-0 z-50">
+    <div
+      className="pointer-events-none fixed inset-0 z-50"
+      style={
+        mobileLayout
+          ? {
+              paddingTop: "calc(env(safe-area-inset-top, 0px) + 12px)",
+              paddingRight: "calc(env(safe-area-inset-right, 0px) + 12px)",
+              paddingBottom: "calc(env(safe-area-inset-bottom, 0px) + 12px)",
+              paddingLeft: "calc(env(safe-area-inset-left, 0px) + 12px)",
+            }
+          : undefined
+      }
+    >
       <div
         className={
           mobileLayout
@@ -414,7 +496,7 @@ export default function IntroGuideModal({
               }
         }
         onMouseDown={(event) => event.stopPropagation()}
-        onClick={(event) => event.stopPropagation()}
+        onClick={mobileLayout ? onClose : (event) => event.stopPropagation()}
       />
 
       <div
@@ -441,6 +523,10 @@ export default function IntroGuideModal({
                   };
                 }
           }
+          onTouchStart={mobileLayout ? handleTouchStart : undefined}
+          onTouchMove={mobileLayout ? handleTouchMove : undefined}
+          onTouchEnd={mobileLayout ? handleTouchEnd : undefined}
+          onTouchCancel={mobileLayout ? handleTouchCancel : undefined}
         >
           <p className="text-center text-base font-semibold text-[color:var(--page-theme-primary-action)]">
             {t("intro.modal.title")}

--- a/frontend/src/features/gameplay/round/components/RoundSummaryModal.tsx
+++ b/frontend/src/features/gameplay/round/components/RoundSummaryModal.tsx
@@ -60,8 +60,14 @@ export default function RoundSummaryModal({
     handleTouchMove,
     handleTouchEnd,
     handleTouchCancel,
+    dragOffsetY,
+    isDragging,
+    isClosing,
+    backdropOpacity,
+    transitionDurationMs,
   } = useSwipeDownDismiss({
     onDismiss: onClose,
+    active: open,
   });
 
   useEffect(() => {
@@ -116,11 +122,19 @@ export default function RoundSummaryModal({
             ? mobileLayout
               ? {
                   inset: 0,
+                  opacity: backdropOpacity,
+                  transition: isDragging
+                    ? "none"
+                    : `opacity ${transitionDurationMs}ms ease-out`,
                 }
               : undefined
             : {
                 top: `${RIGHT_PANEL_ACTIONS_EXPOSED_HEIGHT}px`,
                 left: `${HISTORY_PANEL_WIDTH}px`,
+                opacity: backdropOpacity,
+                transition: isDragging
+                  ? "none"
+                  : `opacity ${transitionDurationMs}ms ease-out`,
               }
         }
         onMouseDown={(event) => event.stopPropagation()}
@@ -129,20 +143,26 @@ export default function RoundSummaryModal({
 
       <div
         className={`pointer-events-auto fixed flex max-h-[calc(100dvh-48px)] w-[700px] max-w-[calc(100vw-24px)] flex-col overflow-hidden rounded-3xl border border-[color:var(--page-theme-border-primary)] bg-[color:var(--page-theme-surface-primary)] shadow-2xl ${
-          centerOnScreen
-            ? "left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2"
-            : ""
+          centerOnScreen ? "left-1/2 top-1/2" : ""
         }`}
         style={
           centerOnScreen
-            ? mobileLayout
-              ? {
-                  left: "50%",
-                  top: "50%",
-                  width: "min(92vw, 700px)",
-                }
-              : undefined
-            : { top: position.y, left: position.x }
+            ? {
+                left: "50%",
+                top: "50%",
+                width: mobileLayout ? "min(92vw, 700px)" : undefined,
+                transform: isClosing
+                  ? "translate(-50%, calc(-50% + 100dvh))"
+                  : `translate(-50%, calc(-50% + ${Math.max(0, dragOffsetY)}px))`,
+                transition: isDragging
+                  ? "none"
+                  : `transform ${transitionDurationMs}ms cubic-bezier(0.22, 1, 0.36, 1)`,
+                willChange: "transform",
+              }
+            : {
+                top: position.y,
+                left: position.x,
+              }
         }
         onMouseDown={(event) => event.stopPropagation()}
         onClick={(event) => event.stopPropagation()}

--- a/frontend/src/features/gameplay/round/components/RoundSummaryModal.tsx
+++ b/frontend/src/features/gameplay/round/components/RoundSummaryModal.tsx
@@ -4,6 +4,7 @@ import {
   HISTORY_PANEL_WIDTH,
   RIGHT_PANEL_ACTIONS_EXPOSED_HEIGHT,
 } from "@/pages/canvas/model/modal-position";
+import { useSwipeDownDismiss } from "@/shared/hooks/use-swipe-down-dismiss";
 import { useI18n } from "@/shared/i18n";
 import { PixelSnapshotPreview } from "@/shared/ui/pixel-snapshot-preview";
 
@@ -14,6 +15,7 @@ interface RoundSummaryModalProps {
   playBackgroundImageUrl: string | null;
   snapshotMaxLongestSide?: number;
   centerOnScreen?: boolean;
+  mobileLayout?: boolean;
   position: { x: number; y: number };
   onClose: () => void;
   onDragStart: (event: MouseEvent<HTMLDivElement>) => void;
@@ -47,11 +49,20 @@ export default function RoundSummaryModal({
   playBackgroundImageUrl,
   snapshotMaxLongestSide = 512,
   centerOnScreen = false,
+  mobileLayout = false,
   position,
   onClose,
   onDragStart,
 }: RoundSummaryModalProps) {
   const { locale, t } = useI18n();
+  const {
+    handleTouchStart,
+    handleTouchMove,
+    handleTouchEnd,
+    handleTouchCancel,
+  } = useSwipeDownDismiss({
+    onDismiss: onClose,
+  });
 
   useEffect(() => {
     if (!open || !summary) {
@@ -81,7 +92,19 @@ export default function RoundSummaryModal({
   const roundSnapshot = summary.snapshotUrl ?? snapshot;
 
   return (
-    <div className="pointer-events-none fixed inset-0 z-50">
+    <div
+      className="pointer-events-none fixed inset-0 z-50"
+      style={
+        mobileLayout
+          ? {
+              paddingTop: "calc(env(safe-area-inset-top, 0px) + 12px)",
+              paddingRight: "calc(env(safe-area-inset-right, 0px) + 12px)",
+              paddingBottom: "calc(env(safe-area-inset-bottom, 0px) + 12px)",
+              paddingLeft: "calc(env(safe-area-inset-left, 0px) + 12px)",
+            }
+          : undefined
+      }
+    >
       <div
         className={
           centerOnScreen
@@ -90,29 +113,47 @@ export default function RoundSummaryModal({
         }
         style={
           centerOnScreen
-            ? undefined
+            ? mobileLayout
+              ? {
+                  inset: 0,
+                }
+              : undefined
             : {
                 top: `${RIGHT_PANEL_ACTIONS_EXPOSED_HEIGHT}px`,
                 left: `${HISTORY_PANEL_WIDTH}px`,
               }
         }
         onMouseDown={(event) => event.stopPropagation()}
-        onClick={(event) => event.stopPropagation()}
+        onClick={mobileLayout ? onClose : (event) => event.stopPropagation()}
       />
 
       <div
-        className={`pointer-events-auto fixed flex max-h-[calc(100vh-48px)] w-[700px] max-w-[calc(100vw-24px)] flex-col overflow-hidden rounded-3xl border border-[color:var(--page-theme-border-primary)] bg-[color:var(--page-theme-surface-primary)] shadow-2xl ${
+        className={`pointer-events-auto fixed flex max-h-[calc(100dvh-48px)] w-[700px] max-w-[calc(100vw-24px)] flex-col overflow-hidden rounded-3xl border border-[color:var(--page-theme-border-primary)] bg-[color:var(--page-theme-surface-primary)] shadow-2xl ${
           centerOnScreen
             ? "left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2"
             : ""
         }`}
-        style={centerOnScreen ? undefined : { top: position.y, left: position.x }}
+        style={
+          centerOnScreen
+            ? mobileLayout
+              ? {
+                  left: "50%",
+                  top: "50%",
+                  width: "min(92vw, 700px)",
+                }
+              : undefined
+            : { top: position.y, left: position.x }
+        }
         onMouseDown={(event) => event.stopPropagation()}
         onClick={(event) => event.stopPropagation()}
       >
         <div
           className="relative flex cursor-move items-center justify-center border-b border-[color:var(--page-theme-border-secondary)] px-5 py-4"
-          onMouseDown={onDragStart}
+          onMouseDown={mobileLayout ? undefined : onDragStart}
+          onTouchStart={mobileLayout ? handleTouchStart : undefined}
+          onTouchMove={mobileLayout ? handleTouchMove : undefined}
+          onTouchEnd={mobileLayout ? handleTouchEnd : undefined}
+          onTouchCancel={mobileLayout ? handleTouchCancel : undefined}
         >
           <p className="text-center text-lg font-bold text-[color:var(--page-theme-primary-action)]">
             {t("roundSummary.title", { round: summary.roundNumber })}

--- a/frontend/src/features/gameplay/session/components/GameSummaryModal.tsx
+++ b/frontend/src/features/gameplay/session/components/GameSummaryModal.tsx
@@ -135,6 +135,11 @@ export default function GameSummaryModal({
     handleTouchMove,
     handleTouchEnd,
     handleTouchCancel,
+    dragOffsetY,
+    isDragging,
+    isClosing,
+    backdropOpacity,
+    transitionDurationMs,
   } = useSwipeDownDismiss({
     onDismiss: onClose,
   });
@@ -395,10 +400,19 @@ export default function GameSummaryModal({
         }
         style={
           mobileLayout
-            ? undefined
+            ? {
+                opacity: backdropOpacity,
+                transition: isDragging
+                  ? "none"
+                  : `opacity ${transitionDurationMs}ms ease-out`,
+              }
             : {
                 top: `${RIGHT_PANEL_ACTIONS_EXPOSED_HEIGHT}px`,
                 left: `${HISTORY_PANEL_WIDTH}px`,
+                opacity: backdropOpacity,
+                transition: isDragging
+                  ? "none"
+                  : `opacity ${transitionDurationMs}ms ease-out`,
               }
         }
         onMouseDown={(event) => event.stopPropagation()}
@@ -408,10 +422,22 @@ export default function GameSummaryModal({
       <div
         className={`pointer-events-auto fixed flex max-h-[calc(100vh-48px)] flex-col overflow-hidden rounded-3xl border border-[color:var(--page-theme-border-primary)] bg-[color:var(--page-theme-surface-primary)] shadow-2xl ${
           mobileLayout
-            ? "left-1/2 top-1/2 w-[min(92vw,700px)] -translate-x-1/2 -translate-y-1/2"
+            ? "left-1/2 top-1/2 w-[min(92vw,700px)]"
             : "w-[700px] max-w-[calc(100vw-24px)]"
         }`}
-        style={mobileLayout ? undefined : { top: position.y, left: position.x }}
+        style={
+          mobileLayout
+            ? {
+                transform: isClosing
+                  ? "translate(-50%, calc(-50% + 100dvh))"
+                  : `translate(-50%, calc(-50% + ${Math.max(0, dragOffsetY)}px))`,
+                transition: isDragging
+                  ? "none"
+                  : `transform ${transitionDurationMs}ms cubic-bezier(0.22, 1, 0.36, 1)`,
+                willChange: "transform",
+              }
+            : { top: position.y, left: position.x }
+        }
         onMouseDown={(event) => event.stopPropagation()}
         onClick={(event) => event.stopPropagation()}
       >

--- a/frontend/src/features/gameplay/session/components/GameSummaryModal.tsx
+++ b/frontend/src/features/gameplay/session/components/GameSummaryModal.tsx
@@ -8,6 +8,7 @@ import {
   HISTORY_PANEL_WIDTH,
   RIGHT_PANEL_ACTIONS_EXPOSED_HEIGHT,
 } from "@/pages/canvas/model/modal-position";
+import { useSwipeDownDismiss } from "@/shared/hooks/use-swipe-down-dismiss";
 import { useI18n } from "@/shared/i18n";
 import { useSnapshotDownload } from "@/shared/hooks/useSnapshotDownload";
 import { PixelSnapshotPreview } from "@/shared/ui/pixel-snapshot-preview";
@@ -129,6 +130,14 @@ export default function GameSummaryModal({
   const { formatNumber, formatPercent, locale, t } = useI18n();
   const [mobilePageIndex, setMobilePageIndex] = useState(0);
   const touchStartXRef = useRef<number | null>(null);
+  const {
+    handleTouchStart,
+    handleTouchMove,
+    handleTouchEnd,
+    handleTouchCancel,
+  } = useSwipeDownDismiss({
+    onDismiss: onClose,
+  });
   const finalSnapshotUrl = summary.snapshotUrl ?? snapshotUrl ?? null;
   const {
     canDownload: canDownloadDefaultSnapshot,
@@ -367,6 +376,16 @@ export default function GameSummaryModal({
   return (
     <div
       className="pointer-events-none fixed inset-0 z-50 px-3 py-6"
+      style={
+        mobileLayout
+          ? {
+              paddingTop: "calc(env(safe-area-inset-top, 0px) + 12px)",
+              paddingRight: "calc(env(safe-area-inset-right, 0px) + 12px)",
+              paddingBottom: "calc(env(safe-area-inset-bottom, 0px) + 12px)",
+              paddingLeft: "calc(env(safe-area-inset-left, 0px) + 12px)",
+            }
+          : undefined
+      }
     >
       <div
         className={
@@ -383,7 +402,7 @@ export default function GameSummaryModal({
               }
         }
         onMouseDown={(event) => event.stopPropagation()}
-        onClick={(event) => event.stopPropagation()}
+        onClick={mobileLayout ? onClose : (event) => event.stopPropagation()}
       />
 
       <div
@@ -399,6 +418,10 @@ export default function GameSummaryModal({
         <div
           className="relative flex cursor-move items-center justify-center border-b border-[color:var(--page-theme-border-secondary)] px-5 py-4"
           onMouseDown={mobileLayout ? undefined : onDragStart}
+          onTouchStart={mobileLayout ? handleTouchStart : undefined}
+          onTouchMove={mobileLayout ? handleTouchMove : undefined}
+          onTouchEnd={mobileLayout ? handleTouchEnd : undefined}
+          onTouchCancel={mobileLayout ? handleTouchCancel : undefined}
         >
           <p className="text-center text-lg font-bold text-[color:var(--page-theme-primary-action)]">
             {t("gameSummary.title")}

--- a/frontend/src/pages/canvas/CanvasPage.tsx
+++ b/frontend/src/pages/canvas/CanvasPage.tsx
@@ -55,6 +55,7 @@ import { translateServerMessage } from "@/shared/i18n/server-messages";
 import { usePageRootClass } from "@/shared/hooks/use-page-root-class";
 import { BrandLogo } from "@/shared/ui/brand-logo";
 import { DropdownSelect } from "@/shared/ui/dropdown-select";
+import type { CanvasViewportPadding } from "@/features/gameplay/canvas/model/viewport";
 import MobileBottomSheet from "./components/MobileBottomSheet";
 import MobileFloatingPalette from "./components/MobileFloatingPalette";
 import useCanvasPage from "./model/useCanvasPage";
@@ -67,6 +68,7 @@ const MOBILE_VOTE_ERROR_DURATION_MS = 3000;
 const MOBILE_BREAKPOINT_MEDIA_QUERY = "(max-width: 1023px)";
 const MOBILE_RECENT_COLOR_LIMIT = 6;
 const MOBILE_RECENT_COLORS_STORAGE_KEY = "votedots:mobile-recent-colors";
+const MOBILE_CANVAS_EDGE_PADDING = 72;
 
 type MobileSheetType = "menu" | "participants" | "history" | null;
 type VoteMode = "select" | "instant";
@@ -328,6 +330,13 @@ export default function CanvasPage({ sessionSourceApi }: CanvasPageProps) {
   );
   const [mobileVoteError, setMobileVoteError] = useState("");
   const [mobileVoteLoading, setMobileVoteLoading] = useState(false);
+  const [mobileSafeAreaInsets, setMobileSafeAreaInsets] =
+    useState<CanvasViewportPadding>({
+      top: 0,
+      right: 0,
+      bottom: 0,
+      left: 0,
+    });
 
   usePageRootClass("page-shell-root");
   useTrackVisitEvent(gameplayEntryEventType);
@@ -380,6 +389,67 @@ export default function CanvasPage({ sessionSourceApi }: CanvasPageProps) {
       mediaQuery.removeEventListener("change", handleMediaQueryChange);
     };
   }, []);
+
+  useLayoutEffect(() => {
+    if (typeof window === "undefined" || typeof document === "undefined") {
+      return;
+    }
+
+    const probe = document.createElement("div");
+    probe.setAttribute("aria-hidden", "true");
+    probe.style.position = "fixed";
+    probe.style.inset = "0";
+    probe.style.pointerEvents = "none";
+    probe.style.visibility = "hidden";
+    probe.style.paddingTop = "env(safe-area-inset-top, 0px)";
+    probe.style.paddingRight = "env(safe-area-inset-right, 0px)";
+    probe.style.paddingBottom = "env(safe-area-inset-bottom, 0px)";
+    probe.style.paddingLeft = "env(safe-area-inset-left, 0px)";
+
+    document.body.appendChild(probe);
+
+    const readInsets = () => {
+      const styles = window.getComputedStyle(probe);
+      const nextInsets = {
+        top: Number.parseFloat(styles.paddingTop) || 0,
+        right: Number.parseFloat(styles.paddingRight) || 0,
+        bottom: Number.parseFloat(styles.paddingBottom) || 0,
+        left: Number.parseFloat(styles.paddingLeft) || 0,
+      };
+
+      setMobileSafeAreaInsets((prev) =>
+        prev.top === nextInsets.top &&
+        prev.right === nextInsets.right &&
+        prev.bottom === nextInsets.bottom &&
+        prev.left === nextInsets.left
+          ? prev
+          : nextInsets,
+      );
+    };
+
+    readInsets();
+    window.addEventListener("resize", readInsets);
+    window.visualViewport?.addEventListener("resize", readInsets);
+
+    return () => {
+      window.removeEventListener("resize", readInsets);
+      window.visualViewport?.removeEventListener("resize", readInsets);
+      probe.remove();
+    };
+  }, []);
+
+  const mobileCanvasViewportPadding = useMemo<CanvasViewportPadding | undefined>(
+    () =>
+      isMobileLayout
+        ? {
+            top: mobileSafeAreaInsets.top + MOBILE_CANVAS_EDGE_PADDING,
+            right: mobileSafeAreaInsets.right + MOBILE_CANVAS_EDGE_PADDING,
+            bottom: mobileSafeAreaInsets.bottom + MOBILE_CANVAS_EDGE_PADDING,
+            left: mobileSafeAreaInsets.left + MOBILE_CANVAS_EDGE_PADDING,
+          }
+        : undefined,
+    [isMobileLayout, mobileSafeAreaInsets],
+  );
 
   useEffect(() => {
     if (typeof document === "undefined" || !mobilePaletteOpen) {
@@ -566,6 +636,7 @@ export default function CanvasPage({ sessionSourceApi }: CanvasPageProps) {
     onCellActivated: (cell) => {
       cellActivatedHandlerRef.current(cell);
     },
+    viewportPadding: mobileCanvasViewportPadding,
   });
 
   useEffect(() => {
@@ -1469,7 +1540,7 @@ export default function CanvasPage({ sessionSourceApi }: CanvasPageProps) {
   if (loading) {
     return (
       <div
-        className="flex h-screen w-full overflow-hidden bg-[color:var(--page-theme-page-background)] text-[color:var(--page-theme-text-primary)]"
+        className="flex h-[100dvh] min-h-[100dvh] w-full overflow-hidden bg-[color:var(--page-theme-page-background)] text-[color:var(--page-theme-text-primary)]"
         style={canvasPageThemeStyle}
       >
         <LoadingScreen />
@@ -1480,7 +1551,7 @@ export default function CanvasPage({ sessionSourceApi }: CanvasPageProps) {
   if (error) {
     return (
       <div
-        className="flex h-screen w-full overflow-hidden bg-[color:var(--page-theme-page-background)] text-[color:var(--page-theme-text-primary)]"
+        className="flex h-[100dvh] min-h-[100dvh] w-full overflow-hidden bg-[color:var(--page-theme-page-background)] text-[color:var(--page-theme-text-primary)]"
         style={canvasPageThemeStyle}
       >
         <ErrorScreen message={error} />
@@ -1491,7 +1562,7 @@ export default function CanvasPage({ sessionSourceApi }: CanvasPageProps) {
   if (gameEnded) {
     return (
       <div
-        className="flex h-screen w-full overflow-hidden bg-[color:var(--page-theme-page-background)] text-[color:var(--page-theme-text-primary)]"
+        className="flex h-[100dvh] min-h-[100dvh] w-full overflow-hidden bg-[color:var(--page-theme-page-background)] text-[color:var(--page-theme-text-primary)]"
         style={canvasPageThemeStyle}
       >
         <GameEndedScreen />
@@ -1502,7 +1573,7 @@ export default function CanvasPage({ sessionSourceApi }: CanvasPageProps) {
   if (roomExpiredReason) {
     return (
       <div
-        className="flex h-screen w-full items-center justify-center overflow-hidden bg-[color:var(--page-theme-page-background)] px-6 text-center text-lg font-medium text-[color:var(--page-theme-text-primary)]"
+        className="flex h-[100dvh] min-h-[100dvh] w-full items-center justify-center overflow-hidden bg-[color:var(--page-theme-page-background)] px-6 text-center text-lg font-medium text-[color:var(--page-theme-text-primary)]"
         style={canvasPageThemeStyle}
       >
         {roomExpiredReason === "terminated_by_owner"
@@ -1515,11 +1586,14 @@ export default function CanvasPage({ sessionSourceApi }: CanvasPageProps) {
   if (isMobileLayout) {
     return (
       <div
-        className="flex h-screen w-full flex-col overflow-hidden bg-[color:var(--page-theme-page-background)] text-[color:var(--page-theme-text-primary)]"
-        style={canvasPageThemeStyle}
+        className="flex h-[100dvh] min-h-[100dvh] w-full flex-col overflow-hidden bg-[color:var(--page-theme-page-background)] text-[color:var(--page-theme-text-primary)]"
+        style={{
+          ...canvasPageThemeStyle,
+          paddingBottom: "env(safe-area-inset-bottom, 0px)",
+        }}
       >
         <div
-          className="shrink-0 px-3 pb-2 pt-3"
+          className="sticky top-0 z-30 shrink-0 bg-[color:var(--page-theme-page-background)] px-3 pb-2 pt-3"
           style={{
             paddingTop: "calc(env(safe-area-inset-top, 0px) + 12px)",
           }}
@@ -1640,7 +1714,11 @@ export default function CanvasPage({ sessionSourceApi }: CanvasPageProps) {
 
               <div className="pointer-events-none absolute inset-0 z-10">
                 <div
-                  className="pointer-events-auto absolute left-3 top-3 flex flex-col gap-2"
+                  className="pointer-events-auto absolute flex flex-col gap-2"
+                  style={{
+                    left: "calc(env(safe-area-inset-left, 0px) + 12px)",
+                    top: "calc(env(safe-area-inset-top, 0px) + 12px)",
+                  }}
                   onPointerDown={(event) => event.stopPropagation()}
                   onClick={(event) => event.stopPropagation()}
                 >
@@ -1672,7 +1750,11 @@ export default function CanvasPage({ sessionSourceApi }: CanvasPageProps) {
 
                 <div
                   ref={mobilePaletteAreaRef}
-                  className="pointer-events-auto absolute right-3 top-3"
+                  className="pointer-events-auto absolute"
+                  style={{
+                    right: "calc(env(safe-area-inset-right, 0px) + 12px)",
+                    top: "calc(env(safe-area-inset-top, 0px) + 12px)",
+                  }}
                   onPointerDown={(event) => event.stopPropagation()}
                   onClick={(event) => event.stopPropagation()}
                 >

--- a/frontend/src/pages/canvas/CanvasPage.tsx
+++ b/frontend/src/pages/canvas/CanvasPage.tsx
@@ -66,6 +66,7 @@ const ROUND_SELECTION_GUIDE_DURATION_MS = 2500;
 const SELECTION_PULSE_DURATION_MS = 1000;
 const MOBILE_VOTE_ERROR_DURATION_MS = 3000;
 const MOBILE_BREAKPOINT_MEDIA_QUERY = "(max-width: 1023px)";
+const MOBILE_LANDSCAPE_MEDIA_QUERY = "(orientation: landscape)";
 const MOBILE_RECENT_COLOR_LIMIT = 6;
 const MOBILE_RECENT_COLORS_STORAGE_KEY = "votedots:mobile-recent-colors";
 const MOBILE_CANVAS_EDGE_PADDING = 72;
@@ -303,6 +304,17 @@ function buildIntroGuideSeenStorageKey(canvasId: number): string {
   return `${INTRO_GUIDE_SEEN_STORAGE_KEY}:${canvasId}`;
 }
 
+function getInitialMobileLandscapeState() {
+  if (typeof window === "undefined") {
+    return false;
+  }
+
+  return (
+    window.matchMedia(MOBILE_BREAKPOINT_MEDIA_QUERY).matches &&
+    window.matchMedia(MOBILE_LANDSCAPE_MEDIA_QUERY).matches
+  );
+}
+
 export default function CanvasPage({ sessionSourceApi }: CanvasPageProps) {
   const navigate = useNavigate();
   const { locale, setLocale, t } = useI18n();
@@ -315,6 +327,9 @@ export default function CanvasPage({ sessionSourceApi }: CanvasPageProps) {
 
     return window.matchMedia(MOBILE_BREAKPOINT_MEDIA_QUERY).matches;
   });
+  const [isMobileLandscape, setIsMobileLandscape] = useState(
+    getInitialMobileLandscapeState,
+  );
   const [mobileSheet, setMobileSheet] = useState<MobileSheetType>(null);
   const [desktopVoteMode, setDesktopVoteMode] = useState<VoteMode>("select");
   const [desktopPaletteColor, setDesktopPaletteColor] = useState(() =>
@@ -372,21 +387,31 @@ export default function CanvasPage({ sessionSourceApi }: CanvasPageProps) {
       return undefined;
     }
 
-    const mediaQuery = window.matchMedia(MOBILE_BREAKPOINT_MEDIA_QUERY);
-    const handleMediaQueryChange = (event: MediaQueryListEvent) => {
-      setIsMobileLayout(event.matches);
+    const mobileQuery = window.matchMedia(MOBILE_BREAKPOINT_MEDIA_QUERY);
+    const landscapeQuery = window.matchMedia(MOBILE_LANDSCAPE_MEDIA_QUERY);
+    const syncMobileState = () => {
+      const nextIsMobile = mobileQuery.matches;
+      const nextIsMobileLandscape = nextIsMobile && landscapeQuery.matches;
 
-      if (!event.matches) {
+      setIsMobileLayout(nextIsMobile);
+      setIsMobileLandscape(nextIsMobileLandscape);
+
+      if (!nextIsMobile || nextIsMobileLandscape) {
         setMobileSheet(null);
         setMobilePaletteOpen(false);
         setMobileVoteError("");
       }
     };
 
-    mediaQuery.addEventListener("change", handleMediaQueryChange);
+    syncMobileState();
+    mobileQuery.addEventListener("change", syncMobileState);
+    landscapeQuery.addEventListener("change", syncMobileState);
+    window.addEventListener("resize", syncMobileState);
 
     return () => {
-      mediaQuery.removeEventListener("change", handleMediaQueryChange);
+      mobileQuery.removeEventListener("change", syncMobileState);
+      landscapeQuery.removeEventListener("change", syncMobileState);
+      window.removeEventListener("resize", syncMobileState);
     };
   }, []);
 
@@ -1332,9 +1357,8 @@ export default function CanvasPage({ sessionSourceApi }: CanvasPageProps) {
   const handleSelectMobileRecentColor = useCallback(
     (nextColor: string) => {
       handleMobilePaletteColorChange(nextColor);
-      commitMobileRecentColor(nextColor);
     },
-    [commitMobileRecentColor, handleMobilePaletteColorChange],
+    [handleMobilePaletteColorChange],
   );
 
   const handleSubmitMobileVote = useCallback(
@@ -1583,6 +1607,39 @@ export default function CanvasPage({ sessionSourceApi }: CanvasPageProps) {
     );
   }
 
+  if (isMobileLayout && isMobileLandscape) {
+    return (
+      <div
+        className="flex h-[100dvh] min-h-[100dvh] w-full items-center justify-center overflow-hidden bg-[color:var(--page-theme-page-background)] px-6 text-[color:var(--page-theme-text-primary)]"
+        style={canvasPageThemeStyle}
+      >
+        <div
+          className="flex w-full max-w-sm flex-col items-center rounded-[32px] border border-[color:var(--page-theme-border-primary)] bg-[color:var(--page-theme-surface-primary)] px-6 py-8 text-center shadow-sm"
+          style={{
+            paddingTop: "calc(env(safe-area-inset-top, 0px) + 32px)",
+            paddingRight: "calc(env(safe-area-inset-right, 0px) + 24px)",
+            paddingBottom: "calc(env(safe-area-inset-bottom, 0px) + 32px)",
+            paddingLeft: "calc(env(safe-area-inset-left, 0px) + 24px)",
+          }}
+        >
+          <div className="flex h-16 w-16 items-center justify-center rounded-full border border-[color:var(--page-theme-border-primary)] bg-[color:var(--page-theme-surface-secondary)] text-2xl">
+            ↻
+          </div>
+          <h1 className="mt-5 text-xl font-semibold text-[color:var(--page-theme-text-primary)]">
+            {locale === "ko"
+              ? "가로 모드는 지원하지 않습니다."
+              : "Landscape mode is not supported."}
+          </h1>
+          <p className="mt-3 text-sm leading-6 text-[color:var(--page-theme-text-secondary)]">
+            {locale === "ko"
+              ? "기기를 세로로 돌린 뒤 다시 이용해 주세요."
+              : "Rotate your device back to portrait mode to continue."}
+          </p>
+        </div>
+      </div>
+    );
+  }
+
   if (isMobileLayout) {
     return (
       <div
@@ -1792,21 +1849,16 @@ export default function CanvasPage({ sessionSourceApi }: CanvasPageProps) {
                           key={color}
                           type="button"
                           onClick={() => handleSelectMobileRecentColor(color)}
-                          className="inline-flex h-9 w-9 items-center justify-center rounded-xl border border-[color:var(--page-theme-border-primary)] shadow-sm backdrop-blur"
+                          className="inline-flex h-9 w-9 rounded-xl border border-[color:var(--page-theme-border-primary)] shadow-sm backdrop-blur"
                           style={{
                             backgroundColor: color,
-                            color: getReadableTextColor(color),
                           }}
                           aria-label={
                             locale === "ko"
                               ? `최근 색상 ${color}`
                               : `Recent color ${color}`
                           }
-                        >
-                          <span className="text-[10px] font-bold leading-none">
-                            •
-                          </span>
-                        </button>
+                        />
                       ))}
                     </div>
 

--- a/frontend/src/pages/canvas/CanvasPage.tsx
+++ b/frontend/src/pages/canvas/CanvasPage.tsx
@@ -43,21 +43,12 @@ import {
   LoadingScreen,
 } from "@/features/gameplay/session";
 import {
-  ColorPalette,
   VotePanel,
   VotePopup,
   voteApi,
 } from "@/features/gameplay/vote";
-import pinIcon from "@/assets/pin-icon.png";
 import {
-  CHECKER_PATTERN,
-  INITIAL_SLOTS,
-  STORAGE_KEYS,
-} from "@/features/gameplay/vote/model/vote.constants";
-import {
-  buildVotePopupEntries,
   loadLastPaletteColor,
-  loadSlotColors,
 } from "@/features/gameplay/vote/model/vote.utils";
 import { useI18n } from "@/shared/i18n";
 import { translateServerMessage } from "@/shared/i18n/server-messages";
@@ -65,6 +56,7 @@ import { usePageRootClass } from "@/shared/hooks/use-page-root-class";
 import { BrandLogo } from "@/shared/ui/brand-logo";
 import { DropdownSelect } from "@/shared/ui/dropdown-select";
 import MobileBottomSheet from "./components/MobileBottomSheet";
+import MobileFloatingPalette from "./components/MobileFloatingPalette";
 import useCanvasPage from "./model/useCanvasPage";
 import { PLAY_THEME_STYLE } from "./model/play-theme";
 
@@ -73,10 +65,11 @@ const ROUND_SELECTION_GUIDE_DURATION_MS = 2500;
 const SELECTION_PULSE_DURATION_MS = 1000;
 const MOBILE_VOTE_ERROR_DURATION_MS = 3000;
 const MOBILE_BREAKPOINT_MEDIA_QUERY = "(max-width: 1023px)";
-const MOBILE_SLOT_COUNT = 8;
+const MOBILE_RECENT_COLOR_LIMIT = 6;
+const MOBILE_RECENT_COLORS_STORAGE_KEY = "votedots:mobile-recent-colors";
 
-type MobileSheetType = "menu" | "participants" | "history" | "palette" | null;
-type MobileVoteMode = "select" | "instant";
+type MobileSheetType = "menu" | "participants" | "history" | null;
+type VoteMode = "select" | "instant";
 
 function MenuGlyph() {
   return (
@@ -176,6 +169,44 @@ function getReadableTextColor(hexColor: string): "#111827" | "#ffffff" {
   const luminance = (red * 299 + green * 587 + blue * 114) / 1000;
 
   return luminance >= 160 ? "#111827" : "#ffffff";
+}
+
+function normalizeHexColor(color: string): string {
+  const normalized = color.trim();
+
+  if (!/^#[0-9a-fA-F]{6}$/.test(normalized)) {
+    return normalized;
+  }
+
+  return `#${normalized.slice(1).toUpperCase()}`;
+}
+
+function loadMobileRecentColors(): string[] {
+  if (typeof window === "undefined") {
+    return [];
+  }
+
+  try {
+    const stored = window.localStorage.getItem(MOBILE_RECENT_COLORS_STORAGE_KEY);
+
+    if (!stored) {
+      return [];
+    }
+
+    const parsed = JSON.parse(stored);
+
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+
+    return parsed
+      .filter((color): color is string => typeof color === "string")
+      .map((color) => normalizeHexColor(color))
+      .filter((color) => /^#[0-9A-F]{6}$/.test(color))
+      .slice(0, MOBILE_RECENT_COLOR_LIMIT);
+  } catch {
+    return [];
+  }
 }
 
 function getPhaseLabelKey(phase: GamePhase): string {
@@ -283,22 +314,18 @@ export default function CanvasPage({ sessionSourceApi }: CanvasPageProps) {
     return window.matchMedia(MOBILE_BREAKPOINT_MEDIA_QUERY).matches;
   });
   const [mobileSheet, setMobileSheet] = useState<MobileSheetType>(null);
-  const [mobileVoteMode, setMobileVoteMode] =
-    useState<MobileVoteMode>("select");
-  const [desktopVoteMode, setDesktopVoteMode] =
-    useState<MobileVoteMode>("select");
+  const [desktopVoteMode, setDesktopVoteMode] = useState<VoteMode>("select");
   const [desktopPaletteColor, setDesktopPaletteColor] = useState(() =>
     loadLastPaletteColor(),
   );
   const [desktopVoteLoading, setDesktopVoteLoading] = useState(false);
-  const [mobilePalettePinned, setMobilePalettePinned] = useState(false);
+  const [mobilePaletteOpen, setMobilePaletteOpen] = useState(false);
   const [mobilePaletteColor, setMobilePaletteColor] = useState(() =>
-    loadLastPaletteColor(),
+    normalizeHexColor(loadLastPaletteColor()),
   );
-  const [mobileSlotColors, setMobileSlotColors] = useState(() =>
-    loadSlotColors().slice(0, MOBILE_SLOT_COUNT),
+  const [mobileRecentColors, setMobileRecentColors] = useState(() =>
+    loadMobileRecentColors(),
   );
-  const [mobileSlotCursor, setMobileSlotCursor] = useState(0);
   const [mobileVoteError, setMobileVoteError] = useState("");
   const [mobileVoteLoading, setMobileVoteLoading] = useState(false);
 
@@ -327,6 +354,7 @@ export default function CanvasPage({ sessionSourceApi }: CanvasPageProps) {
   const guideTimerRef = useRef<number | null>(null);
   const pulseTimerRef = useRef<number | null>(null);
   const mobileVoteErrorTimerRef = useRef<number | null>(null);
+  const mobilePaletteAreaRef = useRef<HTMLDivElement | null>(null);
   const lastAnnouncedRoundIdRef = useRef<number | null>(null);
   const hasPulsedSelectionThisRoundRef = useRef(false);
 
@@ -341,6 +369,7 @@ export default function CanvasPage({ sessionSourceApi }: CanvasPageProps) {
 
       if (!event.matches) {
         setMobileSheet(null);
+        setMobilePaletteOpen(false);
         setMobileVoteError("");
       }
     };
@@ -351,6 +380,37 @@ export default function CanvasPage({ sessionSourceApi }: CanvasPageProps) {
       mediaQuery.removeEventListener("change", handleMediaQueryChange);
     };
   }, []);
+
+  useEffect(() => {
+    if (typeof document === "undefined" || !mobilePaletteOpen) {
+      return;
+    }
+
+    const handlePointerDownOutside = (event: PointerEvent) => {
+      const paletteArea = mobilePaletteAreaRef.current;
+      const target = event.target;
+
+      if (!(target instanceof Node)) {
+        return;
+      }
+
+      if (paletteArea?.contains(target)) {
+        return;
+      }
+
+      setMobilePaletteOpen(false);
+    };
+
+    document.addEventListener("pointerdown", handlePointerDownOutside, true);
+
+    return () => {
+      document.removeEventListener(
+        "pointerdown",
+        handlePointerDownOutside,
+        true,
+      );
+    };
+  }, [mobilePaletteOpen]);
 
   useEffect(() => {
     if (mobileVoteErrorTimerRef.current !== null) {
@@ -686,29 +746,25 @@ export default function CanvasPage({ sessionSourceApi }: CanvasPageProps) {
             {
               id: "mobile-controls",
               targetIds: [
-                "tutorial-mobile-vote-controls",
                 "tutorial-mobile-palette-button",
+                "tutorial-mobile-recent-colors",
               ],
-              title:
-                locale === "ko"
-                  ? "투표 모드와 팔레트"
-                  : "Vote mode and palette",
+              title: locale === "ko" ? "팔레트" : "Palette",
               description:
                 locale === "ko"
-                  ? "좌하단에서 투표 모드를 바꾸고, 우하단 팔레트 버튼으로 색상 패널을 열 수 있습니다.\n색상 선택 모드는 표 하나마다 색상을 선택하고 투표합니다.\n바로 투표 모드는 처음 지정한 색상으로 선택함과 동시에 투표합니다."
-                  : "Switch vote modes at the bottom left and open the color palette from the bottom right button.\nSelect color vote lets you choose a color for each tile before voting.\nInstant vote submits immediately with the color you set first.",
+                  ? "우상단 팔레트 버튼으로 색상을 바꾸고, 그 아래 최근 색상 목록에서 빠르게 다시 선택할 수 있습니다.\n모바일에서는 현재 선택한 색상으로 셀을 누르면 바로 투표합니다."
+                  : "Use the top-right palette button to change colors, and quickly reselect recent colors from the list below.\nOn mobile, tapping a cell immediately votes with the currently selected color.",
               padding: 8,
               panelPosition: "center",
             },
             {
               id: "vote-modal",
-              targetIds: ["tutorial-vote-modal"],
-              title:
-                locale === "ko" ? "팔레트" : "Palette",
+              targetIds: ["tutorial-mobile-palette-panel"],
+              title: locale === "ko" ? "색상 선택" : "Color selection",
               description:
                 locale === "ko"
-                  ? "팔레트에서 색을 고르고, 실시간 현황과 즐겨찾기를 확인할 수 있습니다."
-                  : "Pick colors from the palette and review live status and favorites.",
+                  ? "플로팅 팔레트에서 바로 색상을 고를 수 있습니다."
+                  : "Pick a color directly from the floating palette.",
               padding: 8,
             },
             {
@@ -831,8 +887,6 @@ export default function CanvasPage({ sessionSourceApi }: CanvasPageProps) {
     }
 
     switch (tutorialCurrentStepId) {
-      case "vote-modal":
-        return "palette";
       case "top-actions":
         return "menu";
       case "participants":
@@ -843,6 +897,8 @@ export default function CanvasPage({ sessionSourceApi }: CanvasPageProps) {
         return null;
     }
   }, [isMobileLayout, tutorialCurrentStepId, tutorialOpen]);
+  const shouldOpenTutorialMobilePalette =
+    tutorialOpen && isMobileLayout && tutorialCurrentStepId === "vote-modal";
   const tutorialVoteSelectedCell = useMemo(() => {
     if (selectedCell) {
       return selectedCell;
@@ -1081,13 +1137,14 @@ export default function CanvasPage({ sessionSourceApi }: CanvasPageProps) {
 
   const handleOpenTutorial = useCallback(() => {
     setTutorialStepIndex(0);
-    setMobilePalettePinned(false);
+    setMobilePaletteOpen(false);
     setTutorialOpen(true);
   }, []);
 
   const handleCloseTutorial = useCallback(() => {
     setTutorialOpen(false);
     setMobileSheet(null);
+    setMobilePaletteOpen(false);
   }, []);
 
   useEffect(() => {
@@ -1163,74 +1220,51 @@ export default function CanvasPage({ sessionSourceApi }: CanvasPageProps) {
     handleColorChange(mobilePaletteColor);
   }, [handleColorChange, isMobileLayout, mobilePaletteColor]);
 
-  const persistMobileSlotColors = useCallback((nextSlotColors: string[]) => {
-    if (typeof window === "undefined") {
-      return;
-    }
-
-    const normalized = nextSlotColors.slice(0, MOBILE_SLOT_COUNT);
-
-    while (normalized.length < MOBILE_SLOT_COUNT) {
-      normalized.push("");
-    }
-
-    window.localStorage.setItem(
-      STORAGE_KEYS.slotColors,
-      JSON.stringify([
-        ...normalized,
-        ...INITIAL_SLOTS.slice(MOBILE_SLOT_COUNT),
-      ]),
-    );
-  }, []);
-
   const handleMobilePaletteColorChange = useCallback((nextColor: string) => {
+    const normalizedColor = normalizeHexColor(nextColor);
+
     if (typeof window !== "undefined") {
-      window.localStorage.setItem(STORAGE_KEYS.lastPaletteColor, nextColor);
+      window.localStorage.setItem(
+        "votedots:last-palette-color",
+        normalizedColor,
+      );
     }
 
-    setMobilePaletteColor(nextColor);
+    setMobilePaletteColor(normalizedColor);
     setMobileVoteError("");
   }, []);
 
-  const handleMobileSlotAdd = useCallback(() => {
-    setMobileSlotColors((prev) => {
-      const next = [...prev];
-      next[mobileSlotCursor] = mobilePaletteColor;
-      persistMobileSlotColors(next);
-      return next;
-    });
-    setMobileSlotCursor((prev) => (prev + 1) % MOBILE_SLOT_COUNT);
-  }, [mobilePaletteColor, mobileSlotCursor, persistMobileSlotColors]);
+  const commitMobileRecentColor = useCallback((nextColor?: string) => {
+    const resolvedColor = normalizeHexColor(nextColor ?? mobilePaletteColor);
 
-  const handleMobileSlotReset = useCallback(() => {
-    const next = INITIAL_SLOTS.slice(0, MOBILE_SLOT_COUNT);
-    setMobileSlotColors(next);
-    setMobileSlotCursor(0);
-    persistMobileSlotColors(next);
-  }, [persistMobileSlotColors]);
-
-  const handleMobileSlotSelect = useCallback(
-    (slotColor: string, slotIndex: number) => {
-      setMobileSlotCursor(slotIndex);
-
-      if (!slotColor) {
-        return;
-      }
-
-      handleMobilePaletteColorChange(slotColor);
-    },
-    [handleMobilePaletteColorChange],
-  );
-  const openMobilePaletteSheet = useCallback(() => {
-    if (typeof window === "undefined") {
-      setMobileSheet("palette");
+    if (!/^#[0-9A-F]{6}$/.test(resolvedColor)) {
       return;
     }
 
-    window.requestAnimationFrame(() => {
-      setMobileSheet("palette");
+    setMobileRecentColors((prev) => {
+      const next = [
+        resolvedColor,
+        ...prev.filter((color) => color !== resolvedColor),
+      ].slice(0, MOBILE_RECENT_COLOR_LIMIT);
+
+      if (typeof window !== "undefined") {
+        window.localStorage.setItem(
+          MOBILE_RECENT_COLORS_STORAGE_KEY,
+          JSON.stringify(next),
+        );
+      }
+
+      return next;
     });
-  }, []);
+  }, [mobilePaletteColor]);
+
+  const handleSelectMobileRecentColor = useCallback(
+    (nextColor: string) => {
+      handleMobilePaletteColorChange(nextColor);
+      commitMobileRecentColor(nextColor);
+    },
+    [commitMobileRecentColor, handleMobilePaletteColorChange],
+  );
 
   const handleSubmitMobileVote = useCallback(
     async (targetCell?: Cell | null) => {
@@ -1275,10 +1309,6 @@ export default function CanvasPage({ sessionSourceApi }: CanvasPageProps) {
         });
 
         handleVoteSuccess(mobilePaletteColor);
-
-        if (mobileVoteMode === "select" && !mobilePalettePinned) {
-          setMobileSheet(null);
-        }
       } catch (err: unknown) {
         if (err && typeof err === "object" && "response" in err) {
           const axiosErr = err as {
@@ -1306,9 +1336,7 @@ export default function CanvasPage({ sessionSourceApi }: CanvasPageProps) {
       isRoundExpired,
       locale,
       mobilePaletteColor,
-      mobilePalettePinned,
       mobileVoteLoading,
-      mobileVoteMode,
       phase,
       remaining,
       roundId,
@@ -1371,13 +1399,7 @@ export default function CanvasPage({ sessionSourceApi }: CanvasPageProps) {
     cellActivatedHandlerRef.current = (cell) => {
       if (isMobileLayout) {
         setMobileVoteError("");
-
-        if (mobileVoteMode === "instant") {
-          void handleSubmitMobileVote(cell);
-          return;
-        }
-
-        openMobilePaletteSheet();
+        void handleSubmitMobileVote(cell);
         return;
       }
 
@@ -1390,8 +1412,6 @@ export default function CanvasPage({ sessionSourceApi }: CanvasPageProps) {
     handleSubmitDesktopInstantVote,
     handleSubmitMobileVote,
     isMobileLayout,
-    mobileVoteMode,
-    openMobilePaletteSheet,
   ]);
 
   const mobileMenuLabels =
@@ -1433,31 +1453,14 @@ export default function CanvasPage({ sessionSourceApi }: CanvasPageProps) {
   const activeMobileSheet =
     tutorialOpen && isMobileLayout ? tutorialMobileManagedSheet : mobileSheet;
   const roomGameEndControlsDisabled = phase === GAME_PHASE.GAME_END;
-  const selectedCellLabel = selectedCell
-    ? `(${selectedCell.x}, ${selectedCell.y})`
-    : locale === "ko"
-      ? "선택 없음"
-      : "None";
-  const mobileVoteEntries = useMemo(
-    () =>
-      selectedCell
-        ? buildVotePopupEntries(votes, selectedCell.x, selectedCell.y).slice(
-            0,
-            3,
-          )
-        : [],
-    [selectedCell, votes],
-  );
-  const isPaletteSheetOpen = activeMobileSheet === "palette";
+  const isMobilePaletteVisible =
+    shouldOpenTutorialMobilePalette ||
+    (mobilePaletteOpen &&
+      activeMobileSheet === null &&
+      !introGuideOpen &&
+      !roundSummaryOpen &&
+      !gameSummaryModal);
   const mobilePaletteButtonTextColor = getReadableTextColor(mobilePaletteColor);
-  const canSubmitMobileVote =
-    Boolean(canvasId) &&
-    Boolean(roundId) &&
-    Boolean(selectedCell) &&
-    phase === GAME_PHASE.ROUND_ACTIVE &&
-    !isRoundExpired &&
-    !mobileVoteLoading &&
-    (remaining === null || remaining > 0);
 
   const handleOpenMobileBack = useCallback(() => {
     navigate("/lobby");
@@ -1525,7 +1528,10 @@ export default function CanvasPage({ sessionSourceApi }: CanvasPageProps) {
           <div className="flex h-[58px] items-center rounded-[24px] border border-[color:var(--page-theme-border-primary)] bg-[color:var(--page-theme-surface-primary)] px-4 shadow-sm">
             <button
               type="button"
-              onClick={() => setMobileSheet("menu")}
+              onClick={() => {
+                setMobilePaletteOpen(false);
+                setMobileSheet("menu");
+              }}
               className="inline-flex h-9 w-9 items-center justify-center rounded-full text-[color:var(--page-theme-text-secondary)]"
               aria-label={mobileMenuLabels.title}
               data-tutorial-id="tutorial-mobile-menu-button"
@@ -1539,7 +1545,10 @@ export default function CanvasPage({ sessionSourceApi }: CanvasPageProps) {
 
             <button
               type="button"
-              onClick={() => setMobileSheet("participants")}
+              onClick={() => {
+                setMobilePaletteOpen(false);
+                setMobileSheet("participants");
+              }}
               className="inline-flex min-w-[92px] items-center justify-end gap-1 text-[color:var(--page-theme-text-secondary)]"
               aria-label={t("session.participantList")}
               data-tutorial-id="tutorial-mobile-participants-button"
@@ -1565,7 +1574,10 @@ export default function CanvasPage({ sessionSourceApi }: CanvasPageProps) {
 
             <button
               type="button"
-              onClick={() => setMobileSheet("history")}
+              onClick={() => {
+                setMobilePaletteOpen(false);
+                setMobileSheet("history");
+              }}
               className="flex items-center justify-between gap-2 border-r border-[color:var(--page-theme-border-primary)] px-3 text-left"
               data-tutorial-id="tutorial-mobile-round-info"
             >
@@ -1659,36 +1671,71 @@ export default function CanvasPage({ sessionSourceApi }: CanvasPageProps) {
                 </div>
 
                 <div
-                  className="pointer-events-auto absolute bottom-3 right-3"
+                  ref={mobilePaletteAreaRef}
+                  className="pointer-events-auto absolute right-3 top-3"
                   onPointerDown={(event) => event.stopPropagation()}
                   onClick={(event) => event.stopPropagation()}
-                  data-tutorial-id="tutorial-mobile-palette-button"
                 >
-                  <button
-                    type="button"
-                    onClick={() => {
-                      if (isPaletteSheetOpen && !mobilePalettePinned) {
+                  <div className="relative flex flex-col items-end gap-2">
+                    <button
+                      type="button"
+                      onClick={() => {
                         setMobileSheet(null);
-                        return;
+                        setMobileVoteError("");
+                        setMobilePaletteOpen((prev) => !prev);
+                      }}
+                      className={`inline-flex h-11 w-11 items-center justify-center rounded-2xl border shadow-sm backdrop-blur ${
+                        isMobilePaletteVisible
+                          ? "border-[color:var(--page-theme-primary-action)]"
+                          : "border-[color:var(--page-theme-border-primary)]"
+                      }`}
+                      style={{
+                        backgroundColor: mobilePaletteColor,
+                        color: mobilePaletteButtonTextColor,
+                      }}
+                      aria-label={
+                        locale === "ko" ? "팔레트 열기" : "Open palette"
                       }
+                      data-tutorial-id="tutorial-mobile-palette-button"
+                    >
+                      <PaletteGlyph />
+                    </button>
 
-                      openMobilePaletteSheet();
-                    }}
-                    className={`inline-flex h-11 w-11 items-center justify-center rounded-2xl border shadow-sm backdrop-blur ${
-                      isPaletteSheetOpen
-                        ? "border-[color:var(--page-theme-primary-action)]"
-                        : "border-[color:var(--page-theme-border-primary)]"
-                    }`}
-                    style={{
-                      backgroundColor: mobilePaletteColor,
-                      color: mobilePaletteButtonTextColor,
-                    }}
-                    aria-label={
-                      locale === "ko" ? "팔레트 열기" : "Open palette"
-                    }
-                  >
-                    <PaletteGlyph />
-                  </button>
+                    <div
+                      className="flex flex-col gap-2"
+                      data-tutorial-id="tutorial-mobile-recent-colors"
+                    >
+                      {mobileRecentColors.map((color) => (
+                        <button
+                          key={color}
+                          type="button"
+                          onClick={() => handleSelectMobileRecentColor(color)}
+                          className="inline-flex h-9 w-9 items-center justify-center rounded-xl border border-[color:var(--page-theme-border-primary)] shadow-sm backdrop-blur"
+                          style={{
+                            backgroundColor: color,
+                            color: getReadableTextColor(color),
+                          }}
+                          aria-label={
+                            locale === "ko"
+                              ? `최근 색상 ${color}`
+                              : `Recent color ${color}`
+                          }
+                        >
+                          <span className="text-[10px] font-bold leading-none">
+                            •
+                          </span>
+                        </button>
+                      ))}
+                    </div>
+
+                    <MobileFloatingPalette
+                      open={isMobilePaletteVisible}
+                      color={mobilePaletteColor}
+                      onChange={handleMobilePaletteColorChange}
+                      onCommitColor={commitMobileRecentColor}
+                      tutorialId="tutorial-mobile-palette-panel"
+                    />
+                  </div>
                 </div>
 
                 {mobileVoteError ? (
@@ -1696,43 +1743,6 @@ export default function CanvasPage({ sessionSourceApi }: CanvasPageProps) {
                     {mobileVoteError}
                   </div>
                 ) : null}
-
-                <div
-                  className="pointer-events-auto absolute bottom-3 left-3 flex rounded-full border border-[color:var(--page-theme-border-primary)] bg-[color:rgba(255,255,255,0.94)] p-1 shadow-sm backdrop-blur"
-                  onPointerDown={(event) => event.stopPropagation()}
-                  onClick={(event) => event.stopPropagation()}
-                  data-tutorial-id="tutorial-mobile-vote-controls"
-                >
-                  <button
-                    type="button"
-                    onClick={() => {
-                      setMobileVoteMode("select");
-                      setMobileVoteError("");
-                    }}
-                    className={`rounded-full px-3 py-2 text-xs font-semibold ${
-                      mobileVoteMode === "select"
-                        ? "bg-[color:var(--page-theme-primary-action)] text-[color:var(--page-theme-primary-action-text)]"
-                        : "text-[color:var(--page-theme-text-secondary)]"
-                    }`}
-                  >
-                    {locale === "ko" ? "색상 선택 투표" : "Select color vote"}
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => {
-                      setMobileVoteMode("instant");
-                      setMobileVoteError("");
-                      openMobilePaletteSheet();
-                    }}
-                    className={`rounded-full px-3 py-2 text-xs font-semibold ${
-                      mobileVoteMode === "instant"
-                        ? "bg-[color:var(--page-theme-primary-action)] text-[color:var(--page-theme-primary-action-text)]"
-                        : "text-[color:var(--page-theme-text-secondary)]"
-                    }`}
-                  >
-                    {locale === "ko" ? "바로 투표" : "Instant vote"}
-                  </button>
-                </div>
               </div>
 
               {shouldShowTutorialVotePopup ? (
@@ -1953,6 +1963,7 @@ export default function CanvasPage({ sessionSourceApi }: CanvasPageProps) {
               type="button"
               onClick={() => {
                 setMobileSheet(null);
+                setMobilePaletteOpen(false);
                 handleOpenIntroGuide();
               }}
               className="inline-flex h-11 w-full items-center justify-center rounded-2xl bg-[color:var(--page-theme-primary-action)] px-4 text-sm font-semibold text-[color:var(--page-theme-primary-action-text)]"
@@ -1981,6 +1992,7 @@ export default function CanvasPage({ sessionSourceApi }: CanvasPageProps) {
                       type="button"
                       onClick={() => {
                         setMobileSheet(null);
+                        setMobilePaletteOpen(false);
                         handleOpenGameSummaryModal(item.data);
                       }}
                       className="inline-flex h-11 items-center justify-center rounded-2xl border border-[color:var(--page-theme-accent-warm)] bg-[color:var(--page-theme-accent-warm-soft)] px-3 text-sm font-bold text-[color:var(--page-theme-accent-warm)]"
@@ -1993,6 +2005,7 @@ export default function CanvasPage({ sessionSourceApi }: CanvasPageProps) {
                       type="button"
                       onClick={() => {
                         setMobileSheet(null);
+                        setMobilePaletteOpen(false);
                         handleOpenRoundSummaryModal(item.data);
                       }}
                       className="inline-flex h-11 items-center justify-center rounded-2xl border border-[color:var(--page-theme-border-primary)] bg-[color:var(--page-theme-surface-primary)] px-3 text-sm font-bold text-[color:var(--page-theme-text-primary)]"
@@ -2003,99 +2016,6 @@ export default function CanvasPage({ sessionSourceApi }: CanvasPageProps) {
                 )}
               </div>
             )}
-          </div>
-        </MobileBottomSheet>
-
-        <MobileBottomSheet
-          open={activeMobileSheet === "palette"}
-          title={
-            <div className="flex w-full flex-col items-start justify-start gap-1 text-left">
-              <h2 className="text-lg font-semibold text-black">
-                {locale === "ko" ? "팔레트" : "Palette"}
-              </h2>
-              <div className="flex h-8 shrink-0 items-center justify-start gap-3 text-left text-base font-semibold leading-none text-black">
-                <button
-                  type="button"
-                  className="h-8 w-8 shrink-0 rounded border border-[color:var(--page-theme-border-secondary)] p-0"
-                  style={
-                    selectedCell?.color
-                      ? { backgroundColor: selectedCell.color }
-                      : {
-                          backgroundColor: "#f9fafb",
-                          backgroundImage: CHECKER_PATTERN,
-                          backgroundPosition: "0 0, 4px 4px",
-                          backgroundSize: "8px 8px",
-                        }
-                  }
-                  onClick={() => {
-                    if (selectedCell?.color) {
-                      handleMobilePaletteColorChange(selectedCell.color);
-                    }
-                  }}
-                />
-                <span className="inline-flex h-8 translate-y-px items-center leading-none">
-                  {selectedCellLabel}
-                </span>
-              </div>
-            </div>
-          }
-          headerActions={
-            <>
-              <button
-                type="button"
-                onClick={() => setMobilePalettePinned((prev) => !prev)}
-                className={`inline-flex h-9 w-9 items-center justify-center rounded-full border ${
-                  mobilePalettePinned
-                    ? "border-[color:var(--page-theme-primary-action)] bg-[color:var(--page-theme-primary-action)] text-[color:var(--page-theme-primary-action-text)]"
-                    : "border-[color:var(--page-theme-border-primary)] bg-[color:var(--page-theme-surface-primary)] text-[color:var(--page-theme-text-secondary)]"
-                }`}
-                aria-label={locale === "ko" ? "팔레트 고정" : "Pin palette"}
-              >
-                <img
-                  src={pinIcon}
-                  alt=""
-                  aria-hidden="true"
-                  className="h-8 w-8 object-contain"
-                  draggable={false}
-                />
-              </button>
-            </>
-          }
-          onClose={() => setMobileSheet(null)}
-          maxHeightClassName="max-h-[52vh]"
-          showBackdrop={!mobilePalettePinned}
-          headerActionsOffsetClassName="translate-y-4"
-          tutorialId="tutorial-vote-modal"
-        >
-          <div className="pb-1">
-            {mobileVoteError ? (
-              <div className="mb-3 rounded-2xl border border-[color:var(--page-theme-alert)] bg-[color:var(--page-theme-alert-soft)] px-4 py-2 text-sm text-[color:var(--page-theme-alert)]">
-                {mobileVoteError}
-              </div>
-            ) : null}
-
-            <ColorPalette
-              layout="mobile-compact"
-              selected={mobilePaletteColor}
-              onChange={handleMobilePaletteColorChange}
-              slotColors={mobileSlotColors}
-              slotCursor={mobileSlotCursor}
-              onSlotAdd={handleMobileSlotAdd}
-              onSlotReset={handleMobileSlotReset}
-              onSlotSelect={handleMobileSlotSelect}
-              voteEntries={mobileVoteEntries}
-            />
-
-            <button
-              type="button"
-              onClick={() => void handleSubmitMobileVote()}
-              disabled={!canSubmitMobileVote}
-              className="mt-4 inline-flex h-11 w-full items-center justify-center rounded-[20px] bg-[color:var(--page-theme-primary-action)] px-4 text-sm font-semibold text-[color:var(--page-theme-primary-action-text)] disabled:cursor-not-allowed disabled:opacity-45"
-            >
-              {mobileVoteLoading
-                ? t("vote.popup.loading")
-                : t("vote.popup.submit")}
-            </button>
           </div>
         </MobileBottomSheet>
 

--- a/frontend/src/pages/canvas/components/MobileBottomSheet.tsx
+++ b/frontend/src/pages/canvas/components/MobileBottomSheet.tsx
@@ -29,8 +29,14 @@ export default function MobileBottomSheet({
     handleTouchMove,
     handleTouchEnd,
     handleTouchCancel,
+    dragOffsetY,
+    isDragging,
+    isClosing,
+    backdropOpacity,
+    transitionDurationMs,
   } = useSwipeDownDismiss({
     onDismiss: onClose,
+    active: open,
   });
 
   if (!open) {
@@ -44,6 +50,12 @@ export default function MobileBottomSheet({
           type="button"
           aria-label="close"
           className="pointer-events-auto absolute inset-0 bg-[rgba(0,0,0,0.28)]"
+          style={{
+            opacity: backdropOpacity,
+            transition: isDragging
+              ? "none"
+              : `opacity ${transitionDurationMs}ms ease-out`,
+          }}
           onPointerDown={onClose}
           onPointerMove={onClose}
           onTouchStart={onClose}
@@ -57,6 +69,13 @@ export default function MobileBottomSheet({
         className={`pointer-events-auto absolute inset-x-0 bottom-0 flex flex-col overflow-hidden rounded-t-[28px] border border-b-0 border-[color:var(--page-theme-border-primary)] bg-[color:var(--page-theme-page-background)] shadow-[0_-20px_40px_rgba(15,23,42,0.22)] ${maxHeightClassName}`}
         style={{
           paddingBottom: "calc(env(safe-area-inset-bottom, 0px) + 16px)",
+          transform: isClosing
+            ? "translateY(calc(100% + 32px))"
+            : `translateY(${Math.max(0, dragOffsetY)}px)`,
+          transition: isDragging
+            ? "none"
+            : `transform ${transitionDurationMs}ms cubic-bezier(0.22, 1, 0.36, 1)`,
+          willChange: "transform",
         }}
         data-tutorial-id={tutorialId}
       >

--- a/frontend/src/pages/canvas/components/MobileBottomSheet.tsx
+++ b/frontend/src/pages/canvas/components/MobileBottomSheet.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from "react";
+import { useSwipeDownDismiss } from "@/shared/hooks/use-swipe-down-dismiss";
 
 interface MobileBottomSheetProps {
   open: boolean;
@@ -23,6 +24,15 @@ export default function MobileBottomSheet({
   headerActionsOffsetClassName = "",
   tutorialId,
 }: MobileBottomSheetProps) {
+  const {
+    handleTouchStart,
+    handleTouchMove,
+    handleTouchEnd,
+    handleTouchCancel,
+  } = useSwipeDownDismiss({
+    onDismiss: onClose,
+  });
+
   if (!open) {
     return null;
   }
@@ -34,6 +44,11 @@ export default function MobileBottomSheet({
           type="button"
           aria-label="close"
           className="pointer-events-auto absolute inset-0 bg-[rgba(0,0,0,0.28)]"
+          onPointerDown={onClose}
+          onPointerMove={onClose}
+          onTouchStart={onClose}
+          onTouchMove={onClose}
+          onTouchEnd={onClose}
           onClick={onClose}
         />
       ) : null}
@@ -45,11 +60,23 @@ export default function MobileBottomSheet({
         }}
         data-tutorial-id={tutorialId}
       >
-        <div className="flex justify-center pt-3">
+        <div
+          className="flex justify-center pt-3"
+          onTouchStart={handleTouchStart}
+          onTouchMove={handleTouchMove}
+          onTouchEnd={handleTouchEnd}
+          onTouchCancel={handleTouchCancel}
+        >
           <span className="h-1.5 w-12 rounded-full bg-[color:var(--page-theme-border-primary)]" />
         </div>
 
-        <div className="flex items-center justify-between gap-3 px-5 pb-3 pt-0">
+        <div
+          className="flex items-center justify-between gap-3 px-5 pb-3 pt-0"
+          onTouchStart={handleTouchStart}
+          onTouchMove={handleTouchMove}
+          onTouchEnd={handleTouchEnd}
+          onTouchCancel={handleTouchCancel}
+        >
           <div className="flex min-w-0 flex-1 self-stretch items-center">
             {title}
           </div>

--- a/frontend/src/pages/canvas/components/MobileFloatingPalette.tsx
+++ b/frontend/src/pages/canvas/components/MobileFloatingPalette.tsx
@@ -1,0 +1,43 @@
+import { HexColorPicker } from "react-colorful";
+
+interface MobileFloatingPaletteProps {
+  open: boolean;
+  color: string;
+  onChange: (color: string) => void;
+  onCommitColor: (color?: string) => void;
+  tutorialId?: string;
+}
+
+export default function MobileFloatingPalette({
+  open,
+  color,
+  onChange,
+  onCommitColor,
+  tutorialId,
+}: MobileFloatingPaletteProps) {
+  if (!open) {
+    return null;
+  }
+
+  return (
+    <div
+      className="absolute right-[calc(100%+12px)] top-0 z-20"
+      onPointerDown={(event) => event.stopPropagation()}
+      onClick={(event) => event.stopPropagation()}
+      onPointerUp={() => onCommitColor(color)}
+      onMouseUp={() => onCommitColor(color)}
+      onTouchEnd={() => onCommitColor(color)}
+      data-tutorial-id={tutorialId}
+    >
+      <div className="w-[228px] rounded-[24px] border border-[color:var(--page-theme-border-primary)] bg-[color:rgba(255,255,255,0.98)] p-3 shadow-[0_16px_40px_rgba(15,23,42,0.2)] backdrop-blur">
+        <div className="overflow-hidden rounded-[20px] border border-[color:var(--page-theme-border-primary)]">
+          <HexColorPicker
+            color={color}
+            onChange={onChange}
+            style={{ width: "100%", height: 188 }}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/canvas/model/useCanvasPage.ts
+++ b/frontend/src/pages/canvas/model/useCanvasPage.ts
@@ -97,6 +97,7 @@ export default function useCanvasPage({
     selectedCell,
     displaySelectedCell,
     viewport,
+    loadViewport,
     surfaceSize,
     cameraX,
     cameraY,
@@ -171,7 +172,7 @@ export default function useCanvasPage({
     canvasId,
     gridX,
     gridY,
-    viewport,
+    viewport: loadViewport,
     updateCells,
   });
 

--- a/frontend/src/pages/canvas/model/useCanvasPage.ts
+++ b/frontend/src/pages/canvas/model/useCanvasPage.ts
@@ -4,6 +4,7 @@ import {
   resolvePlayBackgroundImageUrl,
   type PlayBackgroundMode,
 } from "@/features/gameplay/canvas/model/background-assets";
+import type { CanvasViewportPadding } from "@/features/gameplay/canvas/model/viewport";
 import { useChunkLoader } from "@/features/gameplay/canvas/hooks/useChunkLoader";
 import { useCanvasHistory } from "@/features/gameplay/history/hooks/useCanvasHistory";
 import { useVotePopup, useVoteState } from "@/features/gameplay/vote";
@@ -28,6 +29,7 @@ interface UseCanvasPageParams {
   openPopupOnActivate?: boolean;
   resetPreviewOnActivate?: boolean;
   onCellActivated?: (cell: Cell) => void;
+  viewportPadding?: CanvasViewportPadding;
 }
 
 const PLAY_BACKGROUND_MODE_STORAGE_KEY = "votedots:play-background-mode";
@@ -45,6 +47,7 @@ export default function useCanvasPage({
   openPopupOnActivate = true,
   resetPreviewOnActivate = true,
   onCellActivated,
+  viewportPadding,
 }: UseCanvasPageParams) {
   const isRoundExpiredRef = useRef(false);
   const lastAutoOpenedRoundIdRef = useRef<number | null>(null);
@@ -127,6 +130,7 @@ export default function useCanvasPage({
     openPopupOnActivate,
     resetPreviewOnActivate,
     onCellActivated,
+    viewportPadding,
   });
 
   const [resultTemplateImageUrl, setResultTemplateImageUrl] = useState<

--- a/frontend/src/pages/canvas/model/useCanvasScene.ts
+++ b/frontend/src/pages/canvas/model/useCanvasScene.ts
@@ -12,7 +12,11 @@ import {
   useCanvasRenderer,
   useCanvasViewport,
 } from "@/features/gameplay/canvas";
-import { calculateWorldScreenOffset } from "@/features/gameplay/canvas/model/viewport";
+import {
+  calculateWorldScreenOffset,
+  getUsableViewportSize,
+  type CanvasViewportPadding,
+} from "@/features/gameplay/canvas/model/viewport";
 import type { CanvasBatchUpdatedPayload } from "@/features/gameplay/session/model/socket.types";
 import { getGameConfig } from "@/shared/config/game-config";
 import socket from "@/shared/lib/socket";
@@ -26,6 +30,7 @@ interface UseCanvasSceneParams {
   openPopupOnActivate?: boolean;
   resetPreviewOnActivate?: boolean;
   onCellActivated?: (cell: Cell) => void;
+  viewportPadding?: CanvasViewportPadding;
 }
 
 interface ZoomBounds {
@@ -61,7 +66,14 @@ function getZoomBounds(
   container: HTMLDivElement,
   worldWidth: number,
   worldHeight: number,
+  viewportPadding?: CanvasViewportPadding,
 ): ZoomBounds {
+  const usableViewport = getUsableViewportSize({
+    viewportWidth: container.clientWidth,
+    viewportHeight: container.clientHeight,
+    viewportPadding,
+  });
+
   if (worldWidth <= 0 || worldHeight <= 0) {
     return {
       minZoom: 1,
@@ -69,8 +81,8 @@ function getZoomBounds(
     };
   }
 
-  const fitWidthZoom = container.clientWidth / worldWidth;
-  const fitHeightZoom = container.clientHeight / worldHeight;
+  const fitWidthZoom = usableViewport.width / worldWidth;
+  const fitHeightZoom = usableViewport.height / worldHeight;
   const fittedZoom = Math.min(fitWidthZoom, fitHeightZoom);
   const minZoom =
     Number.isFinite(fittedZoom) && fittedZoom > 0 ? fittedZoom : 1;
@@ -104,9 +116,15 @@ function clampCamera(
   viewportWidth: number,
   viewportHeight: number,
   zoom: number,
+  viewportPadding?: CanvasViewportPadding,
 ) {
-  const maxCameraX = Math.max(0, worldWidth - viewportWidth / zoom);
-  const maxCameraY = Math.max(0, worldHeight - viewportHeight / zoom);
+  const usableViewport = getUsableViewportSize({
+    viewportWidth,
+    viewportHeight,
+    viewportPadding,
+  });
+  const maxCameraX = Math.max(0, worldWidth - usableViewport.width / zoom);
+  const maxCameraY = Math.max(0, worldHeight - usableViewport.height / zoom);
 
   return {
     x: Math.min(Math.max(0, nextCameraX), maxCameraX),
@@ -120,23 +138,42 @@ function getDefaultView(params: {
   gridY: number;
   viewportWidth: number;
   viewportHeight: number;
+  viewportPadding?: CanvasViewportPadding;
 }) {
-  const { container, gridX, gridY, viewportWidth, viewportHeight } = params;
+  const {
+    container,
+    gridX,
+    gridY,
+    viewportWidth,
+    viewportHeight,
+    viewportPadding,
+  } = params;
   const { worldWidth, worldHeight } = getWorldSize(gridX, gridY);
-  const bounds = getZoomBounds(container, worldWidth, worldHeight);
+  const bounds = getZoomBounds(
+    container,
+    worldWidth,
+    worldHeight,
+    viewportPadding,
+  );
+  const usableViewport = getUsableViewportSize({
+    viewportWidth,
+    viewportHeight,
+    viewportPadding,
+  });
   const largestGridSize = Math.max(gridX, gridY);
   const zoom =
     largestGridSize >= ZOOMED_ENTRY_GRID_THRESHOLD
       ? clampZoom(bounds.minZoom * INITIAL_VIEWPORT_GRID_DIVISIONS, bounds)
       : bounds.minZoom;
   const camera = clampCamera(
-    (worldWidth - viewportWidth / zoom) / 2,
-    (worldHeight - viewportHeight / zoom) / 2,
+    (worldWidth - usableViewport.width / zoom) / 2,
+    (worldHeight - usableViewport.height / zoom) / 2,
     worldWidth,
     worldHeight,
     viewportWidth,
     viewportHeight,
     zoom,
+    viewportPadding,
   );
 
   return {
@@ -222,6 +259,7 @@ export default function useCanvasScene({
   openPopupOnActivate = true,
   resetPreviewOnActivate = true,
   onCellActivated,
+  viewportPadding,
 }: UseCanvasSceneParams) {
   const containerRef = useRef<HTMLDivElement>(null);
 
@@ -447,6 +485,7 @@ export default function useCanvasScene({
         gridY,
         viewportWidth,
         viewportHeight,
+        viewportPadding,
       });
 
       sceneKeyRef.current = sceneKey;
@@ -480,6 +519,7 @@ export default function useCanvasScene({
     canvasNodeVersion,
     viewportSize.width,
     viewportSize.height,
+    viewportPadding,
   ]);
 
   const { viewport, visibleCellBounds } = useCanvasViewport({
@@ -490,6 +530,7 @@ export default function useCanvasScene({
     cameraX,
     cameraY,
     zoom,
+    viewportPadding,
   });
 
   const { worldWidth, worldHeight } = getWorldSize(gridX, gridY);
@@ -499,6 +540,7 @@ export default function useCanvasScene({
     viewportWidth: viewportSize.width,
     viewportHeight: viewportSize.height,
     zoom,
+    viewportPadding,
   });
 
   const buildCellAtCoordinate = useCallback(
@@ -522,8 +564,13 @@ export default function useCanvasScene({
       }
 
       const cellSize = getGameConfig().board.cellSize;
-      const viewportWorldWidth = container.clientWidth / zoomRef.current;
-      const viewportWorldHeight = container.clientHeight / zoomRef.current;
+      const usableViewport = getUsableViewportSize({
+        viewportWidth: container.clientWidth,
+        viewportHeight: container.clientHeight,
+        viewportPadding,
+      });
+      const viewportWorldWidth = usableViewport.width / zoomRef.current;
+      const viewportWorldHeight = usableViewport.height / zoomRef.current;
       const targetWorldCenterX = x * cellSize + cellSize / 2;
       const targetWorldCenterY = y * cellSize + cellSize / 2;
 
@@ -540,7 +587,7 @@ export default function useCanvasScene({
         ),
       };
     },
-    [gridX, gridY, worldHeight, worldWidth],
+    [gridX, gridY, viewportPadding, worldHeight, worldWidth],
   );
 
   const getPopupPositionForCell = useCallback(
@@ -675,6 +722,7 @@ export default function useCanvasScene({
       viewportWidth: container.clientWidth,
       viewportHeight: container.clientHeight,
       zoom,
+      viewportPadding,
     });
     const nextCamera = clampCamera(
       pending.focusWorldX -
@@ -686,6 +734,7 @@ export default function useCanvasScene({
       container.clientWidth,
       container.clientHeight,
       zoom,
+      viewportPadding,
     );
 
     cameraXRef.current = nextCamera.x;
@@ -693,7 +742,7 @@ export default function useCanvasScene({
     setCameraX(nextCamera.x);
     setCameraY(nextCamera.y);
     pendingZoomAdjustmentRef.current = null;
-  }, [zoom, canvasReady, gridX, gridY]);
+  }, [zoom, canvasReady, gridX, gridY, viewportPadding]);
 
   useLayoutEffect(() => {
     const container = containerRef.current;
@@ -703,7 +752,12 @@ export default function useCanvasScene({
     }
 
     const { worldWidth, worldHeight } = getWorldSize(gridX, gridY);
-    const bounds = getZoomBounds(container, worldWidth, worldHeight);
+    const bounds = getZoomBounds(
+      container,
+      worldWidth,
+      worldHeight,
+      viewportPadding,
+    );
     const nextZoom = clampZoom(zoomRef.current, bounds);
     const nextCamera = clampCamera(
       cameraXRef.current,
@@ -713,6 +767,7 @@ export default function useCanvasScene({
       container.clientWidth,
       container.clientHeight,
       nextZoom,
+      viewportPadding,
     );
 
     if (
@@ -730,7 +785,14 @@ export default function useCanvasScene({
     setZoom(nextZoom);
     setCameraX(nextCamera.x);
     setCameraY(nextCamera.y);
-  }, [canvasReady, gridX, gridY, viewportSize.height, viewportSize.width]);
+  }, [
+    canvasReady,
+    gridX,
+    gridY,
+    viewportPadding,
+    viewportSize.height,
+    viewportSize.width,
+  ]);
 
   const { navigateToCoordinate } = useCanvasNavigation({
     containerRef,
@@ -739,6 +801,7 @@ export default function useCanvasScene({
     zoom,
     setCameraX,
     setCameraY,
+    viewportPadding,
   });
 
   const handlePan = useCallback(
@@ -777,6 +840,7 @@ export default function useCanvasScene({
           container.clientWidth,
           container.clientHeight,
           zoomRef.current,
+          viewportPadding,
         );
 
         cameraXRef.current = nextCamera.x;
@@ -785,7 +849,7 @@ export default function useCanvasScene({
         setCameraY(nextCamera.y);
       });
     },
-    [gridX, gridY],
+    [gridX, gridY, viewportPadding],
   );
 
   const {
@@ -821,7 +885,12 @@ export default function useCanvasScene({
       const pointerOffsetX = centerClientX - containerRect.left;
       const pointerOffsetY = centerClientY - containerRect.top;
       const { worldWidth, worldHeight } = getWorldSize(gridX, gridY);
-      const bounds = getZoomBounds(container, worldWidth, worldHeight);
+      const bounds = getZoomBounds(
+        container,
+        worldWidth,
+        worldHeight,
+        viewportPadding,
+      );
 
       setZoom((currentZoom) => {
         const nextZoom = clampZoom(currentZoom * scale, bounds);
@@ -836,6 +905,7 @@ export default function useCanvasScene({
           viewportWidth: container.clientWidth,
           viewportHeight: container.clientHeight,
           zoom: currentZoom,
+          viewportPadding,
         });
 
         pendingZoomAdjustmentRef.current = {
@@ -944,9 +1014,23 @@ export default function useCanvasScene({
       }
 
       const { worldWidth, worldHeight } = getWorldSize(gridX, gridY);
-      const bounds = getZoomBounds(container, worldWidth, worldHeight);
-      const pointerOffsetX = container.clientWidth / 2;
-      const pointerOffsetY = container.clientHeight / 2;
+      const bounds = getZoomBounds(
+        container,
+        worldWidth,
+        worldHeight,
+        viewportPadding,
+      );
+      const usableViewport = getUsableViewportSize({
+        viewportWidth: container.clientWidth,
+        viewportHeight: container.clientHeight,
+        viewportPadding,
+      });
+      const pointerOffsetX =
+        (container.clientWidth - usableViewport.width) / 2 +
+        usableViewport.width / 2;
+      const pointerOffsetY =
+        (container.clientHeight - usableViewport.height) / 2 +
+        usableViewport.height / 2;
 
       setZoom((currentZoom) => {
         const nextZoom = getNextZoom(currentZoom, zoomIn, bounds);
@@ -961,6 +1045,7 @@ export default function useCanvasScene({
           viewportWidth: container.clientWidth,
           viewportHeight: container.clientHeight,
           zoom: currentZoom,
+          viewportPadding,
         });
 
         pendingZoomAdjustmentRef.current = {
@@ -978,7 +1063,7 @@ export default function useCanvasScene({
         return nextZoom;
       });
     },
-    [canvasReady, gridX, gridY],
+    [canvasReady, gridX, gridY, viewportPadding],
   );
 
   const resetCanvasZoom = useCallback(() => {
@@ -994,6 +1079,7 @@ export default function useCanvasScene({
       gridY,
       viewportWidth: container.clientWidth,
       viewportHeight: container.clientHeight,
+      viewportPadding,
     });
 
     pendingZoomAdjustmentRef.current = null;
@@ -1006,7 +1092,7 @@ export default function useCanvasScene({
     setZoom(defaultView.zoom);
     setCameraX(defaultView.camera.x);
     setCameraY(defaultView.camera.y);
-  }, [canvasReady, gridX, gridY]);
+  }, [canvasReady, gridX, gridY, viewportPadding]);
 
   const handleWheel = useCallback(
     (event: WheelEvent) => {
@@ -1024,7 +1110,12 @@ export default function useCanvasScene({
       const zoomIn = event.deltaY < 0;
 
       const { worldWidth, worldHeight } = getWorldSize(gridX, gridY);
-      const bounds = getZoomBounds(container, worldWidth, worldHeight);
+      const bounds = getZoomBounds(
+        container,
+        worldWidth,
+        worldHeight,
+        viewportPadding,
+      );
 
       setZoom((currentZoom) => {
         const nextZoom = getNextZoom(currentZoom, zoomIn, bounds);
@@ -1039,6 +1130,7 @@ export default function useCanvasScene({
           viewportWidth: container.clientWidth,
           viewportHeight: container.clientHeight,
           zoom: currentZoom,
+          viewportPadding,
         });
 
         pendingZoomAdjustmentRef.current = {
@@ -1057,7 +1149,7 @@ export default function useCanvasScene({
         return nextZoom;
       });
     },
-    [canvasReady, gridX, gridY],
+    [canvasReady, gridX, gridY, viewportPadding],
   );
 
   const handleCanvasUpdated = useCallback(

--- a/frontend/src/pages/canvas/model/useCanvasScene.ts
+++ b/frontend/src/pages/canvas/model/useCanvasScene.ts
@@ -60,8 +60,10 @@ const ZOOM_SCALE = 1.1;
 const MAX_ZOOM = 4;
 const MAX_ZOOM_MULTIPLIER = 4;
 
-const INITIAL_VIEWPORT_GRID_DIVISIONS = 3;
-const ZOOMED_ENTRY_GRID_THRESHOLD = 128;
+const MEDIUM_GRID_ENTRY_ZOOM_MULTIPLIER = 2;
+const LARGE_GRID_ENTRY_ZOOM_MULTIPLIER = 1.5;
+const MEDIUM_GRID_ENTRY_THRESHOLD = 64;
+const LARGE_GRID_ENTRY_THRESHOLD = 256;
 
 function getZoomBounds(
   container: HTMLDivElement,
@@ -163,9 +165,11 @@ function getDefaultView(params: {
   });
   const largestGridSize = Math.max(gridX, gridY);
   const zoom =
-    largestGridSize >= ZOOMED_ENTRY_GRID_THRESHOLD
-      ? clampZoom(bounds.minZoom * INITIAL_VIEWPORT_GRID_DIVISIONS, bounds)
-      : bounds.minZoom;
+    largestGridSize >= LARGE_GRID_ENTRY_THRESHOLD
+      ? clampZoom(bounds.minZoom * LARGE_GRID_ENTRY_ZOOM_MULTIPLIER, bounds)
+      : largestGridSize >= MEDIUM_GRID_ENTRY_THRESHOLD
+        ? clampZoom(bounds.minZoom * MEDIUM_GRID_ENTRY_ZOOM_MULTIPLIER, bounds)
+        : bounds.minZoom;
   const camera = clampCamera(
     (worldWidth - usableViewport.width / zoom) / 2,
     (worldHeight - usableViewport.height / zoom) / 2,

--- a/frontend/src/pages/canvas/model/useCanvasScene.ts
+++ b/frontend/src/pages/canvas/model/useCanvasScene.ts
@@ -13,6 +13,7 @@ import {
   useCanvasViewport,
 } from "@/features/gameplay/canvas";
 import {
+  calculateViewport,
   calculateWorldScreenOffset,
   getUsableViewportSize,
   type CanvasViewportPadding,
@@ -532,6 +533,18 @@ export default function useCanvasScene({
     zoom,
     viewportPadding,
   });
+  const loadViewport =
+    viewportSize.width > 0 && viewportSize.height > 0
+      ? calculateViewport({
+          gridX,
+          gridY,
+          cameraX,
+          cameraY,
+          zoom,
+          viewportWidth: viewportSize.width,
+          viewportHeight: viewportSize.height,
+        })
+      : null;
 
   const { worldWidth, worldHeight } = getWorldSize(gridX, gridY);
   const worldOffset = calculateWorldScreenOffset({
@@ -934,7 +947,6 @@ export default function useCanvasScene({
     previewColor,
     votingCellIds,
     topColorMap,
-    visibleCellBounds,
     cameraX,
     cameraY,
     zoom,
@@ -1314,6 +1326,7 @@ export default function useCanvasScene({
     selectedCell,
     displaySelectedCell: selectionVisible ? selectedCell : null,
     viewport,
+    loadViewport,
     surfaceSize: viewportSize,
     cameraX,
     cameraY,

--- a/frontend/src/shared/hooks/use-swipe-down-dismiss.ts
+++ b/frontend/src/shared/hooks/use-swipe-down-dismiss.ts
@@ -1,0 +1,96 @@
+import { useCallback, useRef, type TouchEvent } from "react";
+
+interface UseSwipeDownDismissParams {
+  onDismiss: () => void;
+  threshold?: number;
+}
+
+export function useSwipeDownDismiss({
+  onDismiss,
+  threshold = 72,
+}: UseSwipeDownDismissParams) {
+  const startPointRef = useRef<{ x: number; y: number } | null>(null);
+  const lockedAxisRef = useRef<"vertical" | "horizontal" | null>(null);
+
+  const resetGesture = useCallback(() => {
+    startPointRef.current = null;
+    lockedAxisRef.current = null;
+  }, []);
+
+  const handleTouchStart = useCallback((event: TouchEvent<HTMLElement>) => {
+    const touch = event.touches[0];
+
+    if (!touch) {
+      return;
+    }
+
+    startPointRef.current = {
+      x: touch.clientX,
+      y: touch.clientY,
+    };
+    lockedAxisRef.current = null;
+  }, []);
+
+  const handleTouchMove = useCallback((event: TouchEvent<HTMLElement>) => {
+    const startPoint = startPointRef.current;
+    const touch = event.touches[0];
+
+    if (!startPoint || !touch) {
+      return;
+    }
+
+    const deltaX = touch.clientX - startPoint.x;
+    const deltaY = touch.clientY - startPoint.y;
+
+    if (!lockedAxisRef.current && Math.abs(deltaX) + Math.abs(deltaY) >= 12) {
+      lockedAxisRef.current =
+        Math.abs(deltaY) >= Math.abs(deltaX) ? "vertical" : "horizontal";
+    }
+
+    if (
+      lockedAxisRef.current === "vertical" &&
+      deltaY > 0 &&
+      Math.abs(deltaY) > Math.abs(deltaX) &&
+      event.cancelable
+    ) {
+      event.preventDefault();
+    }
+  }, []);
+
+  const handleTouchEnd = useCallback(
+    (event: TouchEvent<HTMLElement>) => {
+      const startPoint = startPointRef.current;
+      const touch = event.changedTouches[0];
+
+      if (!startPoint || !touch) {
+        resetGesture();
+        return;
+      }
+
+      const deltaX = touch.clientX - startPoint.x;
+      const deltaY = touch.clientY - startPoint.y;
+
+      if (
+        lockedAxisRef.current === "vertical" &&
+        deltaY >= threshold &&
+        deltaY > Math.abs(deltaX)
+      ) {
+        onDismiss();
+      }
+
+      resetGesture();
+    },
+    [onDismiss, resetGesture, threshold],
+  );
+
+  const handleTouchCancel = useCallback(() => {
+    resetGesture();
+  }, [resetGesture]);
+
+  return {
+    handleTouchStart,
+    handleTouchMove,
+    handleTouchEnd,
+    handleTouchCancel,
+  };
+}

--- a/frontend/src/shared/hooks/use-swipe-down-dismiss.ts
+++ b/frontend/src/shared/hooks/use-swipe-down-dismiss.ts
@@ -1,23 +1,68 @@
-import { useCallback, useRef, type TouchEvent } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, type TouchEvent } from "react";
 
 interface UseSwipeDownDismissParams {
   onDismiss: () => void;
   threshold?: number;
+  closeDurationMs?: number;
+  active?: boolean;
 }
 
 export function useSwipeDownDismiss({
   onDismiss,
   threshold = 72,
+  closeDurationMs = 220,
+  active = true,
 }: UseSwipeDownDismissParams) {
   const startPointRef = useRef<{ x: number; y: number } | null>(null);
   const lockedAxisRef = useRef<"vertical" | "horizontal" | null>(null);
+  const closeTimerRef = useRef<number | null>(null);
+  const [dragOffsetY, setDragOffsetY] = useState(0);
+  const [isDragging, setIsDragging] = useState(false);
+  const [isClosing, setIsClosing] = useState(false);
+
+  useEffect(() => {
+    return () => {
+      if (closeTimerRef.current !== null) {
+        window.clearTimeout(closeTimerRef.current);
+      }
+    };
+  }, []);
+
+  useEffect(() => {
+    if (active) {
+      return;
+    }
+
+    if (closeTimerRef.current !== null) {
+      window.clearTimeout(closeTimerRef.current);
+      closeTimerRef.current = null;
+    }
+
+    startPointRef.current = null;
+    lockedAxisRef.current = null;
+
+    const frameId = window.requestAnimationFrame(() => {
+      setDragOffsetY(0);
+      setIsDragging(false);
+      setIsClosing(false);
+    });
+
+    return () => {
+      window.cancelAnimationFrame(frameId);
+    };
+  }, [active]);
 
   const resetGesture = useCallback(() => {
     startPointRef.current = null;
     lockedAxisRef.current = null;
+    setIsDragging(false);
   }, []);
 
   const handleTouchStart = useCallback((event: TouchEvent<HTMLElement>) => {
+    if (isClosing) {
+      return;
+    }
+
     const touch = event.touches[0];
 
     if (!touch) {
@@ -29,7 +74,8 @@ export function useSwipeDownDismiss({
       y: touch.clientY,
     };
     lockedAxisRef.current = null;
-  }, []);
+    setDragOffsetY(0);
+  }, [isClosing]);
 
   const handleTouchMove = useCallback((event: TouchEvent<HTMLElement>) => {
     const startPoint = startPointRef.current;
@@ -53,7 +99,14 @@ export function useSwipeDownDismiss({
       Math.abs(deltaY) > Math.abs(deltaX) &&
       event.cancelable
     ) {
+      setIsDragging(true);
+      setDragOffsetY(deltaY);
       event.preventDefault();
+      return;
+    }
+
+    if (lockedAxisRef.current === "vertical") {
+      setDragOffsetY(0);
     }
   }, []);
 
@@ -75,22 +128,52 @@ export function useSwipeDownDismiss({
         deltaY >= threshold &&
         deltaY > Math.abs(deltaX)
       ) {
-        onDismiss();
+        setDragOffsetY(Math.max(deltaY, threshold));
+        setIsClosing(true);
+
+        if (closeTimerRef.current !== null) {
+          window.clearTimeout(closeTimerRef.current);
+        }
+
+        closeTimerRef.current = window.setTimeout(() => {
+          closeTimerRef.current = null;
+          onDismiss();
+        }, closeDurationMs);
+      } else {
+        setDragOffsetY(0);
       }
 
       resetGesture();
     },
-    [onDismiss, resetGesture, threshold],
+    [closeDurationMs, onDismiss, resetGesture, threshold],
   );
 
   const handleTouchCancel = useCallback(() => {
+    setDragOffsetY(0);
     resetGesture();
   }, [resetGesture]);
+
+  const backdropOpacity = useMemo(() => {
+    if (isClosing) {
+      return 0;
+    }
+
+    if (dragOffsetY <= 0) {
+      return 1;
+    }
+
+    return Math.max(0, 1 - dragOffsetY / (threshold * 2));
+  }, [dragOffsetY, isClosing, threshold]);
 
   return {
     handleTouchStart,
     handleTouchMove,
     handleTouchEnd,
     handleTouchCancel,
+    dragOffsetY,
+    isDragging,
+    isClosing,
+    backdropOpacity,
+    transitionDurationMs: closeDurationMs,
   };
 }


### PR DESCRIPTION
## 관련 이슈
- close #470 

## 변경 내용

- 모바일 인게임 팔레트를 우상단 플로팅 구조로 정리
- 모바일에서 색상 선택 투표 모드를 제거하고 현재 선택 색상으로 바로 투표하도록 변경
- 최근 색상 리스트를 팔레트 버튼 아래 세로 형태로 표시
- 최근 색상 버튼의 가운데 점 제거
- 최근 색상 클릭 시 현재 색상만 변경하고 최근 순서는 갱신되지 않도록 수정
- 모바일 메뉴/모달의 바깥 클릭 닫기와 아래로 드래그 닫기 동작을 통일
- 시트와 모바일 모달이 드래그에 따라 따라 내려오고, 임계치 미만이면 복귀하고 임계치 이상이면 닫히는 애니메이션 추가
- 드래그로 닫은 뒤 메뉴/모달이 다시 열리지 않던 상태 초기화 문제 수정
- 모바일 헤더와 상태 바를 상단 고정으로 정리
- safe area와 모바일 브라우저 UI를 고려해 모바일 레이아웃과 오버레이 위치 보정
- 버튼이 차지하는 영역만큼 캔버스 내부 상하좌우 여백을 확보하도록 카메라/viewport 계산 수정
- 드래그/핀치 줌 중 셀이 오선택되지 않도록 터치 제스처 처리 보강
- 페인트 레이어를 배경과 동일한 기준으로 렌더하도록 수정
- 청크 로딩 범위를 실제 화면 기준으로 분리해 경계 영역에서 칠해진 셀이 비지 않도록 수정
- 투표 애니메이션/오버레이를 실제 화면 rect 기준으로 렌더하도록 바꿔 화면 외곽에서 사라지지 않도록 수정
- 모바일 가로모드에서는 인게임 대신 `가로 모드는 지원하지 않습니다.` 안내 화면만 표시하도록 변경
- 기본 진입 배율을 그리드 크기 기준으로 조정
  - `64`: fit zoom * 2
  - `128`: fit zoom * 2
  - `256 이상`: fit zoom * 1.5

## 기대 동작

- 모바일 인게임에서 팔레트, 최근 색상, 즉시 투표 흐름이 더 단순하고 일관되게 동작한다
- 메뉴와 모바일 모달이 자연스럽게 닫히고 다시 열 때도 정상 동작한다
- 헤더와 상태 바가 항상 상단에 유지되고 safe area에 가려지지 않는다
- 드래그/핀치 줌 중 셀 오선택이 줄어든다
- 캔버스 경계 영역에서도 칠해진 셀과 투표 애니메이션이 정상적으로 보인다
- 모바일 가로모드 진입 시 게임 UI 대신 안내 화면만 노출된다
- 그리드 크기별 초기 줌 배율이 더 적절하게 적용된다

## 확인 내용

- `frontend`: `npx tsc -b`
- `frontend`: `npm run lint`
- 모바일 실기기 기준 추가 확인 필요
- 확인 포인트
  - 헤더/상태 바 상단 고정
  - 시트/모달 드래그 닫힘 애니메이션
  - 왼쪽/위쪽 경계 셀과 투표 애니메이션 표시 여부
  - 드래그/핀치 줌 후 셀 오선택 방지 여부
  - 가로모드 진입 시 안내 화면 노출
  - 64/128/256 그리드 기본 진입 배율