### PR TITLE
fix: 모바일 캔버스 입력 오동작과 레이아웃 분기 문제 수정

### DIFF
--- a/frontend/src/features/gameplay/canvas/hooks/useCanvasInteraction.ts
+++ b/frontend/src/features/gameplay/canvas/hooks/useCanvasInteraction.ts
@@ -75,12 +75,14 @@ export function useCanvasInteraction({
     hasPanned: boolean;
   } | null>(null);
   const pinchDistanceRef = useRef<number | null>(null);
+  const gestureIncludesMultiTouchRef = useRef(false);
   const suppressTapUntilRef = useRef(0);
   const [isDraggingCanvas, setIsDraggingCanvas] = useState(false);
 
   const resetGesture = () => {
     activeGestureRef.current = null;
     pinchDistanceRef.current = null;
+    gestureIncludesMultiTouchRef.current = false;
     setIsDraggingCanvas(false);
   };
 
@@ -145,6 +147,7 @@ export function useCanvasInteraction({
     }
 
     if (activePointersRef.current.size >= 2) {
+      gestureIncludesMultiTouchRef.current = true;
       activeGestureRef.current = null;
       setIsDraggingCanvas(false);
       pinchDistanceRef.current = getTrackedDistance();
@@ -259,6 +262,7 @@ export function useCanvasInteraction({
       return;
     }
 
+    const shouldSuppressActivation = gestureIncludesMultiTouchRef.current;
     resetGesture();
 
     if (!activeGesture || activeGesture.pointerId !== event.pointerId) {
@@ -270,6 +274,10 @@ export function useCanvasInteraction({
     }
 
     if (performance.now() < suppressTapUntilRef.current) {
+      return;
+    }
+
+    if (shouldSuppressActivation) {
       return;
     }
 

--- a/frontend/src/pages/canvas/CanvasPage.tsx
+++ b/frontend/src/pages/canvas/CanvasPage.tsx
@@ -65,14 +65,21 @@ const INTRO_GUIDE_SEEN_STORAGE_KEY = "votedots:intro-guide-seen";
 const ROUND_SELECTION_GUIDE_DURATION_MS = 2500;
 const SELECTION_PULSE_DURATION_MS = 1000;
 const MOBILE_VOTE_ERROR_DURATION_MS = 3000;
-const MOBILE_BREAKPOINT_MEDIA_QUERY = "(max-width: 1023px)";
 const MOBILE_LANDSCAPE_MEDIA_QUERY = "(orientation: landscape)";
 const MOBILE_RECENT_COLOR_LIMIT = 6;
 const MOBILE_RECENT_COLORS_STORAGE_KEY = "votedots:mobile-recent-colors";
 const MOBILE_CANVAS_EDGE_PADDING = 72;
+const MOBILE_OR_TABLET_USER_AGENT_PATTERN =
+  /Android|iPhone|iPad|iPod|Mobile|Tablet|Silk|Kindle|PlayBook|Opera Mini|Opera Mobi/i;
 
 type MobileSheetType = "menu" | "participants" | "history" | null;
 type VoteMode = "select" | "instant";
+
+interface NavigatorWithUserAgentData extends Navigator {
+  userAgentData?: {
+    mobile?: boolean;
+  };
+}
 
 function MenuGlyph() {
   return (
@@ -304,13 +311,34 @@ function buildIntroGuideSeenStorageKey(canvasId: number): string {
   return `${INTRO_GUIDE_SEEN_STORAGE_KEY}:${canvasId}`;
 }
 
+function isMobileOrTabletTouchDevice() {
+  if (
+    typeof window === "undefined" ||
+    typeof navigator === "undefined"
+  ) {
+    return false;
+  }
+
+  const typedNavigator = navigator as NavigatorWithUserAgentData;
+  const hasTouchCapability =
+    window.matchMedia("(pointer: coarse)").matches ||
+    navigator.maxTouchPoints > 0 ||
+    "ontouchstart" in window;
+  const isMobileOrTabletUserAgent =
+    typedNavigator.userAgentData?.mobile === true ||
+    MOBILE_OR_TABLET_USER_AGENT_PATTERN.test(navigator.userAgent) ||
+    (navigator.platform === "MacIntel" && navigator.maxTouchPoints > 1);
+
+  return hasTouchCapability && isMobileOrTabletUserAgent;
+}
+
 function getInitialMobileLandscapeState() {
   if (typeof window === "undefined") {
     return false;
   }
 
   return (
-    window.matchMedia(MOBILE_BREAKPOINT_MEDIA_QUERY).matches &&
+    isMobileOrTabletTouchDevice() &&
     window.matchMedia(MOBILE_LANDSCAPE_MEDIA_QUERY).matches
   );
 }
@@ -325,7 +353,7 @@ export default function CanvasPage({ sessionSourceApi }: CanvasPageProps) {
       return false;
     }
 
-    return window.matchMedia(MOBILE_BREAKPOINT_MEDIA_QUERY).matches;
+    return isMobileOrTabletTouchDevice();
   });
   const [isMobileLandscape, setIsMobileLandscape] = useState(
     getInitialMobileLandscapeState,
@@ -387,10 +415,10 @@ export default function CanvasPage({ sessionSourceApi }: CanvasPageProps) {
       return undefined;
     }
 
-    const mobileQuery = window.matchMedia(MOBILE_BREAKPOINT_MEDIA_QUERY);
+    const coarsePointerQuery = window.matchMedia("(pointer: coarse)");
     const landscapeQuery = window.matchMedia(MOBILE_LANDSCAPE_MEDIA_QUERY);
     const syncMobileState = () => {
-      const nextIsMobile = mobileQuery.matches;
+      const nextIsMobile = isMobileOrTabletTouchDevice();
       const nextIsMobileLandscape = nextIsMobile && landscapeQuery.matches;
 
       setIsMobileLayout(nextIsMobile);
@@ -404,12 +432,12 @@ export default function CanvasPage({ sessionSourceApi }: CanvasPageProps) {
     };
 
     syncMobileState();
-    mobileQuery.addEventListener("change", syncMobileState);
+    coarsePointerQuery.addEventListener("change", syncMobileState);
     landscapeQuery.addEventListener("change", syncMobileState);
     window.addEventListener("resize", syncMobileState);
 
     return () => {
-      mobileQuery.removeEventListener("change", syncMobileState);
+      coarsePointerQuery.removeEventListener("change", syncMobileState);
       landscapeQuery.removeEventListener("change", syncMobileState);
       window.removeEventListener("resize", syncMobileState);
     };

--- a/frontend/src/pages/canvas/model/useCanvasPage.ts
+++ b/frontend/src/pages/canvas/model/useCanvasPage.ts
@@ -14,6 +14,7 @@ import type {
 } from "@/features/gameplay/session/api/session.api";
 import type { GameplaySessionSourceApi } from "@/features/gameplay/session/api/session-source.api";
 import type { SessionBootstrapResult } from "@/features/gameplay/session";
+import { isRoundActivePhase } from "@/features/gameplay/session/model/game-phase.types";
 import type { CanvasBatchUpdatedPayload } from "@/features/gameplay/session/model/socket.types";
 import type { RoomExpiredPayload } from "@/features/gameplay/session/model/socket.types";
 import useCanvasGameplay from "./useCanvasGameplay";
@@ -50,6 +51,7 @@ export default function useCanvasPage({
   viewportPadding,
 }: UseCanvasPageParams) {
   const isRoundExpiredRef = useRef(false);
+  const selectionSyncEnabledRef = useRef(false);
   const lastAutoOpenedRoundIdRef = useRef<number | null>(null);
   const handledRoundSummaryEventRef = useRef(0);
   const handledGameSummaryEventRef = useRef(0);
@@ -128,6 +130,7 @@ export default function useCanvasPage({
     topColorMap,
     resetPreviewColor,
     openPopup,
+    selectionSyncEnabledRef,
     openPopupOnActivate,
     resetPreviewOnActivate,
     onCellActivated,
@@ -328,6 +331,10 @@ export default function useCanvasPage({
     applyVoteUpdate,
     resetVoteState,
   });
+
+  useEffect(() => {
+    selectionSyncEnabledRef.current = isRoundActivePhase(gameplay.phase);
+  }, [gameplay.phase]);
 
   useEffect(() => {
     isRoundExpiredRef.current = gameplay.isRoundExpiredRefValue;

--- a/frontend/src/pages/canvas/model/useCanvasScene.ts
+++ b/frontend/src/pages/canvas/model/useCanvasScene.ts
@@ -4,6 +4,7 @@ import {
   useLayoutEffect,
   useRef,
   useState,
+  type MutableRefObject,
 } from "react";
 import {
   Cell,
@@ -28,6 +29,7 @@ interface UseCanvasSceneParams {
   topColorMap: Map<string, string>;
   resetPreviewColor: () => void;
   openPopup: (position: { x: number; y: number }) => void;
+  selectionSyncEnabledRef?: MutableRefObject<boolean>;
   openPopupOnActivate?: boolean;
   resetPreviewOnActivate?: boolean;
   onCellActivated?: (cell: Cell) => void;
@@ -261,6 +263,7 @@ export default function useCanvasScene({
   topColorMap,
   resetPreviewColor,
   openPopup,
+  selectionSyncEnabledRef,
   openPopupOnActivate = true,
   resetPreviewOnActivate = true,
   onCellActivated,
@@ -302,6 +305,7 @@ export default function useCanvasScene({
   const pendingZoomAdjustmentRef = useRef<PendingZoomAdjustment | null>(null);
   const panFrameRef = useRef<number | null>(null);
   const pendingPanDeltaRef = useRef({ dx: 0, dy: 0 });
+  const hasSyncedSelectionRef = useRef(false);
 
   const [cells, setCells] = useState<Cell[]>([]);
   const [minimapCells, setMinimapCells] = useState<Cell[]>([]);
@@ -444,6 +448,7 @@ export default function useCanvasScene({
         cameraXRef.current = 0;
         cameraYRef.current = 0;
         selectedCellRef.current = null;
+        hasSyncedSelectionRef.current = false;
         scheduleStateUpdate(() => {
           setCanvasReady(false);
           setSelectedCell(null);
@@ -502,6 +507,7 @@ export default function useCanvasScene({
       cameraXRef.current = defaultView.camera.x;
       cameraYRef.current = defaultView.camera.y;
       selectedCellRef.current = null;
+      hasSyncedSelectionRef.current = false;
       scheduleStateUpdate(() => {
         setZoom(defaultView.zoom);
         setCameraX(defaultView.camera.x);
@@ -645,10 +651,21 @@ export default function useCanvasScene({
   const emitSelectionUpdate = useCallback(
     (nextSelectedCell: Pick<Cell, "x" | "y"> | null) => {
       const activeCanvasId = canvasIdRef.current;
+      const selectionSyncEnabled = selectionSyncEnabledRef?.current ?? true;
+
+      if (nextSelectedCell && !selectionSyncEnabled) {
+        return;
+      }
+
+      if (!nextSelectedCell && !hasSyncedSelectionRef.current) {
+        return;
+      }
 
       if (!socket.connected || !activeCanvasId) {
         return;
       }
+
+      hasSyncedSelectionRef.current = nextSelectedCell !== null;
 
       socket.emit("selection:update", {
         canvasId: activeCanvasId,
@@ -656,7 +673,7 @@ export default function useCanvasScene({
         y: nextSelectedCell?.y ?? null,
       });
     },
-    [],
+    [selectionSyncEnabledRef],
   );
 
   const activateCell = useCallback(

--- a/frontend/test/unit/useCanvasInteraction.test.ts
+++ b/frontend/test/unit/useCanvasInteraction.test.ts
@@ -1,0 +1,132 @@
+import { act, renderHook } from "@testing-library/react";
+import type { PointerEvent as ReactPointerEvent } from "react";
+import { describe, expect, it, vi } from "vitest";
+import type { Cell } from "@/features/gameplay/canvas";
+import { useCanvasInteraction } from "@/features/gameplay/canvas/hooks/useCanvasInteraction";
+
+function createPointerEvent(options: {
+  currentTarget: HTMLDivElement;
+  pointerId: number;
+  pointerType: string;
+  clientX: number;
+  clientY: number;
+  button?: number;
+}) {
+  return {
+    ...options,
+  } as ReactPointerEvent<HTMLDivElement>;
+}
+
+describe("useCanvasInteraction", () => {
+  it("suppresses cell activation for pinch sequences until every pointer is released", () => {
+    let now = 0;
+    vi.spyOn(performance, "now").mockImplementation(() => now);
+
+    const container = document.createElement("div");
+    const canvas = document.createElement("canvas");
+
+    container.appendChild(canvas);
+    container.setPointerCapture = vi.fn();
+    container.releasePointerCapture = vi.fn();
+    canvas.getBoundingClientRect = vi.fn(() => ({
+      left: 0,
+      top: 0,
+      right: 160,
+      bottom: 160,
+      width: 160,
+      height: 160,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+    }));
+
+    const onActivateCell = vi.fn();
+    const onPan = vi.fn();
+    const cells: Cell[] = [{ x: 1, y: 1, color: null, status: "idle" }];
+
+    const { result } = renderHook(() =>
+      useCanvasInteraction({
+        canvasRef: { current: canvas },
+        cells,
+        gridX: 10,
+        gridY: 10,
+        cameraX: 0,
+        cameraY: 0,
+        zoom: 1,
+        worldOffsetX: 0,
+        worldOffsetY: 0,
+        onPan,
+        onActivateCell,
+      }),
+    );
+
+    act(() => {
+      now = 0;
+      result.current.handlePointerDown(
+        createPointerEvent({
+          currentTarget: container,
+          pointerId: 1,
+          pointerType: "touch",
+          clientX: 10,
+          clientY: 10,
+        }),
+      );
+      result.current.handlePointerDown(
+        createPointerEvent({
+          currentTarget: container,
+          pointerId: 2,
+          pointerType: "touch",
+          clientX: 24,
+          clientY: 24,
+        }),
+      );
+      result.current.handlePointerUp(
+        createPointerEvent({
+          currentTarget: container,
+          pointerId: 2,
+          pointerType: "touch",
+          clientX: 24,
+          clientY: 24,
+        }),
+      );
+      result.current.handlePointerUp(
+        createPointerEvent({
+          currentTarget: container,
+          pointerId: 1,
+          pointerType: "touch",
+          clientX: 10,
+          clientY: 10,
+        }),
+      );
+    });
+
+    expect(onActivateCell).not.toHaveBeenCalled();
+
+    act(() => {
+      now = 1_000;
+      result.current.handlePointerDown(
+        createPointerEvent({
+          currentTarget: container,
+          pointerId: 3,
+          pointerType: "touch",
+          clientX: 10,
+          clientY: 10,
+        }),
+      );
+      result.current.handlePointerUp(
+        createPointerEvent({
+          currentTarget: container,
+          pointerId: 3,
+          pointerType: "touch",
+          clientX: 10,
+          clientY: 10,
+        }),
+      );
+    });
+
+    expect(onActivateCell).toHaveBeenCalledTimes(1);
+    expect(onPan).not.toHaveBeenCalled();
+
+    vi.restoreAllMocks();
+  });
+});


### PR DESCRIPTION
## 관련 이슈
- Close #475 

## 개요

모바일 캔버스 입력 처리와 디바이스 레이아웃 분기를 정리했습니다.

- 핀치 줌 종료가 탭으로 오인되어 투표로 이어질 수 있던 문제를 수정했습니다.
- `active_round`가 아닐 때 셀 선택에 따른 `selection:update` 소켓 이벤트가 발생하던 흐름을 차단했습니다.
- 데스크톱에서 브라우저 크기만 줄였을 때 모바일 UI와 가로모드 안내가 노출되던 문제를 수정했습니다.

## 변경사항

- 멀티터치가 한 번이라도 시작된 포인터 시퀀스는 모든 포인터가 완전히 종료될 때까지 셀 탭 활성화로 처리되지 않도록 수정
- `active_round`가 아닐 때는 새 셀 선택에 대한 `selection:update` 소켓 emit이 발생하지 않도록 수정
- 기존에 active 상태에서 동기화된 선택을 해제하는 `null` 이벤트는 유지해서 참가자 선택 표시 잔상이 남지 않도록 처리
- 캔버스 페이지의 모바일 레이아웃 판별 기준을 단순 화면 폭이 아니라 실제 모바일/태블릿 터치 디바이스 기준으로 변경
- 데스크톱 브라우저 창 크기 변경만으로 모바일 전용 UI와 가로모드 미지원 문구가 노출되지 않도록 수정
- 핀치 입력 회귀 방지용 unit test 추가

## 코드 흐름

- 캔버스 포인터 입력 훅에서 멀티터치 개입 여부를 추적하고, 마지막 포인터 해제 시 탭 활성화 여부를 판정합니다.
- 셀 활성화 공통 흐름에서는 현재 phase 기준으로 selection 동기화 가능 여부를 확인한 뒤, 허용된 경우에만 `selection:update`를 emit합니다.
- 캔버스 페이지에서는 모바일 레이아웃 여부를 실제 터치 디바이스 판별 결과로 계산하고, 그 값을 모바일 UI 분기와 가로모드 안내 분기에 함께 사용합니다.

## 검증

- `frontend/src/pages/canvas/CanvasPage.tsx` 대상 eslint 통과
- `test/unit/useCanvasInteraction.test.ts` 통과
- 브라우저 수동 확인은 별도 수행하지 않음

## 결정사항

- 모바일 레이아웃 기준은 `max-width`가 아니라 실제 모바일/태블릿 터치 디바이스 여부를 사용합니다.
- non-active phase에서는 새 선택 좌표 동기화는 막되, 기존 선택 해제 이벤트는 유지합니다.
- 수정 범위는 우선 캔버스 페이지와 관련 입력 흐름에 한정합니다.

## 리뷰 포인트

- non-active phase에서 selection 해제 이벤트를 유지한 방식이 참가자 선택 표시 정리 목적에 맞는지
- 모바일/태블릿 터치 디바이스 판별 기준이 현재 서비스 지원 범위에 적절한지